### PR TITLE
add opensuse-12.2 to os_support

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -30,6 +30,7 @@ barclamp:
     - ubuntu-12.04
     - redhat-6.2
     - centos-6.2
+    - opensuse-12.2
 
 crowbar:
   layout: 2.0


### PR DESCRIPTION
os_support is not currently used by anything (BC_OS_SUPPORT is
populated in build_lib.sh from it but never used) but if it ever
gets used for anything, opensuse-12.2 should be in there.
