### PR TITLE
[Ruby 1.9] Colons are no longer valid in case statements

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -614,14 +614,14 @@ class NodeObject < ChefObject
       found = if_map["#{speeds[x]}#{if_cnt}"] unless found
     }
     case m[1]
-      when '+': (desired..speeds.length).each(&filter)
-      when '-': desired.downto(0,&filter)
-      when '?':
-        (desired..speeds.length).each(&filter)
-        desired.downto(0,&filter) unless found
-      else
-        found = if_map[ref]
-      end
+    when '+' then (desired..speeds.length).each(&filter)
+    when '-' then desired.downto(0,&filter)
+    when '?'
+      (desired..speeds.length).each(&filter)
+      desired.downto(0,&filter) unless found
+    else
+      found = if_map[ref]
+    end
     found
   end
 


### PR DESCRIPTION
Colons are no longer allowed in case statements in Ruby 1.9. Use
semi-colon, then, or newline instead. Also fix indenting.
