### PR TITLE
Ported get_conduits to CR 2.0 [1/2]

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -1,4 +1,4 @@
-# Copyright 2012, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,6 +56,15 @@ class Node < ActiveRecord::Base
     nrs = nrs.select { |x| x.proposal_config_id == x.proposal_config.proposal.active_config_id }
     nrs.map { |x| x.node }
   end
+
+
+  #
+  # Returns the roles associated with the node
+  #
+  def roles
+    Role.joins("join node_roles on role_id = roles.id and node_id = #{self.id}")
+  end
+
 
   #
   # Create function that integrates with Jig functions.


### PR DESCRIPTION
This pull request ports get_conduits to CR2.0, and includes adding a method
to Node to retrieve the roles associated with a given node.

 crowbar_framework/app/models/node.rb |   11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 7f3f471cd8703ba20ddc1aa67cbbc53fcb956339

Crowbar-Release: development
