### PR TITLE
nova conf hardening [2/5]

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -45,6 +45,13 @@ template "/etc/rabbitmq/rabbitmq-env.conf" do
   owner "root"
   group "root"
   mode 0644
+end  
+
+template "/etc/rabbitmq/rabbitmq.config" do
+  source "rabbitmq.config.erb"
+  owner "root"
+  group "root"
+  mode 0644
 end
 
 user "rabbitmq" do

--- a/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
+++ b/chef/cookbooks/rabbitmq/templates/default/rabbitmq.config.erb
@@ -1,0 +1,5 @@
+[
+    {rabbit, [{tcp_listeners, {"<%= node[:rabbitmq][:address] %>", <%= node[:rabbitmq][:port] || 5672 %>}}]},
+    {rabbitmq_mochiweb, [{listeners, [{mgmt, [{ip, "<%= node[:rabbitmq][:address] %>"}, {port, 55672}]}]}]}
+].
+


### PR DESCRIPTION
restrict access to nova conf files to the nova and root system user, bind rabbitmq to admin interface

 chef/cookbooks/rabbitmq/recipes/default.rb         |    7 +++++++
 .../rabbitmq/templates/default/rabbitmq.config.erb |    5 +++++
 2 files changed, 12 insertions(+), 0 deletions(-)
