### PR TITLE
Dont reset the crowbar user after creation [3/3]

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -53,6 +53,7 @@ user "crowbar" do
   home "/home/crowbar"
   password "$6$afAL.34B$T2WR6zycEe2q3DktVtbH2orOroblhR6uCdo5n3jxLsm47PBm9lwygTbv3AjcmGDnvlh0y83u2yprET8g9/mve."
   shell "/bin/bash"
+  not_if "egrep -qi '^crowbar:' /etc/passwd"
 end
 
 directory "/root/.chef" do


### PR DESCRIPTION
Allow the administrator to change the crowbar user after installation without modifying the chef recipes.
In particular, the password should not be whacked ever chef-client run.

 chef/cookbooks/crowbar/recipes/default.rb |    1 +
 1 files changed, 1 insertions(+), 0 deletions(-)
