### PR TITLE
Fix DE1262 -- Rabbitmq going away randomly. [1/1]

### DIFF
--- a/chef/cookbooks/crowbar/files/default/chef-server
+++ b/chef/cookbooks/crowbar/files/default/chef-server
@@ -1,8 +1,6 @@
-/var/log/chef/server*log /var/log/chef/merb*log /var/log/chef/solr.log /var/log/rabbitmq/*.log {
+/var/log/chef/server*log /var/log/chef/expander*log /var/log/chef/*.jetty.log /var/log/chef/merb*log /var/log/chef/solr.log /var/log/rabbitmq/*.log {
   rotate 12
   weekly
   compress
-  postrotate
-	bluepill chef-server restart > /dev/null
-  endscript
+  copytruncate
 }


### PR DESCRIPTION
Same as https://github.com/crowbar/barclamp-crowbar/pull/568, but against Pebbles.

 chef/cookbooks/crowbar/files/default/chef-server |    6 ++----
 1 file changed, 2 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: b44626e09606dabf238fe782cf459142a8c080ab

Crowbar-Release: pebbles
