### PR TITLE
[Ruby 1.9] Fix broken CMDB spec tests

### DIFF
--- a/crowbar_framework/spec/models/cmdb_spec.rb
+++ b/crowbar_framework/spec/models/cmdb_spec.rb
@@ -77,21 +77,21 @@ describe "cmdb proposal manipulation" do
 
     it "can create a test proposal with 2 nodes" do
       barclamp = setup_test_barclamp_with_2_nodes()
-      assert barclamp.proposals.length,1
+      assert_equal 1, barclamp.proposals.length
       pc = barclamp.proposals[0].current_config
-      assert pc.node_roles.length,2
+      assert_equal 2, pc.node_roles.length
 
       evt = Cmdb.prepare_proposal(pc)
 
       # there should now be: 1 cmdbChef event, 2 runs - 1 for test-multi-head, 1 for test-multi-rest
-      assert CmdbEvent.all.length,1
-      assert CmdbRunChef.all.length, 2
+      assert_equal 1, CmdbEvent.all.length
+      assert_equal 2, CmdbRunChef.all.length
 
       ## Verify that evt <-> run relationship holds,
       CmdbRunChef.all.each { |r| r.cmdb_event == evt }
       # verify run status .
-      evt.cmdb_run.each { |r| assert r.status, CmdbRun::RUN_PENDING }
-      assert evt.status, CmdbEvent::EVT_PENDING
+      evt.cmdb_run.each { |r| assert_equal CmdbRun::RUN_PENDING, r.status }
+      assert_equal CmdbEvent::EVT_PENDING, evt.status
     end
   end
 end


### PR DESCRIPTION
`assert` is incorrectly used here, since it just tests that the first
argument is `true`, which in Ruby means _any_ object (eg. 0, 1, "", [],
{}) except `false` and `nil`.

Ruby 1.9 is stricter here and checks that the second argument is a
`String` or `Proc`, thus uncovering the bug/typo. `assert_equal` should
be used here instead.

Also ensure that the order of the two arguments of `assert_equal` is
correct. That is, expected result first followed by actual. This
prevents confusion when reading the error messages in failing tests.

This patch exposes the following test failure that was hidden
previously:

```
 1) cmdb proposal manipulation start a run for a proposal can create a test proposal with 2 nodes
    Failure/Error: assert_equal 1, CmdbEvent.all.length
    Test::Unit::AssertionFailedError:
      <1> expected but was
      <0>.
    # (eval):2:in `send'
    # (eval):2:in `assert_equal'
    # ./spec/models/cmdb_spec.rb:87
```
