### PR TITLE
Only run network BDD tests in interactive mode [1/2]

### DIFF
--- a/crowbar_framework/BDD/default.config
+++ b/crowbar_framework/BDD/default.config
@@ -2,7 +2,7 @@
 {url, "http://192.168.124.10:3000"}.
 {user, "developer"}.
 {password,"Cr0wbar!"}.    % do not store production passwords here!
-{environment, "interactive"}.
+{environment, interactive}.
 {global_setup, crowbar}.
 {secondary_step_files, [crowbar_rest, crowbar, bdd_webrat, bdd_restrat, bdd_catchall]}.
 {translation_error, "translation_missing"}.


### PR DESCRIPTION
Only attempt to run the network BDD tests in interactive mode.
Also fixed a deprecation warning in the network BDD tests.

 crowbar_framework/BDD/default.config |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: f726823a085b0bc142f38605a27259ba5843d690

Crowbar-Release: development
