### PR TITLE
Barclamps Menu is back and routes cleanup [1/1]

### DIFF
--- a/BDD/features/navigation.feature
+++ b/BDD/features/navigation.feature
@@ -37,7 +37,7 @@ Feature: Navigation, Check Core Navigation
 
   Scenario: Barclamps Nav
     Given I am on the home page
-    When I click on the "\\\[Barclamps\\\]" menu item
+    When I click on the "Barclamps" menu item
     Then I should see {bdd:crowbar.i18n.barclamp.index.title} in the body  
       And I should see "crowbar" in the body
       And I should see "deployer" in the body

--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -4,10 +4,10 @@
 
 %ul.buttons
   - if @node.bmc_set?
-    %li= link_to "Reboot", hit_node_path(@node.id, 'reboot'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure') 
-    %li= link_to "Shutdown", hit_node_path(@node.id, 'shutdown'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-    %li= link_to "Power On", hit_node_path(@node.id, 'poweron'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-    %li= link_to "Identify", hit_node_path(@node.name, 'identify'), :class => 'button', :'data-remote' => true
+    %li= link_to "Reboot", "/ipmi/v2/nodes/#{@node.id}/reboot", :method=>:put, :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure') 
+    %li= link_to "Shutdown", "/ipmi/v2/nodes/#{@node.id}/shutdown", :method=>:put, :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+    %li= link_to "Power On", "/ipmi/v2/nodes/#{@node.id}/poweron", :method=>:put, :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+    %li= link_to "Identify", "/ipmi/v2/nodes/#{@node.id}/identify", :method=>:put, :class => 'button', :'data-remote' => true
 
 .column_50.first
   %dl
@@ -52,7 +52,7 @@
 
 %ul.buttons
   - unless @node.is_admin?
-    %li= link_to "Hardware Update", hit_node_path(@node.id, 'update'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-    %li= link_to "Reinstall", hit_node_path(@node.id, 'reinstall'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-    %li= link_to "Reset", hit_node_path(@node.id, 'reset'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-    %li= link_to "Delete", hit_node_path(@node.id, 'delete'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+    %li= link_to "Reboot", "/ipmi/v2/nodes/#{@node.id}/reboot", :method=>:put, :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure') 
+    %li= link_to "Shutdown", "/ipmi/v2/nodes/#{@node.id}/shutdown", :method=>:put, :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+    %li= link_to "Power On", "/ipmi/v2/nodes/#{@node.id}/poweron", :method=>:put, :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+    %li= link_to "Identify", "/ipmi/v2/nodes/#{@node.id}/identify", :method=>:put, :class => 'button', :'data-remote' => true

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -16,11 +16,6 @@ Crowbar::Application.routes.draw do
   
 # DO NOT DELETE OR ALTER THIS LINE - it is for engine mounts
 
-  # ??? what is this ??
-  resources :nodes, :only => [:index, :new] do
-    get 'status', :on => :collection
-  end
-  
   # UI scope documentation / help
   scope 'docs' do
     get '/', :controller=>'docs', :action=>'index', :as => "docs"
@@ -174,22 +169,9 @@ Crowbar::Application.routes.draw do
       scope '2.0' do
         constraints(:id => /([a-zA-Z0-9\-\.\_]*)/, :version => /[0-9].[0-9]/ ) do
   
-          # MOVE TO IMPI actions
-          get "node/:id/hit/:req" => "nodes\#hit", :as => :hit_node # MOVE TO GENERIC - IPMI BARCLAMP??
                   
           scope 'crowbar' do    # MOVE TO GENERIC!
             scope '2.0' do      # MOVE TO GENERIC!
-              # group + node CRUD operations
-              match  "group/:id/node/(:node)" => 'groups#node_action',  :constraints => { :node => /([a-zA-Z0-9\-\.\_]*)/ }
-    
-
-              get "group", :controller=>'groups', :action=>'index'     # MOVE TO GENERIC!
-              #get ":action", :controller=>'crowbar'
-              # basic CRUD operations
-              # (replace w/ generic)
-              match "/node/:id/:target(/:target_id)" , :controller=>'crowbar', :action=>'node', :version=>'2.0'
-              resources :group, :controller=>'groups'     # MOVE TO GENERIC!
-              
              
               # these all need to be updated.
               scope 'users' do

--- a/crowbar_framework/db/migrate/20120723233100_create_navs.rb
+++ b/crowbar_framework/db/migrate/20120723233100_create_navs.rb
@@ -35,7 +35,7 @@ class CreateNavs < ActiveRecord::Migration
       Nav.find_or_create_by_item :item=>'families', :parent_item=>'nodes', :name=>'nav.families', :description=>'nav.families_description', :path=>"dashboard_families_path", :order=>300, :development=>true
 
     # barclamps
-    Nav.find_or_create_by_item :item=>'barclamps', :parent_item=>'root', :name=>'nav.barclamps', :description=>'nav.barclamps_description', :path=>"barclamp_path", :order=>3000, :development=>true
+    Nav.find_or_create_by_item :item=>'barclamps', :parent_item=>'root', :name=>'nav.barclamps', :description=>'nav.barclamps_description', :path=>"barclamp_path", :order=>3000
       Nav.find_or_create_by_item :item=>'all_bc', :parent_item=>'barclamps', :name=>'nav.all_bc', :description=>'nav.all_bc_description', :path=>"barclamp_path", :order=>100
       #Nav.find_or_create_by_item :item=>'crowbar', :parent_item=>'barclamps', :name=>'nav.crowbar_bc', :description=>'nav.crowbar_bc_description', :path=>"index_barclamp_path(:controller=>'crowbar')", :order=>200
       Nav.find_or_create_by_item :item=>'barclamp_graph', :parent_item=>'barclamps', :name=>'nav.barclamp_graph', :description=>'nav.barclamp_graph_description', :path=>"barclamp_graph_path", :order=>800, :development=>true


### PR DESCRIPTION
This small pull brings the barclamps list back into the production UI.

It also includes some routes cleanups that leave only the user routes
remaining in the old formats (Dave P is working on those in parallel)

 BDD/features/navigation.feature                    |    2 +-
 crowbar_framework/app/views/nodes/_show.html.haml  |   16 ++++++++--------
 crowbar_framework/config/routes.rb                 |   18 ------------------
 .../db/migrate/20120723233100_create_navs.rb       |    2 +-
 4 files changed, 10 insertions(+), 28 deletions(-)

Crowbar-Pull-ID: f4ad5d3c073322522408fdbbc0ea8583397d1783

Crowbar-Release: development
