### PR TITLE
Allow admin node to survive a reboot. [1/2]

### DIFF
--- a/etc/init.d/crowbar
+++ b/etc/init.d/crowbar
@@ -19,6 +19,8 @@ for f in /var/lib/gems/*/bin; do
 done
 BLUEPILL_CONFIG="/opt/dell/crowbar_framework/crowbar.pill"
 
+mkdir -p /var/run/crowbar && chown crowbar:crowbar /var/run/crowbar
+
 case "$1" in
     start)
         echo -n "Starting Crowbar webserver"


### PR DESCRIPTION
This fixes the crowbar init script to always create a space for pids
(needed because /var/run does not persist across a reboot, and we no
longer create it as part of a chef-client run), and add a simple init
script for chef-server when using the omniinstalled version.

 etc/init.d/crowbar |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: 279d7e169c8dd7614657c2cc6fa005ae23c18769

Crowbar-Release: development
