### PR TITLE
Fix bug in Chef Export [1/5]

### DIFF
--- a/crowbar_framework/app/controllers/support_controller.rb
+++ b/crowbar_framework/app/controllers/support_controller.rb
@@ -163,9 +163,9 @@ class SupportController < ApplicationController
     if CHEF_ONLINE
       begin
         Dir.entries('db').each { |f| File.delete(File.expand_path(File.join('db',f))) if f=~/.*\.json$/ }
-        NodeObject.all.each { |n| NodeObject.dump n, 'node', n.name }
-        RoleObject.all.each { |r| RoleObject.dump r, 'role', r.name }
-        ProposalObject.all.each { |p| ProposalObject.dump p, 'data_bag_item_crowbar-bc', p.name[/bc-(.*)/,1] }
+        NodeObject.all.each { |n| n.export }
+        RoleObject.all.each { |r| r.export }
+        ProposalObject.all.each { |p| p.export }
         @file = cfile ="crowbar-chef-#{Time.now.strftime("%Y%m%d-%H%M%S")}.tgz"
         pid = fork do
           system "tar -czf #{File.join('/tmp',cfile)} #{File.join('db','*.json')}" 

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -819,6 +819,10 @@ class NodeObject < ChefObject
     @node["crowbar_wall"]["status"]["ipmi"]["address_set"]
   end
 
+  def export
+    NodeObject.dump @node, 'node', name
+  end
+  
   private 
   
   # this is used by the alias/description code split

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -197,6 +197,10 @@ class ProposalObject < ChefObject
     Rails.logger.debug("Done removal of data bag item: #{@item["id"]} - #{@item["deployment"][barclamp]["crowbar-revision"]}")
   end
   
+  def export
+    ProposalObject.dump @item, 'data_bag_item_crowbar-bc', @item.name[/bc-(.*)/,1]
+  end
+  
   private
   
   # 'array' is the unsorted set of objects

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -161,6 +161,10 @@ class RoleObject < ChefObject
   def run_list
     @role.run_list
   end
+  
+  def export
+    RoleObject.dump @role, 'role', name 
+  end
 
 end
 


### PR DESCRIPTION
In the Chef Export, the Node dump command was including too much information.
This change makes the export work.

 .../app/controllers/support_controller.rb          |    6 +++---
 crowbar_framework/app/models/node_object.rb        |    4 ++++
 crowbar_framework/app/models/proposal_object.rb    |    4 ++++
 crowbar_framework/app/models/role_object.rb        |    4 ++++
 4 files changed, 15 insertions(+), 3 deletions(-)
