### PR TITLE
Fix localizations on ApacheHadoop [1/6]

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -180,7 +180,7 @@ class BarclampController < ApplicationController
   def index
     respond_to do |format|
       format.html { 
-        @title = "#{@bc_name.titlecase} #{t('barclamp.index.members')}"
+        @title ||= "#{@bc_name.titlecase} #{t('barclamp.index.members')}" 
         @count = -1
         members = {}
         list = Kernel.const_get("#{@bc_name.camelize}Service").method(:members).call


### PR DESCRIPTION
Mainly this fixes location errors from the last checkin

Added the ability for a metabarclamp to set the name for the 
barclamp list.  This is really helpful because the all the
metabarclamps are multiple word items.  We want to read 
"Apache Hadoop" instead of "Apachehadoop Memembers."  The former
is much more readable.

A similar change needs to be made to the OpenStack barclamp.

 .../app/controllers/barclamp_controller.rb         |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
