### PR TITLE
Resolve name conflicts between crowbar routines and active_scaffold routines [1/5]

### DIFF
--- a/crowbar_framework/app/helpers/application_helper.rb
+++ b/crowbar_framework/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
     end
   end
 
-  def column_class(current_column, total)
+  def cb_column_class(current_column, total)
     if (current_column % total) == 0
       "first"
     elsif (current_column % total) == (total-1)

--- a/crowbar_framework/app/views/barclamp/overview.html.haml
+++ b/crowbar_framework/app/views/barclamp/overview.html.haml
@@ -3,7 +3,7 @@
 #proposals
   - i = -1
   - @groups.sort.each do |group_name, group|
-    .column_25{:class => column_class(i+=1,4)}
+    .column_25{:class => cb_column_class(i+=1,4)}
       %table.data.box{:id => "group_#{(group_name || t('unknown')).parameterize}"}
         %thead
           %tr

--- a/crowbar_framework/app/views/nodes/actions.html.haml
+++ b/crowbar_framework/app/views/nodes/actions.html.haml
@@ -6,7 +6,7 @@
   - i = -1
   - @states.each do |state, state_details|
     - nodes = state_details[:nodes]
-    .column_25{:class => column_class(i+=1,4)}
+    .column_25{:class => cb_column_class(i+=1,4)}
       %table.data.box{:id => "state_#{(state || t('unknown')).parameterize}"}
         %thead
           %tr.state{:id=>state, :draggable=>'true' }

--- a/crowbar_framework/app/views/nodes/index.html.haml
+++ b/crowbar_framework/app/views/nodes/index.html.haml
@@ -18,7 +18,7 @@
     = t('no_items')
   - else
     - i = -1
-    #add_group_div.column_25{:class => column_class(1,4), :style=>'display:none' }
+    #add_group_div.column_25{:class => cb_column_class(1,4), :style=>'display:none' }
       %table.data.box{:id => "new_group_add"}
         %thead
           %tr
@@ -32,7 +32,7 @@
             %td 
             %td= t('.new_drag')
     - @groups.sort.each do |name, group|
-      .column_25{:class => column_class(i+=1,4)}
+      .column_25{:class => cb_column_class(i+=1,4)}
         %table.data.box{:id => "group_#{(name || t('unknown')).parameterize}"}
           %thead
             %tr


### PR DESCRIPTION
 .../app/helpers/application_helper.rb              |    2 +-
 .../app/views/barclamp/overview.html.haml          |    2 +-
 .../app/views/nodes/actions.html.haml              |    2 +-
 crowbar_framework/app/views/nodes/index.html.haml  |    4 ++--
 4 files changed, 5 insertions(+), 5 deletions(-)
