### PR TITLE
Add back chefspec gem for unit tests. [1/1]

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -54,7 +54,7 @@ group :development do
 end
 
 gem "rspec", :group => [:development, :test]
-#gem "chefspec", :group => [:development, :test]
+gem "chefspec", :group => [:development, :test]
 gem "rcov", :group => [:development, :test]
 gem "rspec-rails", ">= 2.10.1", :group => [:development, :test]
 # These to require Ruby 1.9.3


### PR DESCRIPTION
Chefspec was breaking unit tests by requiring a different version of
rspec-mocks than the version of rspec that was running the tests
required.  Since the dev tool now runs rspec on the Chef unit tests
using the same gem bundles that the rest of the Crowbar framework
uses, there are no more version conflicts and we can run unit tests
requiring chefspec again.

 crowbar_framework/Gemfile |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: db50bbf1b0f66dd3328ab91113c81e99aa39c493

Crowbar-Release: development
