### PR TITLE
remove ancient Rails 2.x 'config.gem' directives

### DIFF
--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -62,18 +62,6 @@ module Crowbar
     # Add additional load paths for your own custom dirs
     # config.load_paths += %W( #{RAILS_ROOT}/extras )
   
-    # Specify gems that this application depends on and have them installed with rake gems:install
-    # config.gem "bj"
-    # config.gem "hpricot", :version => '0.6', :source => "http://code.whytheluckystiff.net"
-    # config.gem "sqlite3-ruby", :lib => "sqlite3"
-    # config.gem "aws-s3", :lib => "aws/s3"
-    
-    config.gem "haml"
-    config.gem "sass"
-    config.gem "simple-navigation"
-    config.gem "i18n"
-    config.gem "json"
-    
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]


### PR DESCRIPTION
Tests still seem to pass OK after doing this.
