### PR TITLE
[TravisCI] Patch `rake db:fixtures:dump` task to work in Travis

### DIFF
--- a/crowbar_framework/lib/tasks/fixtures.rake
+++ b/crowbar_framework/lib/tasks/fixtures.rake
@@ -3,11 +3,13 @@ namespace :db do
     desc 'Create YAML test fixtures from data in an existing database.  Defaults to development database. Set RAILS_ENV to override.'
     task :dump => :environment do
       sql = "SELECT * FROM %s"
-      skip_tables = ["schema_info"]
-      ActiveRecord::Base.establish_connection(:development)
+      skip_tables = ["schema_migrations"]
+      dir = File.join(Rails.root, 'test', 'fixtures')
+      FileUtils.mkdir_p dir
+      ActiveRecord::Base.establish_connection(Rails.env)
       (ActiveRecord::Base.connection.tables - skip_tables).each do |table_name|
         i = "000"
-        File.open("#{Rails.root}/test/fixtures/#{table_name}.yml", 'w') do |file|
+        File.open(File.join(dir, "#{table_name}.yml"), 'w') do |file|
           data = ActiveRecord::Base.connection.select_all(sql % table_name)
           file.write data.inject({}) { |hash, record|
             hash["#{table_name}_#{i.succ!}"] = record


### PR DESCRIPTION
- Fix ActiveRecord connection to use Rails.env, as described in the
  rake task description, instead of being hard-coded to :development.
  Travis apparently sets RAILS_ENV to 'test', so db:migrate loads up the
  test database. But db:fixtures:dump was hardcoded to development,
  hence causing it to fail.
- Fix skipped tables from 'schema_info' to 'schema_migrations'. This was
  changed in Rails since 2.1:
  http://api.rubyonrails.org/classes/ActiveRecord/Migration.html
- Ensure that test/fixtures directory exists before dumping.

In general fixtures are a pain to manage, especially when the project
gets bigger and test coverage increases. It's much better to ditch them
altogether and use a replacement like factory_girl or machinist.
