### PR TITLE
Use Bundler (again, but disabled by default)

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -236,6 +236,7 @@ gems:
     - rainbows
     - sendfile
     - sqlite3-ruby
+    - app_config-1.0.2
     # rdoc
     - net-ssh-multi
     - formtastic-1.2.4

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -7,6 +7,7 @@ gem "simple-navigation", "3.7.0"
 gem "i18n",  "0.4.2"
 gem "json",  "1.6.1"
 gem "chef",  "10.24.4"
+gem "app_config", "1.0.2"
 
 # Needed when running in production environment
 gem "syslogger"

--- a/crowbar_framework/Gemfile.lock
+++ b/crowbar_framework/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     activeresource (2.3.17)
       activesupport (= 2.3.17)
     activesupport (2.3.17)
+    app_config (1.0.2)
     bunny (0.7.9)
     chef (10.24.4)
       bunny (>= 0.6.0, < 0.8.0)
@@ -86,6 +87,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  app_config (= 1.0.2)
   chef (= 10.24.4)
   haml (= 3.1.6)
   i18n (= 0.4.2)

--- a/crowbar_framework/config/app_config.yml
+++ b/crowbar_framework/config/app_config.yml
@@ -1,0 +1,9 @@
+# Application (Crowbar) configuration. Changes here require a restart of
+# Crowbar to take effect.
+
+# Disable the use of Bundler for managing Gems by default (for Crowbar 1.x), as
+# it has been deemed to be too risky at this point of the release. This means
+# Gemfile and Gemfile.lock are ignored by default.
+# Crowbar 2.x and above uses Rails 3, which forces the use of Bundler so we
+# don't have/need this option there.
+use_bundler: false

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -106,20 +106,27 @@ module Rails
   end
 end
 
-# Use Bundler to manage gems. See http://gembundler.com/v1.3/rails23.html for
-# details.
-# NOTE: According to the previous comment, this breaks on Redhat?
-class Rails::Boot
-  def run
-    load_initializer
+# We'd usually put things like this in config/initializers/app_config.rb, but
+# that's too late for Bundler configuration.
+require 'rubygems'
+require 'app_config'
+AppConfig.setup(:yaml => "#{RAILS_ROOT}/config/app_config.yml")
 
-    Rails::Initializer.class_eval do
-      def load_gems
-        @bundler_loaded ||= Bundler.require :default, Rails.env
+if AppConfig[:use_bundler]
+  # Use Bundler to manage gems. See http://gembundler.com/v1.3/rails23.html for
+  # details.
+  class Rails::Boot
+    def run
+      load_initializer
+
+      Rails::Initializer.class_eval do
+        def load_gems
+          @bundler_loaded ||= Bundler.require :default, Rails.env
+        end
       end
-    end
 
-    Rails::Initializer.run(:set_load_path)
+      Rails::Initializer.run(:set_load_path)
+    end
   end
 end
 

--- a/crowbar_framework/config/environment.rb
+++ b/crowbar_framework/config/environment.rb
@@ -15,7 +15,13 @@ Rails::Initializer.run do |config|
   # Add additional load paths for your own custom dirs
   # config.load_paths += %W( #{RAILS_ROOT}/extras )
 
-  # Note: Gems are managed by Bundler.
+  unless AppConfig[:use_bundler]
+    config.gem 'haml'
+    config.gem 'sass'
+    config.gem 'simple-navigation'
+    config.gem 'i18n'
+    config.gem 'json'
+  end
   
   # Only load the plugins named here, in the order given (default is alphabetical).
   # :all can be used as a placeholder for all plugins not explicitly named

--- a/crowbar_framework/config/preinitializer.rb
+++ b/crowbar_framework/config/preinitializer.rb
@@ -1,20 +1,22 @@
-begin
-  require 'rubygems'
-  require 'bundler'
-rescue LoadError
-  raise "Could not load the bundler gem. Install it with `gem install bundler`."
-end
+if AppConfig[:use_bundler]
+  begin
+    require 'bundler'
+  rescue LoadError
+    raise "Could not load the bundler gem.\n" +
+      "Install it with `gem install bundler` and then `bundle install`."
+  end
 
-if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("0.9.24")
-  raise RuntimeError, "Your bundler version is too old for Rails 2.3.\n" +
-   "Run `gem install bundler` to upgrade."
-end
+  if Gem::Version.new(Bundler::VERSION) <= Gem::Version.new("0.9.24")
+    raise RuntimeError, "Your bundler version is too old for Rails 2.3.\n" +
+     "Run `gem install bundler` to upgrade."
+  end
 
-begin
-  # Set up load paths for all bundled gems
-  ENV["BUNDLE_GEMFILE"] = File.expand_path("../../Gemfile", __FILE__)
-  Bundler.setup
-rescue Bundler::GemNotFound
-  raise RuntimeError, "Bundler couldn't find some gems.\n" +
-    "Did you run `bundle install`?"
+  begin
+    # Set up load paths for all bundled gems
+    ENV["BUNDLE_GEMFILE"] = File.expand_path("../../Gemfile", __FILE__)
+    Bundler.setup
+  rescue Bundler::GemNotFound
+    raise RuntimeError, "Bundler couldn't find some gems.\n" +
+      "Did you run `bundle install`?"
+  end
 end


### PR DESCRIPTION
Looking at the Git history, there was an attempt to use Bundler in the past which was then reverted. I can't find the details of why or think of any compelling reasons, so let's try this again.

This change makes the development workflow much more sane - just update the Gemfile and `bundle install` to install and develop against the specific gems and versions. This is particularly useful when adding, testing, updating, or removing Gems. We can also be sure that (eg. with `bundle exec`) we're ONLY using the specified set of Gems and corresponding versions.

Bundler is also used by default in Crowbar 2.0 (Rails 3 and above), so this makes the transition easier.

Note that is does _not_ mean we have to use `bundle install` to install Gems. You can do that as a Crowbar developer if you wish, or just stick to the .deb/.rpm packages as you have been doing and in the product.
