### PR TITLE
webui: Tie Hardware Update button visibility to usage of BIOS/RAID

### DIFF
--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -62,7 +62,8 @@
 
 %ul.buttons
   - unless @node.admin?
-    %li= link_to "Hardware Update", hit_node_path(@node.handle, 'update'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_hw_update'), :title => t('.hw_update_tooltip')
+    -if options[:show].include? :bios or options[:show].include? :raid
+      %li= link_to "Hardware Update", hit_node_path(@node.handle, 'update'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_hw_update'), :title => t('.hw_update_tooltip')
     %li= link_to "Reinstall", hit_node_path(@node.handle, 'reinstall'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_reinstall'), :title => t('.reinstall_tooltip')
     - if @node.allocated?
       %li= link_to "Deallocate", hit_node_path(@node.handle, 'reset'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('.confirm_deallocate'), :title => t('.deallocate_tooltip')


### PR DESCRIPTION
If the BIOS and RAID options are not available, then the Hardware Update
button is not needed, so we don't display it. In BIOS or/and RAID
options are available, then we display this button like before.
