### PR TITLE
Use :install and not :upgrade for installing packages

### DIFF
--- a/chef/cookbooks/nscd/recipes/default.rb
+++ b/chef/cookbooks/nscd/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 package "nscd" do
-  action :upgrade
+  action :install
 end
 
 service "nscd" do

--- a/chef/cookbooks/openldap/recipes/auth.rb
+++ b/chef/cookbooks/openldap/recipes/auth.rb
@@ -22,11 +22,11 @@ include_recipe "openssh"
 include_recipe "nscd"
 
 package "libnss-ldap" do
-  action :upgrade
+  action :install
 end
 
 package "libpam-ldap" do
-  action :upgrade
+  action :install
 end
 
 template "/etc/ldap.conf" do

--- a/chef/cookbooks/openldap/recipes/client.rb
+++ b/chef/cookbooks/openldap/recipes/client.rb
@@ -18,7 +18,7 @@
 #
 
 package "ldap-utils" do
-  action :upgrade
+  action :install
 end
 
 directory node[:openldap][:ssl_dir] do

--- a/chef/cookbooks/openldap/recipes/server.rb
+++ b/chef/cookbooks/openldap/recipes/server.rb
@@ -22,11 +22,11 @@ case node[:platform]
 when "ubuntu"
   if (node[:platform_version].to_f >= 10.04)
     package "db4.8-util" do
-      action :upgrade
+      action :install
     end
   else
     package "db4.2-util" do
-      action :upgrade
+      action :install
     end
   end
   cookbook_file "/var/cache/local/preseeding/slapd.seed" do
@@ -37,14 +37,14 @@ when "ubuntu"
   end
   package "slapd" do
     response_file "slapd.seed"
-    action :upgrade
+    action :install
   end
 else
   package "db4.2-util" do
-    action :upgrade
+    action :install
   end
   package "slapd" do
-    action :upgrade
+    action :install
   end
 end
 

--- a/chef/cookbooks/sudo/recipes/default.rb
+++ b/chef/cookbooks/sudo/recipes/default.rb
@@ -18,7 +18,7 @@
 #
 
 package "sudo" do
-  action :upgrade
+  action :install
 end
 
 template "/etc/sudoers" do


### PR DESCRIPTION
As agreed during a community call, we want to use :install to allow
upgrades being controlled instead of automatically installed.
