### PR TITLE
change uses of throw to raise

### DIFF
--- a/crowbar_framework/app/models/attrib.rb
+++ b/crowbar_framework/app/models/attrib.rb
@@ -74,24 +74,24 @@ class Attrib < ActiveRecord::Base
     
   # Returns state of value of :empty, :set (by API) or :managed (by Jig)
   def state
-    throw "must be provided by subclass"
+    raise "must be provided by subclass"
   end
 
   def request=(value)
-    throw "must be provided by subclass"
+    raise "must be provided by subclass"
   end
   
   def request
-    throw "must be provided by subclass"
+    raise "must be provided by subclass"
   end
   
   # used by the API when values are set outside of Jig runs
   def actual=(value)
-    throw "must be provided by subclass"
+    raise "must be provided by subclass"
   end
   
   def actual
-    throw "must be provided by subclass"
+    raise "must be provided by subclass"
   end
   
   def as_json options={}

--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -302,7 +302,7 @@ class Barclamp < ActiveRecord::Base
         bc['barclamp']['requires'].each do |prereq|
           prereq = prereq[1..100] if prereq.starts_with? "@"
           pre = Barclamp.find_by_name prereq
-          throw "ERROR: Cannot load barclamp #{bc_name} because prerequisite #{prereq} has not been imported" if pre.nil?
+          raise "ERROR: Cannot load barclamp #{bc_name} because prerequisite #{prereq} has not been imported" if pre.nil?
           barclamp.prereqs << pre 
         end
       end
@@ -368,7 +368,7 @@ class Barclamp < ActiveRecord::Base
   
   # This method ensures that we have a type defined for 
   def create_type_from_name
-    throw "barclamps require a name" if self.name.nil?
+    raise "barclamps require a name" if self.name.nil?
     file = "#{self.name}"
     myclass = "Barclamp#{self.name.camelize}::Barclamp"
     # this will need to be fixed for the engines!!

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -75,12 +75,12 @@ class Node < ActiveRecord::Base
   # XXX: Once networking is better defined, we should use those routines
   #
   def address(net = "admin")
-    throw "CB1 do not use - use attrib_admin_address"
+    raise "CB1 do not use - use attrib_admin_address"
     jig_hash.address(net)
   end
 
   def public_ip
-    throw "CB1 do not use - use attrib_public_ip"
+    raise "CB1 do not use - use attrib_public_ip"
     jig_hash.public_ip
   end
 

--- a/crowbar_framework/app/models/role_type.rb
+++ b/crowbar_framework/app/models/role_type.rb
@@ -48,10 +48,10 @@ class RoleType < ActiveRecord::Base
       r = RoleType.find_or_create_by_name :name => role_type.to_s, :description => desc
     elsif role_type.is_a? Hash
       # we can make them from a hash if the creator wants to include more info
-      throw "role_type.add requires attribute :name" if role_type.nil? or !role_type.has_key? :name
+      raise "role_type.add requires attribute :name" if role_type.nil? or !role_type.has_key? :name
       r = RoleType.find_or_create_by_name role_type
     else
-      throw "role_type.add cannot use #{role_type.class || 'nil'} to create from attribute: #{role_type.inspect}"
+      raise "role_type.add cannot use #{role_type.class || 'nil'} to create from attribute: #{role_type.inspect}"
     end 
     r
   end

--- a/crowbar_framework/spec/models/crowbar_utils_spec.rb
+++ b/crowbar_framework/spec/models/crowbar_utils_spec.rb
@@ -17,7 +17,7 @@ require 'spec_helper'
 
 describe CrowbarUtils do
   describe "Locking functions" do
-    it "should throw an exception if file create fails" do
+    it "should raise an exception if file create fails" do
       File.stub(:new) {nil}
       expect {
         CrowbarUtils.lock_held?("fred")

--- a/crowbar_framework/test/unit/attrib_has_node_test.rb
+++ b/crowbar_framework/test/unit/attrib_has_node_test.rb
@@ -40,7 +40,7 @@ class AttribHasNodeTest < ActiveSupport::TestCase
     assert @hasnode1.is_a? Attrib
     assert_equal HAS_NODE, @node1.attrib_has_nodes.first.name
     assert_equal @role.id, @hasnode1.role_id
-    # Ruby 1.8 and 1.9 throws different exceptions in this case, so handle it
+    # Ruby 1.8 and 1.9 raise different exceptions in this case, so handle it
     # accordingly. Simplify once we remove 1.8 support.
     @error_class = (RUBY_VERSION == '1.8.7') ? NameError : ArgumentError
   end

--- a/crowbar_framework/test/unit/attrib_model_test.rb
+++ b/crowbar_framework/test/unit/attrib_model_test.rb
@@ -27,7 +27,7 @@ class AttribModelTest < ActiveSupport::TestCase
     @na = @node.set_attrib @attrib, @value
     assert_not_nil @na
     assert_equal @value, @na.value
-    # Ruby 1.8 and 1.9 throws different exceptions in this case, so handle it
+    # Ruby 1.8 and 1.9 raise different exceptions in this case, so handle it
     # accordingly. Simplify once we remove 1.8 support.
     @error_class = (RUBY_VERSION == '1.8.7') ? NameError : ArgumentError
   end


### PR DESCRIPTION
'throw' is for escaping from control flow, whereas 'raise' is for
error conditions, e.g.

http://rubylearning.com/blog/2011/07/12/throw-catch-raise-rescue-im-so-confused/
