### PR TITLE
Enable zombie provisioner mode. [1/10]

### DIFF
--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -301,9 +301,11 @@ class Barclamp < ActiveRecord::Base
       end
   
       # requires (will fail if prereq is missing)
-      if bc['barclamp']['requires']
+      # Don't do this for now, as it will be broken until
+      # all the barclamps are engine-ized.
+      if bc['barclamp']['requires'] && false
         bc['barclamp']['requires'].each do |prereq|
-          prereq = prereq[1..100] if prereq.starts_with? "@"
+          prereq = prereq[1..-1] if prereq.starts_with? "@"
           pre = Barclamp.find_by_name prereq
           raise "ERROR: Cannot load barclamp #{bc_name} because prerequisite #{prereq} has not been imported" if pre.nil?
           barclamp.prereqs << pre 


### PR DESCRIPTION
This series pull requests adds just enough scaffolding to the system
to allow the provisioner to let other machines PXE boot into
Sledgehammer.  The scaffolding comes in the form of default attributes
on the roles needed to allow the provisioner to function, and fixups
to the chef recipes to allow them to operate semi-autonomously.

 crowbar_framework/app/models/barclamp.rb |    6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: b4a5d683f0e2f729f8e7cc489c8f4afaac0e6fac

Crowbar-Release: development
