### PR TITLE
Sort commands in help out.

### DIFF
--- a/bin/barclamp_lib.rb
+++ b/bin/barclamp_lib.rb
@@ -94,7 +94,7 @@ def usage (rc)
   @options.each do |options|
     puts "  #{options[1]}"
   end
-  print_commands(@commands)
+  print_commands(@commands.sort)
   exit rc
 end
 


### PR DESCRIPTION
Otherwise randomized due to Ruby hash key insertion order.
