### PR TITLE
Make creating Chef objects via the API actually function. [1/2]

### DIFF
--- a/crowbar_framework/app/models/jig.rb
+++ b/crowbar_framework/app/models/jig.rb
@@ -259,11 +259,13 @@ private
 =end
   def self.broadcast_to_jigs(desc="no description")
     raise "no block given" unless block_given?
-    Jig.all.each { |x|  
-      begin        
+    Jig.all.each { |x|
+      begin
         yield x
       rescue => exc
         Rails.logger.warn("failed to invoke #{desc} on jig: #{x.inspect}")
+        Rails.logger.warn("Exception: #{exc.inspect}")
+        Rails.logger.warn("Backtrace: #{exc.backtrace}")
       end
     }
   end


### PR DESCRIPTION
This pull request allows the Chef jig to create the Chef node, client,
and node role objects directly instead of needing to issue knife
commands.

Along the way, it also simplifies how some of the chef jig stuff is
handled, and enforces that There Shall Only Be One instance of the
chef jig object on the system at any given time.  We do this because
we have to do evil hacks to the Chef::REST class to inject our auth
information, and we may as well not give anyone the illusion that we
can talk to more than one chef server.

 crowbar_framework/app/models/jig.rb |    6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 359f04772f934645f40b525b894c9854c7e58320

Crowbar-Release: development
