### PR TITLE
Don't pollute the global gem cache with gems for the crowbar framework [1/2]

### DIFF
--- a/setup/01-crowbar-rake-tasks.install
+++ b/setup/01-crowbar-rake-tasks.install
@@ -48,7 +48,7 @@ chmod 0700 /var/run/crowbar
 
 # Fix up /etc/environment
 if ! grep -q '/opt/dell/bin' /etc/environment; then
-    export PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/opt/dell/bin"
+    export PATH="$PATH:/opt/dell/bin"
     sed -i -e "/^PATH/ s@\"\(.*\)\"@\"$PATH\"@" /etc/environment 
 fi
 


### PR DESCRIPTION
This pull requests does two things:
- Install crowbar framework gems with bundle install --path vendor/bundle instead of just using bundle install.  This keeps bundler inadvertently interfering with external commands that might use different versions of the gems the framework requires.
- Fix up /etc/environment handling to not mangle the path quite as much.  Since we no longer have duplicate knife and chef-client commands lying around, we no longer need to mess with $PATH in an attempt to make sure the right one gets used.
  
  setup/01-crowbar-rake-tasks.install |    6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 94c0227ddb31f0e37eda928591c5b68de4dc9b4d

Crowbar-Release: development
