### PR TITLE
Fix Node Selection Naming Bug (that was driving me crazy) [1/5]

### DIFF
--- a/crowbar_framework/app/views/barclamp/_node_selector.html.haml
+++ b/crowbar_framework/app/views/barclamp/_node_selector.html.haml
@@ -204,7 +204,7 @@ $(document).ready(function() {
         var node = $('a.available[id="'+item+'"]');
         if (node.length==0) node = $('a.available[id="-1"]');
         var title = node.attr('title');
-        var shortname = node.text() + ' ' + item;
+        var shortname = node.text(); 
         var ll = "<li class='allocated " + (even_row ? 'even' : 'odd') +"' id='"+ item + "' title='"+ title + "'>"+shortname;
         ll = ll + "<img src='/images/icons/server_delete.png' style='float:right' title='#{t('.remove')}' onclick='remove_item(\""+item+"\",\""+list+"\");'>";
         ll = ll + "</li>";


### PR DESCRIPTION
This was a trivial fix to the proposal node selection page
where the alias and long name were both being shown

The fix was simple and very low risk.

 .../app/views/barclamp/_node_selector.html.haml    |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
