### PR TITLE
Fix failing unit tests

### DIFF
--- a/crowbar_framework/test/unit/attrib_has_deployment_test.rb
+++ b/crowbar_framework/test/unit/attrib_has_deployment_test.rb
@@ -62,9 +62,9 @@ class AttribHasDeploymentTest < ActiveSupport::TestCase
   
   test "deployment is created if missing" do
     t = Barclamp.find_by_name 'test'
-    assert 0, t.deployments 
+    assert_equal 0, t.deployments.size
     attrib = @role.require_deployment 'test', 'foo'
-    assert 1, t.deployments
+    assert_equal 1, t.deployments.size
     assert_equal 'foo', t.deployments.first.name
   end
 
@@ -72,9 +72,9 @@ class AttribHasDeploymentTest < ActiveSupport::TestCase
     t = Barclamp.find_by_name 'test'
     t.allow_multiple_deployments = false
     t.create_deployment 'bar'
-    assert 1, t.deployments 
+    assert_equal 1, t.deployments.size
     attrib = @role.require_deployment 'test'
-    assert 1, t.deployments(true)
+    assert_equal 1, t.deployments(true).size
     assert_equal Barclamp::DEFAULT_DEPLOYMENT_NAME, attrib.deployment.name
   end
 
@@ -82,18 +82,18 @@ class AttribHasDeploymentTest < ActiveSupport::TestCase
     t = Barclamp.find_by_name 'test'
     t.allow_multiple_deployments = true
     t.create_deployment
-    assert 1, t.deployments 
+    assert_equal 1, t.deployments.size
     attrib = @role.require_deployment 'test', 'bar'
-    assert 2, t.deployments(true)
+    assert_equal 2, t.deployments(true).size
     assert_equal 'bar', attrib.deployment.name
   end
   
   test "deployment finds match if given" do
     t = Barclamp.find_by_name 'test'
     t.create_deployment 'bar'
-    assert 1, t.deployments 
+    assert_equal 1, t.deployments.size
     attrib = @role.require_deployment 'test', 'bar'
-    assert 1, t.deployments
+    assert_equal 1, t.deployments.size
     assert_equal 'bar', attrib.deployment.name
   end
 


### PR DESCRIPTION
Fixes the following unit test failures on Ruby 1.9.3:

```
 1) Error:
    test_deployment_creates_new_if_none_given_and_multiple_allowed(AttribHasDeploymentTest):
    ArgumentError: assertion message must be String or Proc, but Array was given.
    /home/travis/build/crowbar/travis-ci-crowbar/crowbar_framework/test/unit/attrib_has_deployment_test.rb:85:in `block in <class:AttribHasDeploymentTest>'

 2) Error:
    test_deployment_finds_first_if_none_given_and_only_1_allowed(AttribHasDeploymentTest):
    ArgumentError: assertion message must be String or Proc, but Array was given.
    /home/travis/build/crowbar/travis-ci-crowbar/crowbar_framework/test/unit/attrib_has_deployment_test.rb:75:in `block in <class:AttribHasDeploymentTest>'

 3) Error:
    test_deployment_finds_match_if_given(AttribHasDeploymentTest):
    ArgumentError: assertion message must be String or Proc, but Array was given.
    /home/travis/build/crowbar/travis-ci-crowbar/crowbar_framework/test/unit/attrib_has_deployment_test.rb:94:in `block in <class:AttribHasDeploymentTest>'

 4) Error:
    test_deployment_is_created_if_missing(AttribHasDeploymentTest):
    ArgumentError: assertion message must be String or Proc, but Array was given.
    /home/travis/build/crowbar/travis-ci-crowbar/crowbar_framework/test/unit/attrib_has_deployment_test.rb:65:in `block in <class:AttribHasDeploymentTest>'
```

Which then in turns reveals the following actual failing tests:

```
  1) Failure:
     test_deployment_finds_first_if_none_given_and_only_1_allowed(AttribHasDeploymentTest) [/tmp/crowbar-dev-test/opt/dell/crowbar_framework/test/unit/attrib_has_deployment_test.rb:77]:
     <1> expected but was
     <2>.

  2) Failure:
     test_deployment_is_created_if_missing(AttribHasDeploymentTest) [/tmp/crowbar-dev-test/opt/dell/crowbar_framework/test/unit/attrib_has_deployment_test.rb:67]:
     <1> expected but was
     <0>.
```

https://travis-ci.org/crowbar/travis-ci-crowbar/jobs/5495043
