### PR TITLE
fix rabbitmq recipes for nova

### DIFF
--- a/chef/cookbooks/rabbitmq/recipes/default.rb
+++ b/chef/cookbooks/rabbitmq/recipes/default.rb
@@ -84,6 +84,7 @@ else
   bash "Enable rabbit management" do
     code <<-'EOH'
   /usr/lib/rabbitmq/bin/rabbitmq-plugins enable rabbitmq_management
+  pkill -u rabbitmq
   /etc/init.d/rabbitmq-server restart
   exit 0
   EOH


### PR DESCRIPTION
without this nova proposal is failed to commit, because rabbitmq can't restart properly after configuring. If you kill it before restarting the proposal will apply successfully.
