### PR TITLE
ignore crowbar_framework/coverage/

### DIFF
--- a/crowbar_framework/.gitignore
+++ b/crowbar_framework/.gitignore
@@ -10,3 +10,4 @@ public/stylesheets/*.css
 .beam
 vendor/cache
 *.swp
+coverage/


### PR DESCRIPTION
This is useful for the flattened crowbar-travis_ci repository.
