### PR TITLE
filter out admin in some places [1/5]

### DIFF
--- a/chef/cookbooks/utils/recipes/default.rb
+++ b/chef/cookbooks/utils/recipes/default.rb
@@ -23,5 +23,7 @@ case platform
   @@ubuntu = true
 end
 
-log("running on OS:[#{platform}] on #{node[:dmi][:system][:product_name]} hardware") { level :info} 
+@@is_admin = node["crowbar"]["admin_node"] rescue false
+
+log("running on OS:[#{platform}] on #{node[:dmi][:system][:product_name]} hardware #{@@is_admin ? 'admin': ''}") { level :info} 
 


### PR DESCRIPTION
RAID and BIOS should be cognizant of what is an admin node...

 chef/cookbooks/utils/recipes/default.rb |    4 +++-
 1 files changed, 3 insertions(+), 1 deletions(-)
