### PR TITLE
Fix crash in crowbar command line tool when no user/password is defined

### DIFF
--- a/bin/barclamp_lib.rb
+++ b/bin/barclamp_lib.rb
@@ -121,7 +121,7 @@ def authenticate(req,uri,data=nil)
       res.each_header { |h, v| puts "#{h}: #{v}" }
     end
 
-    if res['www-authenticate']
+    if res['www-authenticate'] and not @username.nil? and not @password.nil?
       digest_auth=Net::HTTP::DigestAuth.new
       auth=Net::HTTP::DigestAuth.new.auth_header(uri,
                                                  res['www-authenticate'],


### PR DESCRIPTION
Arguably it can be seen as a bug in the rubygem, but it's easy to fix
from here.

CROWBAR_KEY not set, will not be able to authenticate!
Please set CROWBAR_KEY or use -U and -P
/opt/dell/bin/barclamp_lib.rb:484:in `run_sub_command': undefined method`tr' for nil:NilClass (NoMethodError)
        from /usr/lib64/ruby/gems/1.8/gems/net-http-digest_auth-1.1.1/lib/net/http/digest_auth.rb:74:in `auth_header'
        from /opt/dell/bin/barclamp_lib.rb:126:in`authenticate'
        from /usr/lib64/ruby/1.8/net/http.rb:543:in `start'
        from /usr/lib64/ruby/1.8/net/http.rb:440:in`start'
        from /opt/dell/bin/barclamp_lib.rb:109:in `authenticate'
        from /opt/dell/bin/barclamp_lib.rb:138:in`get_json'
        from /opt/dell/bin/barclamp_lib.rb:250:in `proposal_list'
        from (eval):1:in`run_sub_command'
        from (eval):1:in `eval'
        from /opt/dell/bin/barclamp_lib.rb:484:in`run_sub_command'
        from (eval):1:in `run_sub_command'
        from /opt/dell/bin/barclamp_lib.rb:488:in`eval'
        from /opt/dell/bin/barclamp_lib.rb:484:in `run_sub_command'
        from /opt/dell/bin/barclamp_lib.rb:488:in`run_command'
        from /opt/dell/bin/barclamp_lib.rb:493:in `main'
        from /opt/dell/bin/crowbar_crowbar:21
