### PR TITLE
Add HTTP Reponse version information to v2 API (and BDD detects) [1/1]

### DIFF
--- a/BDD/bdd.hrl
+++ b/BDD/bdd.hrl
@@ -18,3 +18,6 @@
   % note: the ids field is for backward compatability against the legacy 2.0 api
 
 -record(item, {type = unknown, data, link = unknown}).
+
+% track URL data per API
+-record(meta_api, {datatype = "unknown", version = "0.0"}).

--- a/BDD/crowbar.erl
+++ b/BDD/crowbar.erl
@@ -18,6 +18,7 @@
 -export([step/3, validate/1, g/1, i18n/2, i18n/3, i18n/4, i18n/5, i18n/6, json/2]).
 -import(bdd_utils).
 -import(json).
+-include("bdd.hrl").
 
 g(Item) ->
   case Item of
@@ -65,6 +66,7 @@ validate(JSON) ->
 step(Config, _Global, {step_setup, _N, Test}) -> 
   % setup the groups object override
   bdd_utils:config_set(alias_map,{group, group_cb}),
+  bdd_utils:config_set(api_map,{"application/vnd.crowbar+json", crowbar_rest}),
   bdd_utils:log(debug, "crowbar:step Global Setup running (creating node ~p)",[g(node_name)]),
   Node = node:json(g(node_name), Test ++ g(description), 100),
   bdd_restrat:create(Config, node:g(path), g(node_atom), name, Node),

--- a/BDD/crowbar_rest.erl
+++ b/BDD/crowbar_rest.erl
@@ -13,7 +13,7 @@
 % limitations under the License. 
 % 
 -module(crowbar_rest).
--export([step/3, g/1, validate_core/1, validate/1, api_wrapper/1, api_wrapper_raw/1, api_wrapper/2, inspector/2]).
+-export([step/3, g/1, validate_core/1, validate/1, api_wrapper/3, api_wrapper/1, api_wrapper_raw/1, api_wrapper/2, inspector/2]).
 -export([get_id/2, get_id/3, create/3, create/4, create/5, create/6, destroy/3]).
 -import(bdd_utils).
 -import(json).
@@ -38,6 +38,12 @@ validate(JSON) ->
        validate_core(JSON)],
   bdd_utils:assert(R, debug). 
 
+api_wrapper(Data, "application/vnd.crowbar+json", "1.9") -> api_wrapper_raw(Data);
+api_wrapper(Data, "application/json", "0.0")             -> #item{data=Data};
+api_wrapper(Data, Type, Version) ->
+  bdd_utils:log(warn, crowbar_rest, api_wrapper, "Fall through API type ~p version ~p",[Type, Version]),
+  Data.
+  
 api_wrapper_raw(J) ->  
   JSON = json:parse(J),
   api_wrapper(JSON).

--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -22,6 +22,9 @@ require 'active_support/core_ext/string'
 class ApplicationController < ActionController::Base
   
   
+  CB_CONTENT_TYPE19 = "application/vnd.crowbar+json; version=1.9"
+  CB_CONTENT_TYPE20 = "application/vnd.crowbar+json; version=2.0"
+  
   helper_method :is_dev?
   
   before_filter :crowbar_auth
@@ -82,7 +85,7 @@ class ApplicationController < ActionController::Base
   def api_index(type, list, link=nil)
     if params[:version].eql?('v2') 
       link ||= eval("#{type.to_s.pluralize(0)}_path")   # figure out path from type
-      return {:json=>{:list=>list, :count=>list.count, :type=>type, :link=>link}}
+      return {:json=>{:list=>list, :count=>list.count, :type=>type, :link=>link}, :content_type=>CB_CONTENT_TYPE19 }
     else
       return {:text=>I18n.t('api.wrong_version', :version=>params[:version])}
     end
@@ -98,7 +101,7 @@ class ApplicationController < ActionController::Base
       link ||= "#{eval("#{type.to_s.pluralize(0)}_path")}/#{key}"   # figure out path from type
       o ||= type_class.find_key key
       if o
-        return {:json=>{:item=>o, :type=>type, :link=>link}}
+        return {:json=>{:item=>o, :type=>type, :link=>link}, :content_type=>CB_CONTENT_TYPE19}
       else
         return {:text=>I18n.t('api.not_found', :id=>key, :type=>type.to_s), :status => :not_found}
       end


### PR DESCRIPTION
This is an intermediate pull that introduces versioning into the 
response header for the v2 API path.

This will allow BDD to do a better job dealing w/ changes in the
API syntax.

I've started to have BDD detect the content type and version so 
that we can use it in tests.  This will take more work to fully
integrate.

 BDD/bdd.hrl                                        |    5 +++-
 BDD/bdd_restrat.erl                                |   24 ++++++++++++++++----
 BDD/crowbar.erl                                    |    2 ++
 BDD/crowbar_rest.erl                               |    8 ++++++-
 BDD/simple_auth.erl                                |   13 +++++++++--
 .../app/controllers/application_controller.rb      |    7 ++++--
 6 files changed, 49 insertions(+), 10 deletions(-)

Crowbar-Pull-ID: b360f70bed53264d37cda69c5f946406e92e65be

Crowbar-Release: development
