### PR TITLE
Make docs rebuilding configurable

### DIFF
--- a/crowbar_framework/app/controllers/docs_controller.rb
+++ b/crowbar_framework/app/controllers/docs_controller.rb
@@ -22,7 +22,7 @@ class DocsController < ApplicationController
   def index
     @id = params[:id].gsub("%2B",'+') rescue nil
     @root = Doc.find_by_name(@id || 'root')
-    if @root.nil? or Rails.env.development? or params.has_key? :rebuild
+    if @root.nil? or Settings.docs.rebuild or params.has_key?(:rebuild)
       # for dev, we want to be able to turn off rebuilds
       unless params[:rebuild].eql? "false"
         Doc.delete_all

--- a/crowbar_framework/config/settings.yml
+++ b/crowbar_framework/config/settings.yml
@@ -5,4 +5,5 @@
 # See https://github.com/railsjedi/rails_config#readme for details.
 
 docs:
-  debug: true
+  debug:   true
+  rebuild: true

--- a/crowbar_framework/config/settings/production.yml
+++ b/crowbar_framework/config/settings/production.yml
@@ -1,2 +1,3 @@
 docs:
-  debug: false
+  debug:   false
+  rebuild: false


### PR DESCRIPTION
The docs are hardcoded to rebuild when in development mode, unless the
`rebuild` parameter is passed in. This makes it very slow (>10s) when
working on it, so let's just make it configurable.

Rebuild still on by default when in development mode, and off in
production to maintain the same behavior. But it can now be easily
configured locally in `config/settings.local.yml`.

(This was requested by Ken).
