### PR TITLE
Final Travis fix in network barclamp [1/2]

### DIFF
--- a/crowbar_framework/test/network_test_helper.rb
+++ b/crowbar_framework/test/network_test_helper.rb
@@ -165,15 +165,18 @@ class NetworkTestHelper
 
 
   def self.create_a_barclamp()
-    barclamp = BarclampNetwork::Barclamp.new(:name => "default")
-    barclamp.save!
+    barclamp = BarclampNetwork::Barclamp.find_key(BarclampNetwork::Barclamp::BARCLAMP_NAME)
+    if barclamp.nil?
+      barclamp = BarclampNetwork::Barclamp.new(:name => BarclampNetwork::Barclamp::BARCLAMP_NAME)
+      barclamp.save!
 
-    snapshot = Snapshot.new()
-    snapshot.barclamp = barclamp
-    snapshot.save!
+      snapshot = Snapshot.new()
+      snapshot.barclamp = barclamp
+      snapshot.save!
 
-    barclamp.template = snapshot
-    barclamp.save!
+      barclamp.template = snapshot
+      barclamp.save!
+    end
     barclamp
   end
 end


### PR DESCRIPTION
This pull contains a fix for the final nagging Travis issue in the network barclamp.
The creation of the network barclamp is now conditional in the unit tests.
The name of the network barclamp is changed from "default" to "network" as it should be.

 crowbar_framework/test/network_test_helper.rb |   17 ++++++++++-------
 1 file changed, 10 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: b9a7a2c1b452c95169ed23db7d379806d41d7c8c

Crowbar-Release: development
