### PR TITLE
load simplecov for specs, except on Ruby 1.8.7 where we use rcov

### DIFF
--- a/crowbar_framework/.simplecov
+++ b/crowbar_framework/.simplecov
@@ -1,0 +1,6 @@
+if RUBY_VERSION != '1.8.7'
+  require 'simplecov'
+  SimpleCov.start 'rails' do
+    use_merging true
+  end
+end

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+# SimpleCov supports only Ruby 1.9. It must be required and started before the
+# application code loads, so keep this block at the top.
+require 'simplecov'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)

--- a/crowbar_framework/test/test_helper.rb
+++ b/crowbar_framework/test/test_helper.rb
@@ -14,10 +14,7 @@
 
 # SimpleCov supports only Ruby 1.9. It must be required and started before the
 # application code loads, so keep this block at the top.
-if RUBY_VERSION != '1.8.7'
-  require 'simplecov'
-  SimpleCov.start
-end
+require 'simplecov'
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
Also uses the standard 'rails' configuration for simplecov, which
groups coverage into models, controllers, helpers, etc.
