### PR TITLE
Mark a node as not allocated on discovering

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -44,6 +44,12 @@ class CrowbarService < ServiceObject
       node.crowbar["crowbar"] = {} if node.crowbar["crowbar"].nil?
       node.crowbar["crowbar"]["network"] = {} if node.crowbar["crowbar"]["network"].nil?
 
+      if state == "discovering" and node.allocated.nil?
+        @logger.debug("Crowbar transition: marking #{name} as initially not allocated")
+        node.allocated = false
+        save_it = true
+      end
+
       pop_it = false
       if (state == "hardware-installing" or state == "hardware-updating" or state == "update") 
         @logger.debug("Crowbar transition: force run because of state #{name} to #{state}")


### PR DESCRIPTION
To avoid a race on the sledgehammer (where a node can be discovered, but
not yet marked as not allocated), do that as early as possible.

The code in the deployer barclamp to auto-allocate (if use_allocate is
set to false) will still work fine.
