### PR TITLE
Rework how we allocate disks to barclamps. Will close DE1120 and DE1162. [8/8]

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -339,11 +339,13 @@ class NodeObject < ChefObject
   end
 
   def number_of_drives
-    self.crowbar['crowbar']['disks'].length rescue -1
+    @node[:block_device].find_all do |disk,data|
+      disk =~ /^[hsv]d/ && data[:removable] == "0"
+    end.length
   end
-  
+
   def physical_drives
-    self.crowbar['crowbar']['disks'].length rescue -1
+    number_of_drives
   end
   
   def [](attrib)


### PR DESCRIPTION
For many releases, Crowbar has built node[:crowbar][:disks] at node
discovery time, and the Chef cookbooks have used what is in that array
to determine what drives they can use.  This scheme has a few
shortcomings:

 1 The code always assumed that /dev/sda was going to be the boot
    device.
 2 The list was built at discovery time, and so it was blind to any
    changes in the disk topology that would happen when the raid
    barclamp did its thing
 3 The only choices for a disk role were OS and Storage, leading to
    all sorts of fun when multiple roles wanted to grab a physical
    disk or twenty to get all Big Data.

To fix the above shortcomings, I have replaced node[:crowbar][:disks]
with a set of methods on the
BarclampInventory::Barclamp::Inventory::Disk class (and its objects)
that let you:

 1 Get a list of all unclaimed fixed nonremovable disks on a node.
 2 Get a list of all disks that have been claimed by a barclamp on a
    node.
 3 Claim a disk for a barclamp.
 4 Release a claim for a disk.

To make sure that the claims for a disk stay relatively sane, there
are some restrictions on when you can claim a disk:

 1 You cannot claim a disk before the RAID barclamp has finished
    making any changes it is going to make to a system.
 2 You can only make and release claims to a disk on the node that
    has the disk.  In practice, this means that the only place you can
    claim a disk is in a recipe running on the node that has the disks
    to be claimed or released.

How it is implemented:

All claims to a disk are tracked on
node[:crowbar_wall][:claimed_disks][disk.unique_name]
disk.unique_name is a method that looks up as unique a name as
possible for the disk, making the claim and release machinery as
insensitive to the vagaries of device naming as you can reasonably get
on a modern Linux system.

 crowbar_framework/app/models/node_object.rb |    8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: af9a80a504bf66b9f098a6eb589cb881facd40d3

Crowbar-Release: pebbles
