### PR TITLE
Add missing gem from pull 320 (add simplecov) [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -251,6 +251,7 @@ gems:
     - rails-erd
     - rake
     - rcov
+    - simplecov
     - rdoc
     - rest-client
     # Pinned to not interfere with chefspec.


### PR DESCRIPTION
This is a very small fix to include simplecov in the gemlist.

This omission was breaking the installs.

 crowbar.yml |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 4e47cf3c9977220933e19b9ce383d82d2ca8108f

Crowbar-Release: development
