### PR TITLE
webui: Only show BIOS/RAID UI when there are options for this

### DIFF
--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -20,22 +20,20 @@
             %p
               = " #{t '.override'} "
               = text_field_tag :group, @node.group(true), :size => 20
-        %li.select
-          = f.label :bios, t('.bios')
-          -if @node.admin?
-            = t 'na'
-          -elsif @options[:show].include? :bios
-            = select_tag :bios, options_for_select(option_default(@options[:bios], @node.bios_set, 'bios'), @node.bios_set)
-          -else
-            = t 'feature_na'
-        %li.select
-          = f.label :raid, t('.raid')
-          -if @node.admin?
-            = t 'na'
-          -elsif @options[:show].include? :raid and !@node.admin?
-            = select_tag :raid,  options_for_select(option_default(@options[:raid], @node.raid_set, 'raid'), @node.raid_set)
-          -else
-            = t 'feature_na'
+        -if @options[:show].include? :bios
+          %li.select
+            = f.label :bios, t('.bios')
+            -if @node.admin?
+              = t 'na'
+            -else
+              = select_tag :bios, options_for_select(option_default(@options[:bios], @node.bios_set, 'bios'), @node.bios_set)
+        -if @options[:show].include? :raid
+          %li.select
+            = f.label :raid, t('.raid')
+            -if @node.admin?
+              = t 'na'
+            -else
+              = select_tag :raid,  options_for_select(option_default(@options[:raid], @node.raid_set, 'raid'), @node.raid_set)
     %fieldset.buttons
       %ol
         -unless @node.allocated? or @node.admin?

--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -1,3 +1,4 @@
+- options = CrowbarService.read_options
 .led{:id => "head_#{@node.handle}", :class=>"led #{@node.status}", :title=>t(@node.state, :scope=>:state, :default=>@node.state.titlecase), :style=>'float:left;'}
 %h1{:title=>@node.description}= "#{@node.alias} (#{link_to t('edit'), edit_node_path(@node.handle)})"#.html_safe
 
@@ -26,7 +27,10 @@
     = dl_item(t('model.attributes.node.hardware'), @node.hardware)
     = dl_item(t('model.attributes.node.cpu'), @node.cpu)
     = dl_item(t('model.attributes.node.memory'), format_memory(@node.memory))
-    = dl_item(t('model.attributes.node.number_of_drives'), "#{@node.number_of_drives}, #{t('.raid')}: #{t('raid.'+@node.raid_set)}")
+    -if options[:show].include? :raid
+      = dl_item(t('model.attributes.node.number_of_drives'), "#{@node.number_of_drives}, #{t('.raid')}: #{t('raid.'+@node.raid_set)}")
+    -else
+      = dl_item(t('model.attributes.node.number_of_drives'), "#{@node.number_of_drives}")
     = dl_item(t('model.attributes.node.asset_tag'), @node.asset_tag)
 
 .clear

--- a/crowbar_framework/app/views/nodes/families.html.haml
+++ b/crowbar_framework/app/views/nodes/families.html.haml
@@ -1,3 +1,4 @@
+- options = CrowbarService.read_options
 %h1= t('.title')
 
 %table.data.box
@@ -8,7 +9,8 @@
       %th= t('.ram')
       %th= t('.nics')
       %th= t('.drives')
-      %th= t('.raid')
+      -if options[:show].include? :raid
+        %th= t('.raid')
       %th= t('.hardware')
       %th= t('.cpu')
   %tbody
@@ -22,6 +24,7 @@
         %td= format_memory(f[:family][:ram])
         %td= f[:family][:nics]
         %td= f[:family][:drives]
-        %td= f[:family][:raid]
+        -if options[:show].include? :raid
+          %td= f[:family][:raid]
         %td= f[:family][:hw]
         %td= f[:family][:cpu]

--- a/crowbar_framework/app/views/nodes/list.html.haml
+++ b/crowbar_framework/app/views/nodes/list.html.haml
@@ -18,8 +18,10 @@
         %th= t('.hw_description')
         %th= t('.description')
         %th= t('.group')
-        %th= t('.bios')
-        %th= t('.raid')
+        -if @options[:show].include? :bios
+          %th= t('.bios')
+        -if @options[:show].include? :raid
+          %th= t('.raid')
         %th.center 
           Allocate? 
           = check_box_tag 'all', 'all', false, {:onChange=>"check_all()"}
@@ -33,16 +35,10 @@
               %td= "#{node.hardware}<br/>#{node.memory}<br/>#{node.nics} Nics"
               %td= text_field_tag "node:#{node.name}:description".to_sym, "#{node.description(true)|| ""}", :size => 30
               %td= text_field_tag "node:#{node.name}:group".to_sym, node.group(true), :size => 15
-              %td
-                -if @options[:show].include? :bios
-                  = select_tag "node:#{node.name}:bios".to_sym, options_for_select(option_default(@options[:bios], node.bios_set, 'bios'), node.bios_set)
-                -else
-                  = t 'feature_na'
-              %td
-                -if @options[:show].include? :raid
-                  = select_tag "node:#{node.name}:raid".to_sym, options_for_select(option_default(@options[:raid], node.raid_set, 'raid'), node.raid_set)
-                -else
-                  = t 'feature_na'
+              -if @options[:show].include? :bios
+                %td= select_tag "node:#{node.name}:bios".to_sym, options_for_select(option_default(@options[:bios], node.bios_set, 'bios'), node.bios_set)
+              -if @options[:show].include? :raid
+                %td= select_tag "node:#{node.name}:raid".to_sym, options_for_select(option_default(@options[:raid], node.raid_set, 'raid'), node.raid_set)
               %td.center
                 -unless node.allocated
                   = check_box_tag("node:#{node.name}:allocate".to_sym, 'checked')
@@ -53,8 +49,10 @@
               %td= "#{node.hardware}<br/>#{node.memory}<br/>#{node.nics} Nics"
               %td= text_field_tag "node:#{node.name}:description".to_sym, (node.description(true) || ""), :size => 30
               %td= text_field_tag "node:#{node.name}:group".to_sym, node.group, :size => 15
-              %td= t 'na'
-              %td= t 'na'
+              -if @options[:show].include? :bios
+                %td= t 'na'
+              -if @options[:show].include? :raid
+                %td= t 'na'
               %td.center= t 'na'
       - else
         %tr

--- a/crowbar_framework/config/locales/en.yml
+++ b/crowbar_framework/config/locales/en.yml
@@ -369,7 +369,6 @@ en:
   not_set: Not set
   undetermined: Undetermined
   na: N/A
-  feature_na: Feature Not Available
   name: Name
   down: Down
   offline: Chef Offline


### PR DESCRIPTION
I don't think it's worth showing "Feature not available" if there are no
usable options for BIOS and RAID.
