### PR TITLE
Change how we calculate fingerprints. [1/1]

### DIFF
--- a/BDD/features/node.feature
+++ b/BDD/features/node.feature
@@ -66,8 +66,7 @@ Feature: Nodes
 
   Scenario: Node Detail REST
     When REST gets the {object:node} "bdd1.example.com"
-    Then key "fingerprint" should be a number
-      And there should be a key "state"
+    Then there should be a key "state"
       And there should be a key "name"
       And there should be a key "description"
       And there should be a key "created_at"

--- a/BDD/node.erl
+++ b/BDD/node.erl
@@ -34,7 +34,6 @@ validate(JSON) ->
   Wrapper = crowbar_rest:api_wrapper(JSON),
   J = Wrapper#item.data,
   R =[Wrapper#item.type == node,
-      bdd_utils:is_a(J, integer, fingerprint), 
       bdd_utils:is_a(J, boolean, allocated), 
       bdd_utils:is_a(J, string, state), 
       bdd_utils:is_a(J, boolean, admin), 

--- a/crowbar_framework/app/controllers/dashboard_controller.rb
+++ b/crowbar_framework/app/controllers/dashboard_controller.rb
@@ -16,7 +16,7 @@
 class DashboardController < ApplicationController
 
   def index  
-    @sum = Node.sum(:fingerprint)
+    @sum = Node.name_hash
     @groups = Group.find_all_by_category 'ui'
     @node = Node.find_key params[:id]
     session[:node] = params[:id]

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -36,7 +36,7 @@ class NodesController < ApplicationController
     status = {}
     state = {}
     i18n = {}
-    sum = Node.sum(:fingerprint)
+    sum = Node.name_hash
     begin
       result = Node.find_keys params[:id]
       unless result.nil?

--- a/crowbar_framework/db/migrate/20120731225516_create_nodes.rb
+++ b/crowbar_framework/db/migrate/20120731225516_create_nodes.rb
@@ -19,7 +19,6 @@ class CreateNodes < ActiveRecord::Migration
       t.string      :alias, :limit => 100, :null => false
       t.string      :description, :null=>true
       t.string      :state, :null=>true
-      t.integer     :fingerprint, :default=>0
       t.integer     :order, :default=>10000
       t.boolean     :admin, :default=>false
       t.boolean     :allocated, :default=>false

--- a/crowbar_framework/test/unit/node_model_test.rb
+++ b/crowbar_framework/test/unit/node_model_test.rb
@@ -57,16 +57,6 @@ class NodeModelTest < ActiveSupport::TestCase
     assert_equal n.groups.size, 1
     assert_equal n.groups[0].id, g.id
   end
-
-  test "fingerprint" do
-    n = Node.create :name=>"fingerprint.example.com"
-    assert_not_nil n.fingerprint
-    assert_not_equal n.fingerprint, 0
-    fp = n.fingerprint
-    n.name = "hash.example.com"
-    n.save!
-    assert_not_equal n.fingerprint, fp
-  end
   
   test "Naming Conventions" do
     assert_raise(ActiveRecord::RecordInvalid, SQLite3::ConstraintException) { Node.create!(:name=>"fqdnrequired") }

--- a/doc/devguide/api/node.md
+++ b/doc/devguide/api/node.md
@@ -41,7 +41,6 @@ Details:
 
     {
       "id":4,
-      "fingerprint":-1224971211,
       "state":null,
       "name":"greg.example.com",
       "description":null,

--- a/doc/devguide/testing/bdd/dsl.md
+++ b/doc/devguide/testing/bdd/dsl.md
@@ -46,7 +46,6 @@ The following sentences can be used for testing HTML web pages where you can cha
 The following sentences can be used for testing REST JSON (aka AJAX) API calls where you can change the information in 
 
 * When REST requests the "2.0/node/status" page
-* Then key "fingerprint" should be a number
 * Then key "[nodes][admin][state]" should be "Ready"
 * Then key "count" should be "0"
 * Then key "[groups][0]" should contain "7" items


### PR DESCRIPTION
Saving the individual fingerprints for a node and then adding was
giving me intermittent integer overflows when adding up the fingerprints.

Since fingerprint is only used to force a refresh of the UI when we
add or remove a node, instead add a class method to the Node model
that returns the sha1sum of all the node names sorted in ascending
order. This achieves the same goal without worrying about how Ruby
string hash values will fit into the database or worrying about
triggering an integer overflow in the database.

 BDD/features/node.feature                          |    3 +--
 BDD/node.erl                                       |    1 -
 .../app/controllers/dashboard_controller.rb        |    2 +-
 .../app/controllers/nodes_controller.rb            |    2 +-
 crowbar_framework/app/models/node.rb               |   10 +++++-----
 .../db/migrate/20120731225516_create_nodes.rb      |    1 -
 crowbar_framework/test/unit/node_model_test.rb     |   10 ----------
 doc/devguide/api/node.md                           |    1 -
 doc/devguide/testing/bdd/dsl.md                    |    1 -
 9 files changed, 8 insertions(+), 23 deletions(-)

Crowbar-Pull-ID: 394a32993d751a1a01cd1e69f92a8757fd5d0a97

Crowbar-Release: development
