### PR TITLE
Use placeholder text for group field

### DIFF
--- a/crowbar_framework/app/views/nodes/index.html.haml
+++ b/crowbar_framework/app/views/nodes/index.html.haml
@@ -1,5 +1,5 @@
 %p#add_button{:style => 'float:right'}
-  = text_field_tag "new_group", t('.default_new'), :size => 15
+  = text_field_tag 'new_group', nil, :placeholder => t('.default_new'), :size => 15
   = link_to t('.add'), "javascript:add_group();", :class => 'button', :id=>'add_button'
 %h1= t('.title')
 


### PR DESCRIPTION
Instead of using an invalid default value (no spaces allowed).
