### PR TITLE
Add UEFI support to fredwilma [4/4]

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -282,19 +282,6 @@ class NodeObject < ChefObject
     @node.nil? ? false : @node["crowbar"]["allocated"]
   end
 
-  def rename(value, domain)
-    return "unknown" if @node.nil?
-    @node.name value
-    @node[:fqdn] = value
-    @node[:domain] = domain
-    # This modifying of the run_list is to handle change the name of the crowbar tracking role (SAFE)
-    @node.run_list.run_list_items.delete "role[#{@role.name}]"
-    @role.name = "crowbar-#{value.gsub(".", "_")}"
-    @node.run_list.run_list_items << "role[#{@role.name}]"
-    @node.save
-    save
-  end
-
   # creates a hash with key attributes of the node from ohai for comparison
   def family
     f = {}


### PR DESCRIPTION
This pull request series adds support for nodes running in UEFI mode.
- We no longer rename nodes.  Some of the other UEFI related changes
  caused the node rename bugs to trigger more often than I wanted.
- Kickstarts, seeds, autoyasts, pxelinux config files, and elilo
  config files are configured on a per-node basis instead of a
  per-state basis.  This lets us be a little more flexible in how
  nodes are deployed.  UEFI needs this to handle some boot-related
  issues on redhat.
- Sledgehammer has been updated to include UEFI handling code.

Currently UEFI for Ubuntu on PowerEdge R 12th gen servers will not
work due to bad interactions between grub2 and the BIOS.  Redhat
(i.e. grub 1) works normally on PE-R and PE-C gear.

 crowbar_framework/app/models/node_object.rb |   13 -------------
 1 file changed, 13 deletions(-)
