### PR TITLE
Update EPEL to pull in correct current repo information. [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -138,7 +138,7 @@ rpms:
   redhat-6.2:
     repos:
       - rpm http://rbel.frameos.org/rbel6
-      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-7.noarch.rpm
+      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-8.noarch.rpm
     build_pkgs:
       - libcurl-devel
       - yum-plugin-downloadonly
@@ -148,7 +148,7 @@ rpms:
   centos-6.2:
     repos:
       - rpm http://rbel.frameos.org/rbel6
-      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-7.noarch.rpm
+      - rpm http://mirrors.servercentral.net/fedora/epel/6/i386/epel-release-6-8.noarch.rpm
     build_pkgs:
       - libcurl-devel
       - yum-plugin-downloadonly


### PR DESCRIPTION
EPEL repo version for RHEL 6 bumped its version to 6.8.

Make sure we pull in that version.

 crowbar.yml |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 46eacd58f6f644fac22e27e3850abb1d6fde7a77

Crowbar-Release: development
