### PR TITLE
[Security] Upgrade to Rails 3.2.11

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -247,7 +247,7 @@ gems:
     - net-ssh-multi
     - puma
     - railroad
-    - rails-(~>3.2.10)
+    - rails-(~>3.2.11)
     - rails-erd
     - rake
     - rcov

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -15,7 +15,7 @@
 source "http://127.0.0.1:3001"
 #source 'http://rubygems.org'
 
-gem 'rails', '~> 3.2.10'
+gem 'rails', '~> 3.2.11'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'


### PR DESCRIPTION
See http://weblog.rubyonrails.org/2013/1/8/Rails-3-2-11-3-1-10-3-0-19-and-2-3-15-have-been-released/
for details.
