### PR TITLE
Fix DE1262 -- Rabbitmq server intermittently going away. [1/1]

### DIFF
--- a/chef/cookbooks/crowbar/files/default/chef-server
+++ b/chef/cookbooks/crowbar/files/default/chef-server
@@ -1,8 +1,6 @@
-/var/log/chef/server*log /var/log/chef/merb*log /var/log/chef/solr.log /var/log/rabbitmq/*.log {
+/var/log/chef/server*log /var/log/chef/expander*log /var/log/chef/*.jetty.log /var/log/chef/merb*log /var/log/chef/solr.log /var/log/rabbitmq/*.log {
   rotate 12
   weekly
   compress
-  postrotate
-	bluepill chef-server restart > /dev/null
-  endscript
+  copytruncate
 }


### PR DESCRIPTION
It turns out that rabbitmq does not deal with being restarted several
times in a row while its logfiles may or may not be there.

The ultimate fix is long and rather complicated, so for now we will
just have logrotate use copytruncate to avoid needing to restart
rabbitmq and the Chef services.

 chef/cookbooks/crowbar/files/default/chef-server |    6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 271754a47a313e1f65eead7f90b2b327783c48a2

Crowbar-Release: mesa-1.6
