### PR TITLE
Better fix for new network json [1/2]

### DIFF
--- a/crowbar_framework/app/models/crowbar_validator.rb
+++ b/crowbar_framework/app/models/crowbar_validator.rb
@@ -106,6 +106,12 @@ class CrowbarValidator < Kwalify::Validator
            msg = "Should be an IP Address: #{value}"
            errors << Kwalify::ValidationError.new(msg, path)
          end
+      when 'CidrIpAddress'
+         regex = /\A(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)(?:\.(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)){3}(\/(?:[1-2]?\d|3[0-2]))?\z/
+         if value[regex].nil?
+           msg = "Should be a CIDR IP Address: #{value}"
+           errors << Kwalify::ValidationError.new(msg, path)
+         end
       when 'IpAddressMap'
          regex = /\A(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)(?:\.(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)){3}\z/
          value.each_key do |key|


### PR DESCRIPTION
This change adds a new CidrIpAddress type to the kwalify schema for jsons.
The new network json uses this type for validation on subnets.

 crowbar_framework/app/models/crowbar_validator.rb |    6 ++++++
 1 files changed, 6 insertions(+), 0 deletions(-)
