### PR TITLE
Add -pre and -post hook infrastructure to Sledgehammer. [1/6]

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -275,7 +275,10 @@ class NodeObject < ChefObject
 
   def allocated=(value)
     return false if @role.nil?
+    Rails.logger.info("Setting allocate state for #{@node.name} to #{value}")
     self.crowbar["crowbar"]["allocated"] = value
+    @role.save
+    value
   end
 
   def allocated?


### PR DESCRIPTION
This pull request series adds the ability to wrap Crowbar state
transitions in Sledgehammer with -pre and -post hooks. 

See README.sledgehammer-hooks for more information.

 crowbar_framework/app/models/node_object.rb |   29 +++++++++++++++------------
 1 file changed, 16 insertions(+), 13 deletions(-)
