### PR TITLE
Update the test framework to use a teamed network.json [1/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -153,6 +153,7 @@ debs:
     #- sun-java6-jdk
     #- sun-java6-jre
     - dpkg-dev
+    - screen
 
 rpms:
   redhat-5.6:
@@ -274,7 +275,7 @@ rpms:
     - ruby-shadow
     # sudo stuff
     - sudo
-
+    - screen
 
 gems:
   pkgs:


### PR DESCRIPTION
In the process of adding support or this, I also added:
- Use screen to run the actaul installation of crowbar on the admin
  node.  This also makes the installation process much less fragile in
  the face of changing network interface configurations.
- Have the test framework kick off the admin node install via SSH
  instead of using the crowbar.hostname hack.
- Make crowbar_ohai ignore any network interfaces that are not
  directly backed by a physical device.  This makes the condiut
  mapping code much more stable when adding or removing devices that
  act like a virtual ethernet device.
  
  crowbar.yml |    3 ++-
  1 files changed, 2 insertions(+), 1 deletions(-)
