### PR TITLE
Fix broken handling of proposal queue for already queued proposals

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -262,17 +262,12 @@ class ServiceObject
         db = ProposalObject.new new_queue
       end
 
+      preexisting_queued_item = nil
       db["proposal_queue"].each do |item|
         # Am I already in the queue
         if item["barclamp"] == bc and item["inst"] == inst
-          nodes = []
-          elements.each do |elem, inodes|
-            inodes.each do |node|
-              nodes << node unless nodes.include?(node)
-            end
-          end
-          @logger.debug("queue proposal: exit #{inst} #{bc}: already queued")
-          return [nodes, {}]
+          preexisting_queued_item = item
+          break
         end
       end
 
@@ -293,9 +288,26 @@ class ServiceObject
       end
 
       delay, pre_cached_nodes = add_pending_elements(bc, inst, elements, queue_me)
-      return [ delay, pre_cached_nodes ] if delay.empty?
+      if delay.empty?
+        # remove from queue if it was queued before; might not be in the queue
+        # because the proposal got changed since it got added to the queue
+        unless preexisting_queued_item.nil?
+          @logger.debug("queue proposal: dequeuing already queued #{inst} #{bc}")
+          dequeued = dequeue_proposal_no_lock(db["proposal_queue"], inst, bc)
+          db.save if dequeued
+        end
 
-      db["proposal_queue"] << { "barclamp" => bc, "inst" => inst, "elements" => elements, "deps" => deps }
+        return [ delay, pre_cached_nodes ]
+      end
+
+      if preexisting_queued_item.nil?
+        db["proposal_queue"] << { "barclamp" => bc, "inst" => inst, "elements" => elements, "deps" => deps }
+      else
+        # update item that is already in queue
+        preexisting_queued_item["elements"] = elements
+        preexisting_queued_item["deps"] = deps
+      end
+
       db.save
     rescue Exception => e
       @logger.error("Error queuing proposal for #{bc}:#{inst}: #{e.message}")


### PR DESCRIPTION
The assumption that a proposal that was already queued should stay
queued is fundamentally broken: the proposal might have been updated,
leading to a situation where it doesn't need to be queued anymore.

Instead of assuming wrong, we always check if a proposal should go in
the queue. If the item was not already queued, we keep the same
behavior. If it was already queued, then:
- if it doesn't need to go in the queue, we remove it from the queue
- if it does need to go in the queue, we update the item in the queue
  with up-to-date status.

This fixes an issue where everything can be blocked forever because a
proposal is stuck as queued forever.
