### PR TITLE
Fix EPEL meta-package version [2/7]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -216,7 +216,7 @@ rpms:
   redhat-6.2:
     repos:
       - rpm http://rbel.frameos.org/rbel6
-      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-6.noarch.rpm
+      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-7.noarch.rpm
     build_pkgs:
       - libcurl-devel
       - yum-plugin-downloadonly
@@ -226,7 +226,7 @@ rpms:
   centos-6.2:
     repos:
       - rpm http://rbel.frameos.org/rbel6
-      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-6.noarch.rpm
+      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-7.noarch.rpm
     build_pkgs:
       - libcurl-devel
       - yum-plugin-downloadonly


### PR DESCRIPTION
This updates the EPEL metapackage from version 6.6 to 6.7.

This should make builds succeed again by being able to pull in kwalify.

 crowbar.yml |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
