### PR TITLE
Add os_support stanzas to selected barclamps. [1/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -24,6 +24,10 @@ barclamp:
   proposal_schema_version: 1
   member:
     - crowbar
+  os_support:
+    - ubuntu-12.04
+    - redhat-6.2
+    - centos-6.2
 
 crowbar:
   layout: 2


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |    4 ++++
 1 file changed, 4 insertions(+)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
