### PR TITLE
bmc user and password for ipmi commands / links

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -710,6 +710,14 @@ class NodeObject < ChefObject
     nhash.merge rhash
   end
 
+  def get_bmc_user
+    @node["ipmi"]["bmc_user"] rescue nil
+  end
+
+  def get_bmc_password
+    @node["ipmi"]["bmc_password"] rescue nil
+  end
+
   def set_state(state)
     if CHEF_ONLINE
       # use the real transition function for this
@@ -723,8 +731,10 @@ class NodeObject < ChefObject
 
     if state == "reset" or state == "reinstall" or state == "update"
       if CHEF_ONLINE
-        bmc = get_network_by_type("bmc")
-        system("ipmitool -H #{bmc["address"]} -U crowbar -P crowbar power cycle") unless bmc.nil?
+        bmc          = get_network_by_type("bmc")
+        bmc_user     = get_bmc_user
+        bmc_password = get_bmc_password
+        system("ipmitool -I lanplus -H #{bmc["address"]} -U #{bmc_user} -P #{bmc_password} power cycle") unless bmc.nil?
       else
         NodeObject.clear_cache @node
         puts "Node #{name} to #{state} caused cache object to be deleted."
@@ -735,35 +745,37 @@ class NodeObject < ChefObject
 
   def reboot
     set_state("reboot")
-    bmc = get_network_by_type("bmc")
+    bmc          = get_network_by_type("bmc")
+    bmc_user     = get_bmc_user
+    bmc_password = get_bmc_password
     return puts "Node #{name} IMPI Reboot call to #{bmc["address"]}" unless CHEF_ONLINE
-    system("ipmitool -H #{bmc["address"]} -U crowbar -P crowbar power cycle") unless bmc.nil?
+    system("ipmitool -I lanplus -H #{bmc["address"]} -U #{bmc_user} -P #{bmc_password} power cycle") unless bmc.nil?
   end
 
   def shutdown
     set_state("shutdown")
-    bmc = get_network_by_type("bmc")
-    if CHEF_ONLINE
-      system("ipmitool -H #{bmc["address"]} -U crowbar -P crowbar power off") unless bmc.nil?
-    else
-      return puts "Node #{name} IMPI Shutdown call to #{bmc["address"]}"
-    end
+    bmc          = get_network_by_type("bmc")
+    bmc_user     = get_bmc_user
+    bmc_password = get_bmc_password
+    return puts "Node #{name} IMPI Shutdown call to #{bmc["address"]}" unless CHEF_ONLINE
+    system("ipmitool -I lanplus -H #{bmc["address"]} -U #{bmc_user} -P #{bmc_password} power off") unless bmc.nil?
   end
 
   def poweron
     set_state("poweron")
-    bmc = get_network_by_type("bmc")
-    if CHEF_ONLINE
-      system("ipmitool -H #{bmc["address"]} -U crowbar -P crowbar power on") unless bmc.nil?
-    else
-      puts "Node #{name} IMPI Power On call to #{bmc["address"]}"
-    end
+    bmc          = get_network_by_type("bmc")
+    bmc_user     = get_bmc_user
+    bmc_password = get_bmc_password
+    return puts "Node #{name} IMPI Power On call to #{bmc["address"]}" unless CHEF_ONLINE
+    system("ipmitool -I lanplus -H #{bmc["address"]} -U #{bmc_user} -P #{bmc_password} power on") unless bmc.nil?
   end
 
   def identify
-    bmc = get_network_by_type("bmc")
+    bmc          = get_network_by_type("bmc")
+    bmc_user     = get_bmc_user
+    bmc_password = get_bmc_password
     return puts "Node #{name} IMPI Identify call to #{bmc["address"]}" unless CHEF_ONLINE
-    system("ipmitool -H #{bmc["address"]} -U crowbar -P crowbar chassis identify") unless bmc.nil?
+    system("ipmitool -I lanplus -H #{bmc["address"]} -U #{bmc_user} -P #{bmc_password} chassis identify") unless bmc.nil?
   end
 
   def allocate


### PR DESCRIPTION
the ipmitool commands used via the UI and `crowbar machines (shutdown|poweron|reboot|identify)` are hardcoded with the user and password of "crowbar", but the ipmi proposal allows configuring these values.  if the values are changed in the proposal and on the BMCs, all ipmitool commands fail.  this commit will query the ipmi proposal for the bmc_user and bmc_password values to be used in all ipmitool commands.  it also enables the use of lanplus ipmi interface in order to allow bmc_passwords longer than 16 characters.

i also changed the logic in the shutdown and poweron functions to match that of reboot and identify.  i want to say that they didn't work otherwise, but i'm not %100 sure about that.  however, this code allows all ipmi functions to work with any user or password, even passwords greater than 16 characters.

the current behavior of UI seems to disable all ipmi links if the node is in the "shutdown" state, but the "power on" link should be visible, otherwise it provides no value.  unfortunately, i've not figured this out yet.  perhaps i'll get to it in later pull request.
