### PR TITLE
[Ruby 1.9] Fix broken barclamp_model unit tests

### DIFF
--- a/crowbar_framework/test/unit/barclamp_model_test.rb
+++ b/crowbar_framework/test/unit/barclamp_model_test.rb
@@ -222,8 +222,8 @@ class BarclampModelTest < ActiveSupport::TestCase
     bc.name = "foo"
     Barclamp.import_1x_deployment(bc,json)
     ordered = bc.get_roles_by_order
-    assert_equal ['foo_mon_master'],       ordered.first
-    assert_equal ['foo_mon', 'foo_store'], ordered.second
+    assert_equal ['foo_mon_master'],       ordered.first.map(&:name)
+    assert_equal ['foo_mon', 'foo_store'], ordered.second.map(&:name)
   end
 
 end


### PR DESCRIPTION
`assert` is incorrectly used here, since it just tests that the first
argument is `true`, which in Ruby means _any_ object (eg. 0, 1, "", [],
{}) except `false` and `nil`.

Ruby 1.9 is stricter here and checks that the second argument is a
`String` or `Proc`, thus uncovering the bug/typo. `assert_equal` should
be used here instead.

Also ensure that the order of the two arguments of `assert_equal` is
correct. That is, expected result first followed by actual. This
prevents confusion when reading the error messages in failing tests.

Finally, prefer using single quotes instead of double quotes when string
interpolation is not needed.

The second commit fixes the assertion comparing an array of objects to
an array of strings.
