### PR TITLE
Rework how we allocate disks to barclamps. Will close DE1120 and DE1162. [8/8]

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -339,11 +339,15 @@ class NodeObject < ChefObject
   end
 
   def number_of_drives
-    self.crowbar['crowbar']['disks'].length rescue -1
+    # This needs to be kept in sync with the fixed method in
+    # barclamp_library.rb in in the deployer barclamp.
+    @node[:block_device].find_all do |disk,data|
+      disk =~ /^[hsv]d/ && data[:removable] == "0"
+    end.length
   end
-  
+
   def physical_drives
-    self.crowbar['crowbar']['disks'].length rescue -1
+    number_of_drives
   end
   
   def [](attrib)


### PR DESCRIPTION
For many releases, Crowbar has built node[:crowbar][:disks] at node
discovery time, and the Chef cookbooks have used what is in that array
to determine what drives they can use. This scheme has a few
shortcomings:
1. The code always assumed that /dev/sda was going to be the boot
   device.
2. The list was built at discovery time, and so it was blind to any
   changes in the disk topology that would happen when the raid
   barclamp did its thing
3. The only choices for a disk role were OS and Storage, leading to
   all sorts of fun when multiple roles wanted to grab a physical
   disk or twenty to get all Big Data.

To fix the above shortcomings, I have replaced node[:crowbar][:disks]
with a set of methods on the
BarclampInventory::Barclamp::Inventory::Disk class (and its objects)
that let you:
1. Get a list of all unclaimed fixed nonremovable disks on a node.
2. Get a list of all disks that have been claimed by a barclamp on a
   node.
3. Claim a disk for a barclamp.
4. Release a claim for a disk.

To make sure that the claims for a disk stay relatively sane, there
are some restrictions on when you can claim a disk:
1. You cannot claim a disk before the RAID barclamp has finished
   making any changes it is going to make to a system.
2. You can only make and release claims to a disk on the node that
   has the disk. In practice, this means that the only place you can
   claim a disk is in a recipe running on the node that has the disks
   to be claimed or released.

How it is implemented:

All claims to a disk are tracked on
node[:crowbar_wall][:claimed_disks][disk.unique_name]
disk.unique_name is a method that looks up as unique a name as
possible for the disk, making the claim and release machinery as
insensitive to the vagaries of device naming as you can reasonably get
on a modern Linux system.

Related changes made in this patch series:
- Killed off the UI code in the Cinder barclamp that attempted to let you assign specific
  disks to a role.  Since we were using raw device names that were
  prone to change over the node discovery process, and that we do
  not know what the boot device will be until after the node is
  allocated and we set up RAID (if applicable) on the system, the
  device names that the UI was presenting would only be accurate
  after the node was up and transitioned into a ready state.  The UI
  now only allows the local (which maps to a loopback-mounted Large
  File that has been turned into a PV for Cinder's VG), first (which
  picks the first unclaimed raw device), and all (which grabs all
  unclaimed raw devices).
- Killed nova-volume entirely.  It would have required the same
  changes that Cinder required.
  
  crowbar_framework/app/models/node_object.rb |   10 +++++++---
  1 file changed, 7 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: b33d4f791a3432f0d3d2d4ea58a1c80f9ce6c95e

Crowbar-Release: pebbles
