### PR TITLE
Backed out Ruby 1.8 breaking change [1/1]

### DIFF
--- a/crowbar_framework/test/test_helper.rb
+++ b/crowbar_framework/test/test_helper.rb
@@ -14,7 +14,10 @@
 
 # SimpleCov supports only Ruby 1.9. It must be required and started before the
 # application code loads, so keep this block at the top.
-require 'simplecov'
+if RUBY_VERSION != '1.8.7'
+  require 'simplecov'
+  SimpleCov.start
+end
 
 ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../config/environment", __FILE__)


### PR DESCRIPTION
The last modification to this file broke running unit tests using Ruby 1.8.

Backing out the removal of the conditional so that unit tests can be run with 1.8.

 crowbar_framework/test/test_helper.rb |    5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 63f3dc46387ae788fc99e32981591419f34cff4a

Crowbar-Release: development
