### PR TITLE
Zap run_in_prod. [1/1]

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -15,10 +15,8 @@
 
 class Node < ActiveRecord::Base
   before_validation :default_population
-  before_destroy    :jig_delete
-  
   attr_accessible :name, :description, :alias, :order, :admin, :allocated
-  
+
   # Make sure we have names that are legal
   # old:
   #  FQDN_RE = /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9]))*\.([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])*\.([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/
@@ -329,11 +327,6 @@ class Node < ActiveRecord::Base
   end
 
   private
-
-  # make sure we do housekeeping before we remove the DB object
-  def jig_delete
-    Jig.delete_node self
-  end
 
   # make sure some safe values are set for the node
   def default_population


### PR DESCRIPTION
We only create the Chef jig via the Rake task to inject chef
connection information, and we force the BarclampChef::Jig class to be
a singleton and refuse to create its instance if the server info is
not populated in the database.

Because of that, we no longer need to guard against doing chef jig
stuff in the unit test environment.

 .../app/controllers/nodes_controller.rb            |   27 +++++---------------
 crowbar_framework/app/models/node.rb               |    9 +------
 2 files changed, 8 insertions(+), 28 deletions(-)

Crowbar-Pull-ID: 8c27aa9750f06dbcc92cbe2885def90fa64997a7

Crowbar-Release: development
