### PR TITLE
Allocated ip available as attr, plus get_bus_map proof of concept [1/2]

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -299,13 +299,13 @@ class Node < ActiveRecord::Base
 
   # retrieves the Attrib from AttribInstance
   # NOTE: for safety, will create the association if it is missing
-  def attrib_get(attrib)
+  def attrib_get(attrib, useclass=AttribInstance::DEFAULT_CLASS)
     a = Attrib.find_key attrib 
     if a.nil?
       # find or create the attrib
       a = Attrib.find_or_create_by_name :name=>attrib, :description=>I18n.t('model.attribs.node.default_create_description')
     end
-    AttribInstance.find_or_create_by_attrib_and_node(a, self)
+    AttribInstance.find_or_create_by_attrib_and_node(a, self, useclass)
   end
     
   # if you set the attribute from the new, then we require that you have a crowbar barclamp association


### PR DESCRIPTION
This pull request includes:
1. Setting the allocate ip address as an attribute on the Node
2. The first piece of the conduit calculation (get_bus_map) along with a
   custom AttribInstance that makes the bus map for a node publicly available.
These two components are the first to exercise setting a Jig attribute on a node and making a custom attribute that is set on a node.

 crowbar_framework/app/models/node.rb |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 619186241d4e828e4b1bca58c144dc8a9442c5b7

Crowbar-Release: development
