### PR TITLE
Use default as name for proposals of barclamps with a unique proposal

### DIFF
--- a/crowbar_framework/app/views/barclamp/_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/_index.html.haml
@@ -25,7 +25,8 @@
           - if barclamp[:proposals].length == 0
             - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
               = hidden_field_tag :barclamp, name
-              = hidden_field_tag :name, t('proposal.items.default')
+              -# Hard-coding "default" as name for unique proposals: it's the same name used for proposals during crowbar install process
+              = hidden_field_tag :name, "default"
               = hidden_field_tag :description, "#{t 'created_on'} #{l(Time.now) }"
               %input.button{:type => "submit", :value => t('proposal.actions.create')}
           - else


### PR DESCRIPTION
While the name here is not localized anymore, the rationale is that this
is the same name as used during the install process for core crowbar
barclamps. This makes things more consistent. Also, the name is much
less visible now if multiple proposals are not allowed.
