### PR TITLE
Deactivate (and dequeue) proposal when deleting it

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -550,9 +550,9 @@ class ServiceObject
     # Always dequeue to make sure it won't become active by accident later on
     dequeue_proposal(inst)
 
-    inst = "#{@bc_name}-config-#{inst}"
-    @logger.debug "Trying to deactivate role #{inst}" 
-    role = RoleObject.find_role_by_name(inst)
+    role_name = "#{@bc_name}-config-#{inst}"
+    @logger.debug "Trying to deactivate role #{role_name}"
+    role = RoleObject.find_role_by_name(role_name)
     if role.nil?
       [404, {}]
     else


### PR DESCRIPTION
If a proposal is being deleted, it needs to be deactivated first (in
case it was active) and dequeued (in case it was queued). Otherwise, the
role will still exist, and this will break later proposals that have the
same name.

Note that while the webui guides the user to avoid this bug, it's easy
to trigger the bug from command line:
  crowbar <barclamp> proposal delete <proposal>
