### PR TITLE
DE1098 - join being called on a hash object type. [1/1]

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -33,7 +33,7 @@ module NodesHelper
     ip_list.each_pair do |network, addresses|
       unless network=='~notconnected' && addresses.nil?
         if network == '[not managed]'
-          html += "<li><b>#{network}:</b> #{addresses.join(',')}</li>"
+          html += "<li><b>#{network}:</b> #{addresses.to_a.join(',')}</li>"
         else
           html += "<li><b>#{network}:</b> #{addresses.keys.collect {|k| "#{k}: #{addresses[k]}"}.join(',')}</li>"
         end


### PR DESCRIPTION
DE1098 - When the network is "not managed", it's trying to call addresses.join and in
this case addresses is a hash not an array. Force an array conversion before the join
to prevent an exception from occurring - addresses.to_a.join.

 crowbar_framework/app/helpers/nodes_helper.rb |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)

Crowbar-Pull-ID: 67d0172a957640e84d14ee0f91f80003d3c76e38

Crowbar-Release: fred
