### PR TITLE
Improve OS detection for Windows [1/1]

### DIFF
--- a/BDD/bdd.erl
+++ b/BDD/bdd.erl
@@ -329,7 +329,7 @@ scenario_steps(Config, [H | T], N, Given, When, Then, Finally, LastStep, Scenari
 	  {Type, SS} -> {Type, SS}
 	end,
 	% calculate for the skips
-	{_, OStype} = os:type(),
+	OStype = bdd_utils:os_type(),
 	case Step of
 	  {step_skip, S}    ->  log(info,"Skipping ~p ~s", [ScenarioID, S]), 
                     	    skip;

--- a/BDD/bdd_utils.erl
+++ b/BDD/bdd_utils.erl
@@ -19,7 +19,7 @@
 -export([scenario_store/3, scenario_retrieve/3]).
 -export([puts/0, puts/1, puts/2, debug/3, debug/2, debug/1, trace/6, untrace/3]).
 -export([log/5, log/4, log/3, log/2, log/1, log_level/1, depricate/4, depricate/6]).
--export([features/1, features/2, feature_name/2]).
+-export([features/1, features/2, feature_name/2, os_type/0]).
 -export([setup_create/5, setup_create/6, teardown_destroy/3]).
 -export([is_site_up/1, is_a/2, is_a/3, marker/1]).
 -define(NORMAL_TOKEN, 1).
@@ -377,6 +377,14 @@ add_token(Token, TokenList) ->
     _ -> [NewToken|TokenList]
   end.
 
+os_type() ->
+  case os:type() of
+    {win32, _}    -> windows;
+    {_, nt}       -> windows;
+    {unix, linux} -> linux;
+    {_, Other}    -> Other    
+  end.
+  
 % This routine is used for special subtitutions in steps that run functions or turn strings into atoms
 token_substitute(_Config, [$a, $p, $p, $l, $y, $: | Apply]) -> [File, Method | Params] = string:tokens(Apply, "."),
                                                               apply(list_to_atom(File), list_to_atom(Method), Params);


### PR DESCRIPTION
If you have the questionable judgement (like I do) to run BDD from 
Windows, then the CLI tests need to be correctly skipped.

This small change allows the "Unless windows" test bypass to work
correctly.

You could also use "While linux" to do the same thing.  It's up to 
you which you like to type more.

 BDD/bdd.erl       |    2 +-
 BDD/bdd_utils.erl |   10 +++++++++-
 2 files changed, 10 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: ef635819ff662f09cd3f87d5aa966fbc29ff40a0

Crowbar-Release: development
