### PR TITLE
Add .gitignore files for all barclamps [1/26]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.lock
+.idea
+.rvmrc
 *~
 erl_crash.dump
 trace_*.txt


### PR DESCRIPTION
Add .gitignore files for all barclamps - Gemfile.lock files, for exp, will be ignored

 .gitignore |    3 +++
 1 file changed, 3 insertions(+)

Crowbar-Pull-ID: 742c6f610fb8dc538944e63bd5cee6e9545ff688

Crowbar-Release: development
