### PR TITLE
Do not pass "r" to File.read()

### DIFF
--- a/bin/crowbar_machines
+++ b/bin/crowbar_machines
@@ -306,7 +306,7 @@ def opt_parse()
       when '--timeout'
         @timeout = arg
       when '--file'
-        data = File.read(arg, "r")
+        data = File.read(arg)
       else
         found = false
         lsub_options.each do |x|

--- a/bin/crowbar_node_state
+++ b/bin/crowbar_node_state
@@ -162,7 +162,7 @@ def opt_parse()
       when '--timeout'
         @timeout = arg
       when '--file'
-        data = File.read(arg, "r")
+        data = File.read(arg)
       else
         found = false
         lsub_options.each do |x|


### PR DESCRIPTION
This won't work in ruby 1.8.x, which I think is a target for pebbles.
And for later versions of ruby, this should be the default, so no
change.
