### PR TITLE
Epic refactor of network barclamp [1/2]

### DIFF
--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -93,6 +93,9 @@ class Barclamp < ActiveRecord::Base
     template.add_attrib a, r if template
   end
 
+
+  DEFAULT_DEPLOYMENT_NAME = I18n.t('default')
+
   #
   # Possible Override function
   #
@@ -107,7 +110,7 @@ class Barclamp < ActiveRecord::Base
   #
   def create_proposal(deployment=nil)
     deployment = {:name=>deployment} if deployment.is_a? String
-    deployment ||= { :name => I18n.t('default')}
+    deployment ||= { :name => DEFAULT_DEPLOYMENT_NAME}
     proposal = nil
     if allow_multiple_deployments or deployments.count==0
       # setup required items


### PR DESCRIPTION
This pull request includes:
- Conversion of the network barclamp to a Rails Engine and all of the corresponding namespacing changes
- Rename of BarclampConfig, BarclampInstance, AttribInstance, Attrib, RoleInstance, Role fan out
- Removal of Crowbar 1.0 proposal and service objects
- Any odds and ends necessary to get the network barclamp unit tests fully functional
  
  crowbar_framework/app/models/barclamp.rb |    5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: fd8b6516ed91645f2acb1ca198501df1597d772e

Crowbar-Release: development
