### PR TITLE
freeze activesupport for a while

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -231,7 +231,7 @@ gems:
     - activesupport-2.3.14
     - bundler
     - builder
-    - activesupport
+    - activesupport-3.2.13
     - eventmachine
     - rainbows
     - sendfile


### PR DESCRIPTION
activesupport 4.0.0 has been released few days ago. 4.0.0 satisfy to bluepill-0.0.51 requirements(>=3.0.0) but require ruby 1.9. We have ruby 1.8 and not seemed like we want to use ruby 1.9.

Eugene Shurmin, from our team going to make a proposal how to avoid such troubles in future using ruby bundle, but for now the build is broken.
