### PR TITLE
fix installer script

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -95,8 +95,8 @@ end
 
 bash "Add crowbar chef client" do
   environment ({'EDITOR' => '/bin/true', 'HOME' => '/root'})
-  code "knife client create crowbar -a --file /opt/dell/crowbar_framework/config/client.pem -u chef-validator -k /etc/chef/validation.pem"
-  not_if "knife client list -u crowbar -k /opt/dell/crowbar_framework/config/client.pem"
+  code "knife client create crowbar -a --file /opt/dell/crowbar_framework/config/client.pem -u chef-webui -k /etc/chef/webui.pem "
+  not_if "export HOME=/root;knife client list -u crowbar -k /opt/dell/crowbar_framework/config/client.pem"
 end
 
 file "/opt/dell/crowbar_framework/log/production.log" do


### PR DESCRIPTION
dd new client failed with validator but works with webui user and pem file, env variable needed for knife in not_if guard (maybe a chef 0.10.6 issue which is now pulled in with the build script
