### PR TITLE
Fix 6 failing user spec tests

### DIFF
--- a/crowbar_framework/spec/models/user_spec.rb
+++ b/crowbar_framework/spec/models/user_spec.rb
@@ -20,6 +20,7 @@ describe User do
   before(:each) do
     @attr = { 
       :name => "Example User",
+      :username => "example_user",
       :email => "user@example.com",
       :password => "foobar",
       :password_confirmation => "foobar"


### PR DESCRIPTION
Fixes the following spec failures:

```
 1) User should create a new instance given a valid attribute
    Failure/Error: User.create!(@attr)
    ActiveRecord::RecordInvalid:
      Validation failed: Username can't be blank
    # ./spec/models/user_spec.rb:30

 2) User should reject duplicate email addresses
    Failure/Error: User.create!(@attr)
    ActiveRecord::RecordInvalid:
      Validation failed: Username can't be blank
    # ./spec/models/user_spec.rb:50

 3) User should accept valid email addresses
    Failure/Error: valid_email_user.should be_valid
      expected valid? to return true, got false
    # ./spec/models/user_spec.rb:37
    # ./spec/models/user_spec.rb:35:in `each'
    # ./spec/models/user_spec.rb:35

 4) User should reject email addresses identical up to case
    Failure/Error: User.create!(@attr.merge(:email => upcased_email))
    ActiveRecord::RecordInvalid:
      Validation failed: Username can't be blank
    # ./spec/models/user_spec.rb:57

 5) User password encryption should have an encrypted password attribute
    Failure/Error: @user = User.create!(@attr)
    ActiveRecord::RecordInvalid:
      Validation failed: Username can't be blank
    # ./spec/models/user_spec.rb:100

 6) User password encryption should set the encrypted password attribute
    Failure/Error: @user = User.create!(@attr)
    ActiveRecord::RecordInvalid:
      Validation failed: Username can't be blank
    # ./spec/models/user_spec.rb:100
```
