### PR TITLE
Just count the physical network interfaces

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -298,7 +298,7 @@ class NodeObject < ChefObject
   end
 
   def nics
-    @node["network"]["interfaces"].length rescue 0
+    @node["crowbar_ohai"]["detected"]["network"].length rescue 0
   end
   
   def memory


### PR DESCRIPTION
Use node["crowbar_ohai"]["detected"]["network"] for counting the NICs as that
one just includes the physical interfaces. node["network"]["interfaces"] also
contains loopback, bonding, bridges and so on.
