### PR TITLE
fix BDD tests around node create [1/1]

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -72,7 +72,7 @@ class NodesController < ApplicationController
 
   # RESTful DELETE of the node resource
   def destroy
-    n = find_ndoe(params)    
+    n = find_node(params)    
     run_in_prod_only do
       system("knife node delete -y #{node.name}")
       system("knife client delete -y #{node.name}")
@@ -233,7 +233,7 @@ Find a node by name or ID based on the passed in params
 in: params from request
 =end
 
-  def find_ndoe(params)
+  def find_node(params)
     if p= params[:name]
       return Node.find_by_name p
     end


### PR DESCRIPTION
BDD tests were breaking around create/destroy node bacause of running wiht Jig's.
Currently, interactions with chef have been restricted to production env.

 .../app/controllers/nodes_controller.rb            |   40 +++++++++++++++++---
 1 file changed, 34 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: 8af6288a13aa3784784eec70f69744be75cd232e

Crowbar-Release: development
