### PR TITLE
Hide PFS fields based on "use git" choice AND hide import barclamps [2/2]

### DIFF
--- a/crowbar_framework/config/navigation.rb
+++ b/crowbar_framework/config/navigation.rb
@@ -16,7 +16,7 @@ SimpleNavigation::Configuration.run do |navigation|
       # insert here for :add  (this is legacy support)
     end
     primary.item :utils, t('nav.utils'), utils_path do |secondary| 
-      secondary.item :util_import, t('nav.util_import'), utils_import_path 
+      secondary.item :util_import, t('nav.util_import'), utils_import_path if RAILS_ENV == 'development'
       secondary.item :util_index, t('nav.util_logs'), utils_path 
       # insert here for :utils
     end


### PR DESCRIPTION
This small change hides fields for PFS unless the user is turning on that feature.
Since all the PFS barclamp features uses the same partial, this is a minor update that
will impact the UI on all the OpenStack PFS barclamps.

Also, moved the "barclamp import" screen under the dev mode flag because we 
are not testing it and should not expose it in the production UI.

 crowbar_framework/config/navigation.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 2138b0d6d078e6323b3a5dfd217c69f70bb00421

Crowbar-Release: pebbles
