### PR TITLE
Add render_instance_selector helper to render instance selector

### DIFF
--- a/crowbar_framework/app/helpers/application_helper.rb
+++ b/crowbar_framework/app/helpers/application_helper.rb
@@ -112,7 +112,7 @@ module ApplicationHelper
     nodes
   end
   
-  def instance_selector(bc, name, field, proposal)
+  def instance_selector_get_select_tag(bc, name, field, proposal)
     service = eval("#{bc.camelize}Service.new nil")
     options = service.list_active[1] | service.proposals[1]
     if options.empty?
@@ -129,6 +129,17 @@ module ApplicationHelper
     end
 
     select_tag name, options_for_select(options, def_val), :onchange => "update_value(\'#{field}\', \'#{name}\', 'string')"
+  end
+
+  def render_instance_selector(bc, name, label, field, proposal)
+    return if not Kernel.const_get("#{bc.camelize}Service").method(:allow_multiple_proposals?).call
+    select_tag = instance_selector_get_select_tag(bc, name, field, proposal)
+    render :partial => "barclamp/instance_selector", :locals => { :field => field, :label => label, :select_tag => select_tag }
+  end
+
+  def instance_selector(bc, name, field, proposal)
+    Chef::Log.error("instance_selector method is deprecated! Please update your code to use render_instance_selector.")
+    instance_selector_get_select_tag(bc, name, field, proposal)
   end
 
 end

--- a/crowbar_framework/app/views/barclamp/_instance_selector.html.haml
+++ b/crowbar_framework/app/views/barclamp/_instance_selector.html.haml
@@ -1,0 +1,3 @@
+%p
+  %label{ :for => field }= label
+  = select_tag


### PR DESCRIPTION
It works like the instance selectors in templates, except that it also
checks if multiple proposals are allowed for a barclamp, and doesn't
show anything if this is not the case.

This will make it easy to change, temporarily or not, the
allow_multiple_proposals of barclamps. And this avoids repeating these
three template lines several times in each barclamp template.
