### PR TITLE
Blacklist problematic proposal names. [1/1]

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -23,6 +23,7 @@ require 'json'
 
 class ServiceObject
 
+  FORBIDDEN_PROPOSAL_NAMES=["template","nodes","commit","status"]
   extend CrowbarOffline
 
   def initialize(thelogger)
@@ -610,6 +611,9 @@ class ServiceObject
   def proposal_create(params)
     base_id = params["id"]
     params["id"] = "bc-#{@bc_name}-#{params["id"]}"
+    if FORBIDDEN_PROPOSAL_NAMES.any?{|n| n == base_id}
+      return [403,I18n.t('model.service.illegal_name', :name => base_id)]
+    end
 
     prop = ProposalObject.find_proposal(@bc_name, base_id)
     return [400, I18n.t('model.service.name_exists')] unless prop.nil?

--- a/crowbar_framework/config/locales/en.yml
+++ b/crowbar_framework/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
       name_exists: Name already exists. Please choose another.
       too_short: Invalid name.  Name must have some characters.
       illegal_chars: Invalid service name '%{name}'.  Please limit name to [A-z0-9_] without spaces.
+      illegal_name: Illegal proposal name '%{name}'.  Please choose another proposal name.
       already_commit: Proposal already being applied.
       cannot_find: Failed to find proposal
       template_missing: Failed to load proposal template for barclamp '%{name}'.


### PR DESCRIPTION
Due to historical names of routes and internal Crowbar machinery,
there are some proposal names that will cause issues if they are ever
used. To make sure this does not cause a problem in the field, the
following proposal names are blacklisted:
- template
- nodes
- commit
- status
  
  crowbar_framework/app/models/service_object.rb |    4 ++++
  crowbar_framework/config/locales/en.yml        |    1 +
  2 files changed, 5 insertions(+)

Crowbar-Pull-ID: 2e712163e823a042b8837c1a742ffcf55bca4d5c

Crowbar-Release: pebbles
