### PR TITLE
Jig delegation model start & rspec setup for shared contexts [1/1]

### DIFF
--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -287,8 +287,8 @@ class Barclamp < ActiveRecord::Base
       u.digest_password(pass)   # this is required if we want API access
       u.save!
     end
-    # Create the machine-install user.
-    unless User.find_by_username("machine-install")
+    # Create the machine-install user (but only on production deployment)
+    unless User.find_by_username("machine-install") || !Rails.env.production?
       if File.exists?('/etc/crowbar.install.key')
         user,pass = IO.read('/etc/crowbar.install.key').strip.split(':',2)
       else

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -338,6 +338,7 @@ class Node < ActiveRecord::Base
   def default_population
     self.name = self.name.downcase
     self.alias = self.name.split(".")[0]
+    # the line belowrequires a crowbar deployment to which the status attribute is tied
     self.state ||= 'unknown' 
     if self.groups.size == 0
       g = Group.find_or_create_by_name :name=>'not_set', :description=>I18n.t('not_set', :default=>'Not Set')

--- a/crowbar_framework/spec/models/jig_extending_spec.rb
+++ b/crowbar_framework/spec/models/jig_extending_spec.rb
@@ -1,0 +1,54 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: aabes
+
+require 'spec_helper'
+
+describe Jig do 
+
+  # make sure that the there's a crowbar deploment (named 'test')
+  include_context "crowbar test deployment"
+  include_context "2 dummy nodes"
+
+  let(:jig1) { double('jig1') }
+  let(:jig2) { double('jig2') }
+  let(:jigs) { [jig1, jig2] }
+  before(:each) { Jig.stub(:all) { jigs } }
+
+  def set_expectation(what,_with)
+    jigs.each { |j| j.should_receive(what).with(_with) }
+  end
+
+  it "should broadcast create to all jigs" do
+    node = Node.create :name=>"test"
+    set_expectation(:create_node,node)
+    Jig.create_node(node)
+  end
+
+  it "should broadcast delete to all jigs" do
+    node = Node.create :name=>"test"
+    set_expectation(:delete_node,node)
+    Jig.delete_node(node)
+  end
+
+  it "should broadcast refresh to all jigs" do
+    node = Node.create :name=>"test"
+    set_expectation(:refresh_node,node)
+    Jig.refresh_node(node)
+  end
+
+
+ 
+end

--- a/crowbar_framework/spec/models/jig_spec.rb
+++ b/crowbar_framework/spec/models/jig_spec.rb
@@ -40,6 +40,8 @@ end
 
 
 describe "jig proposal manipulation" do
+  # make sure that the there's a crowbar deploment (named 'test')
+  include_context "crowbar test deployment"
 
   def setup_test_barclamp_with_2_nodes
     n1 = Factory(:node)

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -13,7 +13,8 @@ require 'rspec/autorun'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
+# (see https://github.com/rspec/rspec-core/issues/25 for the reason to use expand_path)
+Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require File.expand_path(f) }
 
 RSpec.configure do |config|
   # EMAIL test helpers

--- a/crowbar_framework/spec/support/shared_contexts/base_deployement_nodes.rb
+++ b/crowbar_framework/spec/support/shared_contexts/base_deployement_nodes.rb
@@ -1,0 +1,35 @@
+# Copyright 2013, Dell 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+
+
+
+# This context establsihes a base Crowbar deployment.
+# it should be included in all tests that manipulate node attributes
+shared_context "crowbar test deployment" do
+  
+  before(:all) do
+    # we need this to ensure that we have the crowbar barclamp
+    Barclamp.import 'crowbar'
+    c = Barclamp.find_by_name('crowbar')
+    c.create_proposal :name=>'test'
+    # we also need to have the test jig
+    BarclampCrowbar::Jig.find_or_create_by_name :name=>'test'
+  end
+end  
+
+# Just 2 dummy nodes
+shared_context "2 dummy nodes" do
+  let(:node1) { Node.create :name=>"unit1.test.com" }
+  let(:node2) { Node.create :name=>"unit2.test.com" }
+end


### PR DESCRIPTION
see commit message

 crowbar_framework/app/models/barclamp.rb           |    4 +-
 crowbar_framework/app/models/jig.rb                |   49 ++++++++++++++++--
 crowbar_framework/app/models/node.rb               |    1 +
 .../spec/models/jig_extending_spec.rb              |   54 ++++++++++++++++++++
 crowbar_framework/spec/models/jig_spec.rb          |   19 +++++++
 crowbar_framework/spec/spec_helper.rb              |    3 +-
 .../shared_contexts/base_deployement_nodes.rb      |   35 +++++++++++++
 7 files changed, 159 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: ec41a8fec45f192dbea2f0ee61264b87a926486f

Crowbar-Release: development
