### PR TITLE
Fix broken build by setting DISABLE_CHEF=false in the production environment. [1/1]

### DIFF
--- a/crowbar_framework/config/environments/production.rb
+++ b/crowbar_framework/config/environments/production.rb
@@ -41,6 +41,7 @@ require 'syslogger'
 config.logger = Syslogger.new("crowbar_app", Syslog::LOG_PID, Syslog::LOG_LOCAL0)
 config.logger.level = Logger::DEBUG
 config.log_level = :debug
+DISABLE_CHEF=false
 
 # Use a different cache store in production
 # config.cache_store = :mem_cache_store


### PR DESCRIPTION
Exactly what the title says.

 .../config/environments/production.rb              |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: a37dde0c7f292e69bba3bdc35a6406ac0c3bbb21

Crowbar-Release: development
