### PR TITLE
Fix log rotation for chef components. [2/2]

### DIFF
--- a/chef/cookbooks/crowbar/files/default/chef-server
+++ b/chef/cookbooks/crowbar/files/default/chef-server
@@ -1,0 +1,8 @@
+/var/log/chef/server*log /var/log/chef/merb*log /var/log/chef/solr.log /var/log/rabbitmq/*.log {
+  rotate 12
+  weekly
+  compress
+  postrotate
+	bluepill chef-server restart > /dev/null
+  endscript
+}

--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -180,6 +180,14 @@ template "/opt/dell/crowbar_framework/rainbows-dev.cfg" do
             :app_location => "/opt/dell/crowbar_framework")
 end
 
+%w(chef-server-api chef-server-webui chef-solr rabbitmq-server).each do |f|
+  file "/etc/logrotate.d/#{f}" do
+    action :delete
+  end
+end
+
+cookbook_file "/etc/logrotate.d/chef-server"
+
 bluepill_service "crowbar-webserver" do
   variables(:processes => [ {
                               "name" => "rainbows",


### PR DESCRIPTION
Add the appropriate logrotate config file for chef-server and chef-client.

The prepackaged ones assumed that the old sysv init stuff was being used.
Since we run our chef components under bluepill, we need to use it to
bounce the service to let logrotation do it's thing.

 chef/cookbooks/crowbar/files/default/chef-server |    8 ++++++++
 chef/cookbooks/crowbar/recipes/default.rb        |    8 ++++++++
 2 files changed, 16 insertions(+)
