### PR TITLE
Die horribly if any of our transitions fail. [1/4]

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -113,6 +113,7 @@ class CrowbarService < ServiceObject
           rescue Exception => e
             @logger.fatal("json/transition for #{bc}:#{rname} failed: #{e.message}")
             @logger.fatal("#{e.backtrace}")
+            return [500, "#{bc} transition to #{rname} failed.\n#{e.message}\n#{e.backtrace}"]
           end
         end
       end


### PR DESCRIPTION
Have crowbar_service.rb return 500 if any of the barclamp state transitions fail instead of merrily rolling on.
