### PR TITLE
Unbreak Pebbles smoketest and unviolate the API. [1/1]

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -558,8 +558,6 @@ class ServiceObject
   end
 
   def destroy_active(inst)
-    # Always dequeue to make sure it won't become active by accident later on
-    dequeue_proposal(inst)
 
     role_name = "#{@bc_name}-config-#{inst}"
     @logger.debug "Trying to deactivate role #{role_name}"
@@ -574,7 +572,7 @@ class ServiceObject
       dep[@bc_name]["config"].delete("crowbar-committing")
       dep[@bc_name]["config"].delete("crowbar-queued")
       role.override_attributes = dep
-      answer = apply_role(role, inst, false)
+      answer = apply_role(role, role_name, false)
       role.destroy
       answer
     end
@@ -649,9 +647,6 @@ class ServiceObject
   end
 
   def proposal_delete(inst)
-    # Deactivate the proposal first, in case it was in use
-    destroy_active(inst)
-
     prop = ProposalObject.find_proposal(@bc_name, inst)
     if prop.nil?
       [404, {}]


### PR DESCRIPTION
This pull request will partially revert
a69f7417519febc110b84fac088d3a1cf05c7525,
which changes the delete_proposal code to also delete any active
proposals that were based on the to-be-deleted proposal.  This commit
broke our API unit tests and violated the API that explicitly allowed you
to have an active proposal that was decoupled from the proposal that
created it.

While the commit being reverted is arguably the right thing to do in
certian situations, changes that may break the API need to have more
thurough discussion.

 crowbar_framework/app/models/service_object.rb |    7 +------
 1 file changed, 1 insertion(+), 6 deletions(-)

Crowbar-Pull-ID: 49ce6f80de50886f5a801a915f6b662bceb939ee

Crowbar-Release: pebbles
