### PR TITLE
Add update_value_direct() javascript helper

### DIFF
--- a/crowbar_framework/app/views/barclamp/_attribute_helper.html.haml
+++ b/crowbar_framework/app/views/barclamp/_attribute_helper.html.haml
@@ -1,11 +1,8 @@
 
 :javascript
-  function update_value(path, part, type) {
+  function update_value_direct(path, value, type) {
     var input = document.getElementById('proposal_attributes');
     var json = JSON.parse(input.value);
-
-    var comp = document.getElementById(part);
-    var value = comp.value;
 
     // Do type conversions
     if (type == 'boolean') {
@@ -42,3 +39,7 @@
     input.value = JSON.stringify(json); 
   }
 
+  function update_value(path, part, type) {
+    var comp = document.getElementById(part);
+    update_value_direct(path, comp.value, type);
+  }


### PR DESCRIPTION
The update_value() function cannot be passed directly a value: the value
needs to be fetched from an HTML component. There are some cases where
we might want to pass a value directly. So split update_value() code
into a update_value_direct() helper, and the code wrapping it.
