### PR TITLE
[Ruby 1.9] Add SimpleCov for test code coverage

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -40,8 +40,13 @@ group :development do
   gem "rails-erd"
 end
 
+# rcov supports only Ruby 1.8, while simplecov supports only Ruby 1.9. So
+# pick the right one based on the Ruby version. Simplify once 1.8 support is
+# dropped.
+gem 'rcov',      :platforms => :ruby_18, :group => [:development, :test]
+gem 'simplecov', :platforms => :ruby_19, :group => :test, :require => false
+
 gem "chefspec", :group => [:development, :test]
-gem "rcov", :group => [:development, :test]
 gem "rspec-rails", "~> 2.11.4", :group => [:development, :test]
 # These to require Ruby 1.9.3
 gem "factory_girl", "<3.0" , :group => [:development, :test]

--- a/crowbar_framework/test/test_helper.rb
+++ b/crowbar_framework/test/test_helper.rb
@@ -11,7 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
 # See the License for the specific language governing permissions and 
 # limitations under the License. 
-# 
+
+# SimpleCov supports only Ruby 1.9. It must be required and started before the
+# application code loads, so keep this block at the top.
+if RUBY_VERSION != '1.8.7'
+  require 'simplecov'
+  SimpleCov.start
+end
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
Rcov only works for Ruby 1.8, while SimpleCov only works for Ruby 1.9.
So during the transition phase where both Ruby versions are supported,
we need to require and activate the appropriate one.

SimpleCov outputs the HTML report to RAILS_ROOT/coverage. One way to
easily view the report from your workstation/laptop (assuming your
Crowbar dev system is somewhere else) is to run:

```
cd RAILS_ROOT/public
ln -s ../coverage && ln -s coverage/assets
rails s puma
```

You can then view the report at http://192.168.124.10:3000/coverage.

Note that there's a minor bug in SimpleCov that triggers 404s for some
background images. This is harmless, but can be worked around with:

```
cd RAILS_ROOT/coverage/assets/0.7.1
ln -s smoothness/images
```
