### PR TITLE
Updates to crowbar and nova metadata [2/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -95,7 +95,7 @@ debs:
       - deb-src http://extras.ubuntu.com/ubuntu precise main
       - deb http://security.ubuntu.com/ubuntu precise-security main restricted universe multiverse
       - deb-src http://security.ubuntu.com/ubuntu precise-security main restricted universe multiverse
-      - deb http://apt.opscode.com/ oneiric-0.10 main
+      - deb http://apt.opscode.com/ precise-0.10 main
   repos:
     # Rabbit MQ repo
     #- deb http://www.rabbitmq.com/debian/ testing main


### PR DESCRIPTION
Opscode has a real precise repo for CHef, so switch to use it.

Canonical added a bunch of Conflicts: and Breaks: stanzas to some nova 
packages, so clean them up to allow package fetching to work again.

 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
