### PR TITLE
Add seed data

### DIFF
--- a/crowbar_framework/db/seeds.rb
+++ b/crowbar_framework/db/seeds.rb
@@ -1,7 +1,59 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+
+include ActiveSupport::Benchmarkable
+
+def logger
+  @logger ||= Logger.new(STDOUT)
+end
+
+# ----------------------------
+# Create groups
+# ----------------------------
+
+benchmark('Group.delete_all') do
+  Group.delete_all
+end
+
+benchmark('Create groups') do
+  @rack01 = Group.create!(:name => 'Rack01',     :description => 'First rack')
+  @rack02 = Group.create!(:name => 'Rack02',     :description => 'Second rack')
+  @prod   = Group.create!(:name => 'Production', :description => 'Production servers')
+end
+
+# ----------------------------
+# Create nodes
+# ----------------------------
+
+benchmark('Node.delete_all') do
+  Node.delete_all
+end
+
+benchmark('Create nodes') do
+  for i in 1..2 do
+    node = Node.create!(
+      :name        => "node%02d.crowbar.com" % i,
+      :description => "Load balancer #%d" % i
+    )
+    node.groups << @rack01
+    node.groups << @prod
+  end
+
+  for i in 1..3 do
+    node = Node.create!(
+      :name        => "node%02d.crowbar.com" % (i+2),
+      :description => "Database server #%d" % i
+    )
+    node.groups << @rack01
+    node.groups << @prod
+  end
+
+  for i in 1..5 do
+    node = Node.create!(
+      :name        => "node%02d.crowbar.com" % (i+5),
+      :description => "Application server #%d" % i,
+    )
+    node.groups << @rack02
+    node.groups << @prod
+  end
+end


### PR DESCRIPTION
These seed data are useful during development, especially when working
with the UI and you don't want to deal with the overhead/hassle of
setting up actual nodes to manage.

Load them into your development instance by running:

```
cd /tmp/crowbar-dev-test/opt/dell/crowbar_framework 
rake db:seed
```

**WARNING**: This drops all existing rows in the `groups` and `nodes` tables.

You should then see something like [this screenshot](http://imagebin.org/index.php?mode=image&id=254394).
