### PR TITLE
Create default network barclamp deployment in DB migration [1/2]

### DIFF
--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -165,6 +165,9 @@ class Barclamp < ActiveRecord::Base
   
   # Create deployment creates the bones of the proposal, but not the nodes
   # create proposal can be overridden to put things in nodes
+  #
+  # Note that passing a deployment_name of nil will cause default the
+  # deployment name to I18n.t('default') if a new deployment is created.
   def create_deployment(deployment=nil)
     deployment = {:name=>deployment} if deployment.is_a? String
     deployment ||= { :name => DEFAULT_DEPLOYMENT_NAME}


### PR DESCRIPTION
This pull causes the default network deployment to be created in a DB migration.
This will allow running the network BDD tests in the dev test environment.

 crowbar_framework/app/models/barclamp.rb |   11 +++++++++++
 1 file changed, 11 insertions(+)

Crowbar-Pull-ID: 4a0d2c563f8ca91a70eca8e7b66271115a07cd8c

Crowbar-Release: development
