### PR TITLE
First pass at adding native package support to Crowbar [1/2]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -51,9 +51,22 @@ debs:
   #repos:
     # Rabbit MQ repo
     #- deb http://www.rabbitmq.com/debian/ testing main
+  required_pkgs:
+    - ruby1.9.1
+    - ruby1.9.1-dev
+    - gcc
+    - rubygems
+    - tcpdump
+    - libcurl4-gnutls-dev
+    - build-essential
+    - libxml2-dev
+    - zlib1g-dev
+    - nginx
+    - ipmitool
+    - efibootmgr
   build_pkgs:
-#    - ruby1.8-dev
-#    - rubygems1.8
+    - ruby1.9.1
+    - rubygems
     - ruby1.9.1-dev
     - build-essential
     - libsqlite3-dev
@@ -86,7 +99,6 @@ debs:
     - sqlite
     - sqlite3
     - libsqlite3-dev
-    - libshadow-ruby1.8
     - chef
     - chef-server
     - chef-server-webui
@@ -110,13 +122,9 @@ debs:
     # rabbitmq stuff
     - rabbitmq-server
     # ruby stuff
-    - ruby1.8
-    - ruby1.8-dev
     - ruby1.9.1
     - ruby1.9.1-dev
-    - ruby-dev
     - rubygems
-    - rubygems1.8
     # runit stuff
     - runit
     # sudo stuff
@@ -154,6 +162,17 @@ rpms:
       - createrepo
       - libxml2-devel
       - zlib-devel
+  required_pkgs:
+    - install
+    - rubygems
+    - gcc
+    - make
+    - ruby-devel
+    - libxml2-devel
+    - zlib-devel
+    - tcpdump
+    - nginx
+    - efibootmgr
   build_pkgs:
     - rubygems
     - ruby-devel


### PR DESCRIPTION
This pull request adds basic support for generating RPM and Deb files

The main place this is added is to package_barclamp.sh.  To use it,
pass the --deb and --rpm flags to package_barclamp.sh, and it will
generate installable .deb and .rpm packages along with the package
cache tarballs.

The generated packages have a semi-useless version numbering scheme
based the current time that we will definitly want to replace with
something semantic at some point.  The utility that generates the
specfiles and debian control metadata knows how to dependency-order
the packages based on intra barclamp dependencies, and I also added a
required_pkgs section to the gems and rpms sections of the
crowbar.yml, and we also know how to include those dependencies in the
generated packages.

I also added the ability to build an ISO using OS native packages, but
the install process does not know how to use native barclamp packages
yet.

Next steps:

1: Get a "working" admin node.
2: Work on automatically translating gems -> RPM packages/debs.
3: Fix all the assumptions about bundler that will break when that happens.

 crowbar.yml |   33 ++++++++++++++++++++++++++-------
 1 file changed, 26 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: 5b598c8110f085ef576877b660248715e65e9054

Crowbar-Release: development
