### PR TITLE
Make local unit tests always use local gems, and other enhancements [1/3]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -227,9 +227,8 @@ gems:
     - bundler
     - bunny
     - cancan
-    - chef
+    - chef-(~>10.16.2)
     - chefspec
-    - daemons
     - database_cleaner
     - delayed_job_active_record
     - devise
@@ -238,31 +237,24 @@ gems:
     - haml
     - highline
     - i18n
-    - ipaddress
     - jquery-rails
     - json
     - kwalify
     - launchy
     - libxml-ruby
-    - mixlib-authentication
-    - mixlib-cli
-    - mixlib-config
-    - mixlib-log
-    - mixlib-shellout
-    - moneta
     - net-http-digest_auth
     - net-ssh
     - net-ssh-multi
-    - ohai
     - puma
     - railroad
-    - rails-3.2.9
+    - rails-(~>3.2.9)
     - rails-erd
     - rake
     - rcov
     - rdoc
     - rest-client
-    - rspec-rails-2.11.4
+    # Pinned to not interfere with chefspec.
+    - rspec-rails-(=2.11.4)
     - sass
     - sass-rails
     - sendfile
@@ -270,10 +262,6 @@ gems:
     - sqlite3
     - state_machine
     - syslogger
-    - systemu
-    - uuidtools
     - xml-simple
-    - yajl-ruby
-    - factory_girl-2.6.4
-    - factory_girl_rails-1.7.0
+    - factory_girl_rails-(~>1.7.0)
     - foodcritic


### PR DESCRIPTION
This pull request fixes up our gem handling routines in the build
system to no longer require a chroot to fetch all required gems and
their dependencies.

Instead, we add a wrapper for rubygems that allows you to specify
multiple version constraints, and use that wrapper with dependency and
fetch to fetch a gem and all of its depencencies without the
requirement of actually installing htem -- a feature that neither gem
nor bundler have on their own.

This also expands our understanding of gem declarations in crowbar.yml
files to allow specifying version constraints using rubygem-inspired syntax.

The above work allows us to always have the unit test system always use local gems,
and provides a way to allow the local gem cache to be updated independently of the
rest of the build cache.

 crowbar.yml |   22 +++++-----------------
 1 file changed, 5 insertions(+), 17 deletions(-)

Crowbar-Pull-ID: 5a7193a964dbe055d1ecdae15c758660cc205039

Crowbar-Release: development
