### PR TITLE
freeze activesupport for nodes

### DIFF
--- a/chef/cookbooks/bluepill/recipes/default.rb
+++ b/chef/cookbooks/bluepill/recipes/default.rb
@@ -21,6 +21,12 @@ gem_package "i18n" do
   action :install
 end
 
+gem_package "activesupport" do
+  version "3.2.13"
+  action :install
+end
+
+
 gem_package "bluepill" do
   version node["bluepill"]["version"] if node["bluepill"]["version"]
   action :install


### PR DESCRIPTION
Since we frozen activesupport in crowbar.yml we should freeze it in chef recipes. Otherwise nodes are not able to install bluepill.
