### PR TITLE
Setting ip address as attribute and exposing bus_order_call [1/2]

### DIFF
--- a/crowbar_framework/app/models/attrib_instance.rb
+++ b/crowbar_framework/app/models/attrib_instance.rb
@@ -34,7 +34,10 @@ class AttribInstance < ActiveRecord::Base
   def self.find_or_create_by_attrib_and_node(attrib, node=nil, defaultclass=DEFAULT_CLASS)
     node_id = (node.nil? ? 0 : node.id)
     attrib_id = (attrib.nil? ? nil : attrib.id)
-    defaultclass.find_or_create_by_attrib_id_and_node_id :node_id=>node_id, :attrib_id=>attrib_id
+
+    ai = AttribInstance.find_by_attrib_id_and_node_id(attrib_id, node_id)
+    ai = defaultclass.create!(:node_id=>node_id, :attrib_id=>attrib_id) if ai.nil?
+    ai
   end
 
   # for now, none of the proposed values are visible

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -541,7 +541,7 @@ class ServiceObject
   end
 
 
-  def get_object(type, object_id)
+  def self.get_object(type, object_id)
     object = nil
     object_id = object_id.to_s
 
@@ -552,15 +552,11 @@ class ServiceObject
     else
       objects = type.where( :name => object_id )
       if objects.size == 0
-        error_msg = "Unable to find #{type} with id=#{object_id}"
-        @logger.error(error_msg)
-        raise ActiveRecord::RecordNotFound, error_msg
+        raise ActiveRecord::RecordNotFound, "Unable to find #{type} with id=#{object_id}"
       end
       object = objects[0] if objects.size == 1
       if objects.size > 1
-        error_msg = "There are #{objects.size} #{type}s with the name #{object_id}"
-        @logger.error(error_msg)
-        raise error_msg
+        raise "There are #{objects.size} #{type}s with the name #{object_id}"
       end
     end
 
@@ -568,7 +564,7 @@ class ServiceObject
   end
 
 
-  def get_object_safe(type, object_id)
+  def self.get_object_safe(type, object_id)
     begin
       return get_object(type, object_id)
     rescue ActiveRecord::RecordNotFound => ex


### PR DESCRIPTION
This pull contains 2 changes:
1. When an ip address is allocated to a node, it is set as an attribute on the node.
2. The 1st part of the conduit calculation: bus_order has been implemented and exposed as a customer attr on the node.

 crowbar_framework/app/models/attrib_instance.rb |    5 ++++-
 crowbar_framework/app/models/service_object.rb  |   12 ++++--------
 2 files changed, 8 insertions(+), 9 deletions(-)

Crowbar-Pull-ID: fc688ffdeeaf809a3e66a8a50f4197dfcd43c390

Crowbar-Release: development
