### PR TITLE
[Ruby 1.9] Fix malformed doc/crowbar.yml

### DIFF
--- a/crowbar_framework/doc/crowbar.yml
+++ b/crowbar_framework/doc/crowbar.yml
@@ -25,7 +25,6 @@ crowbar/releasenotes:
 crowbar/userguide:
   order: 1000
   crowbar/userguide/general:
-    order: 10
     - crowbar/userguide/nodes
   crowbar/userguide/utils:
     order: 100


### PR DESCRIPTION
Without this patch, Ruby 1.8 silently ignores the value 10 of the
"order" key, and sets it to the following array instead:

```
> cd RAILS_ROOT
> rvm use 1.8.7
> irb
1.8.7-p371 :001 > require 'yaml'
1.8.7-p371 :002 > YAML.load_file('doc/crowbar.yml')['crowbar/userguide']['crowbar/userguide/general']
 => {"order"=>["crowbar/userguide/nodes"]}
```

Which is unintended but doesn't cause any obvious problems. However,
Ruby 1.9 is stricter with YAML parsing and chokes:

```
> cd RAILS_ROOT
> rvm use 1.9.3
> irb
1.9.3-p327 :001 >   require 'yaml'
1.9.3-p327 :002 >   YAML.load_file 'doc/crowbar.yml'
Psych::SyntaxError: (doc/crowbar.yml): did not find expected key while
                    parsing a block mapping at line 28 column 5
```

With this patch, both Ruby 1.8 and 1.9 returns
`{"order"=>["crowbar/userguide/nodes"]}`.
