### PR TITLE
Change button labels back to Delete and Reset instead of Forget and Deallocate [1/1]

### DIFF
--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -61,5 +61,5 @@
     %li= link_to "Hardware Update", hit_node_path(@node.handle, 'update'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_hw_update'), :title => t('.hw_update_tooltip')
     %li= link_to "Reinstall", hit_node_path(@node.handle, 'reinstall'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_reinstall'), :title => t('.reinstall_tooltip')
     - if @node.allocated?
-      %li= link_to "Deallocate", hit_node_path(@node.handle, 'reset'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_deallocate'), :title => t('.deallocate_tooltip')
-    %li= link_to "Forget", hit_node_path(@node.handle, 'delete'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_forget'), :title => t('.forget_tooltip')
+      %li= link_to "Reset", hit_node_path(@node.handle, 'reset'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure'), :title => t('.reset_tooltip')
+    %li= link_to "Delete", hit_node_path(@node.handle, 'delete'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure'), :title => t('.delete_tooltip')

--- a/crowbar_framework/config/locales/en.yml
+++ b/crowbar_framework/config/locales/en.yml
@@ -215,8 +215,8 @@ en:
       confirm_forget: This will remove all records of the node from the Crowbar / Chef database.  It will be rediscovered if it reboots.  Proceed?
       hw_update_tooltip: Reboot the node in order to apply BIOS/RAID updates
       reinstall_tooltip: Rebuild the node to a pristine state using its current deployment profile
-      deallocate_tooltip: Remove the current allocation from the node
-      forget_tooltip: Remove all records of the node from the Crowbar / Chef database
+      delete_tooltip: Delete node from Crowbar
+      reset_tooltip: Reset node for reallocation
     form:
       allocate: Allocate
       save: Save


### PR DESCRIPTION
 crowbar_framework/app/views/nodes/_show.html.haml |    4 ++--
 crowbar_framework/config/locales/en.yml           |    4 ++--
 2 files changed, 4 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 85d956b386262457c81dc4dc26d6fde18c5a59cf

Crowbar-Release: hadoop-2.3
