### PR TITLE
Stop renaming nodes as part of initial node discovery. [3/3]

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -282,19 +282,6 @@ class NodeObject < ChefObject
     @node.nil? ? false : @node["crowbar"]["allocated"]
   end
 
-  def rename(value, domain)
-    return "unknown" if @node.nil?
-    @node.name value
-    @node[:fqdn] = value
-    @node[:domain] = domain
-    # This modifying of the run_list is to handle change the name of the crowbar tracking role (SAFE)
-    @node.run_list.run_list_items.delete "role[#{@role.name}]"
-    @role.name = "crowbar-#{value.gsub(".", "_")}"
-    @node.run_list.run_list_items << "role[#{@role.name}]"
-    @node.save
-    save
-  end
-
   # creates a hash with key attributes of the node from ohai for comparison
   def family
     f = {}


### PR DESCRIPTION
This pull request series does away with node rename during discovery.

It is intended to fix the opensource build along with making the discovery
codepath a little simpler.

 crowbar_framework/app/models/node_object.rb |   13 -------------
 1 file changed, 13 deletions(-)
