### PR TITLE
Add a public_name attribute to each node

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -97,6 +97,10 @@ class NodesController < ApplicationController
                 node.alias = values['alias']
                 dirty = true
             end
+            if !(node.public_name == values['public_name'])
+                node.public_name = values['public_name']
+                dirty = true
+            end
             if !(node.group == values['group'])
               if values['group'] and values['group'] != "" and !(values['group'] =~ /^[a-zA-Z][a-zA-Z0-9._:-]+$/)
                 raise node.name + ": " + t('nodes.list.group_error')
@@ -261,6 +265,7 @@ class NodesController < ApplicationController
       @node.bios_set = params[:bios]
       @node.raid_set = params[:raid]
       @node.alias = params[:alias]
+      @node.public_name = params[:public_name]
       @node.group = params[:group]
       @node.description = params[:description]
       @node.save

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -65,10 +65,25 @@ class NodeObject < ChefObject
     elsif nodes.length == 0
       nil
     else
-      raise "#{I18n.t('multiple_node', :scope=>'model.node')}: #{nodes.join(',')}"
+      raise "#{I18n.t('multiple_node_alias', :scope=>'model.node')}: #{nodes.join(',')}"
     end
   end
-  
+
+  def self.find_node_by_public_name(name)
+    nodes = if CHEF_ONLINE
+      self.find "crowbar_public_name:#{chef_escape(name)}"
+    else
+      nodes = self.find_all_nodes.keep_if { |n| n.public_name==name }
+    end
+    if nodes.length == 1
+      return nodes[0]
+    elsif nodes.length == 0
+      nil
+    else
+      raise "#{I18n.t('multiple_node_public_name', :scope=>'model.node')}: #{nodes.join(',')}"
+    end
+  end
+
   def self.find_node_by_name(name)
     val = if CHEF_ONLINE
       name += ".#{ChefObject.cloud_domain}" unless name =~ /(.*)\.(.)/
@@ -169,10 +184,10 @@ class NodeObject < ChefObject
     # valid DNS Name
     if !(value =~ /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/)
       Rails.logger.warn "Alias #{value} not saved because it did not conform to valid DNS hostnames"
-      raise "#{I18n.t('model.node.invalid_dns')}: #{value}"
+      raise "#{I18n.t('model.node.invalid_dns_alias')}: #{value}"
     elsif value.length+ChefObject.cloud_domain.length>255  
       Rails.logger.warn "Alias #{value}.#{ChefObject.cloud_domain} FQDN not saved because it exceeded the 63 character length limit"
-      raise "#{I18n.t('too_long_dns', :scope=>'model.node')}: #{value}.#{ChefObject.cloud_domain}"
+      raise "#{I18n.t('too_long_dns_alias', :scope=>'model.node')}: #{value}.#{ChefObject.cloud_domain}"
     else
       # don't allow duplicate alias
       node = NodeObject.find_node_by_alias value 
@@ -187,6 +202,39 @@ class NodeObject < ChefObject
       end
     end
     return value
+  end
+
+  def public_name(suggest=false)
+    if !crowbar["crowbar"]["public_name"].nil? && !crowbar["crowbar"]["public_name"].empty?
+      crowbar["crowbar"]["public_name"]
+    elsif suggest
+      default_loader['public_name']
+    else
+      nil
+    end
+  end
+
+  def public_name=(value)
+    value = value.strip.sub(/\s/,'-')
+    # valid DNS Name
+    if not (value.nil? or value.empty?)
+      if !(value =~ /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/)
+        Rails.logger.warn "Public name #{value} not saved because it did not conform to valid DNS hostnames"
+        raise "#{I18n.t('invalid_dns_public_name', :scope=>'model.node')}: #{value}"
+      elsif value.length>255
+        Rails.logger.warn "Public name #{value} not saved because it exceeded the 255 character length limit"
+        raise "#{I18n.t('too_long_dns_public_name', :scope=>'model.node')}: #{value}"
+      else
+        # don't allow duplicate public names
+        node = NodeObject.find_node_by_public_name value
+        if node and !node.handle.eql?(handle)
+          Rails.logger.warn "Public name #{value} not saved because #{node.name} already has the same public name."
+          raise I18n.t('duplicate_public_name', :scope=>'model.node') + ": " + node.name
+        end
+      end
+    end
+
+    crowbar["crowbar"]["public_name"] = value
   end
 
   def description(suggest=false, use_name=false)

--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -7,6 +7,10 @@
           = f.label :alias, t('.alias')
           = text_field_tag :alias, @node.alias(true), :size => 20
         %li.text
+          = f.label :public_name, t('.public_name')
+          = text_field_tag :public_name, @node.public_name(true), :size => 20
+          %p.inline-hints= t('.public_name_hint')
+        %li.text
           = f.label :description, t('.description')
           = text_field_tag :description, @node.description(true), :size => 40
         %li.text

--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -12,6 +12,7 @@
 .column_50.first
   %dl
     = dl_item(t('model.attributes.node.name'), @node.name)
+    = dl_item(t('model.attributes.node.public_name'), (@node.public_name.nil? ? "-" : @node.public_name))
     = dl_item(t('model.attributes.node.state'), t(@node.state, :scope => :state, :default=>@node.state.titlecase), {:class=>"node_state", :title=>"#{t('raw')}: #{@node.state}"})
     = dl_item(t('model.attributes.node.uptime'), (@node.ready? ? @node.uptime : t('model.attributes.node.na')))
     - if @node.switch_unit.nil?

--- a/crowbar_framework/app/views/nodes/list.html.haml
+++ b/crowbar_framework/app/views/nodes/list.html.haml
@@ -15,6 +15,7 @@
       %tr
         %th= t('.name')
         %th= t('.alias')
+        %th= t('.public_name')
         %th= t('.hw_description')
         %th= t('.description')
         %th= t('.group')
@@ -32,6 +33,7 @@
             %td= link_to node.name.split('.')[0], node_path(node.handle), :title=> node.ip
             -unless node.admin?
               %td= text_field_tag "node:#{node.name}:alias".to_sym, "#{node.alias(true)}", :size => 15
+              %td= text_field_tag "node:#{node.name}:public_name".to_sym, "#{node.public_name(true)}", :size => 15
               %td= "#{node.hardware}<br/>#{node.memory}<br/>#{node.nics} Nics"
               %td= text_field_tag "node:#{node.name}:description".to_sym, "#{node.description(true)|| ""}", :size => 30
               %td= text_field_tag "node:#{node.name}:group".to_sym, node.group(true), :size => 15
@@ -46,6 +48,7 @@
                   = t 'complete'
             -else
               %td= text_field_tag "node:#{node.name}:alias".to_sym, "#{node.alias(true) || t('.admin')}", :size => 15
+              %td= text_field_tag "node:#{node.name}:public_name".to_sym, "#{node.public_name(true)}", :size => 15
               %td= "#{node.hardware}<br/>#{node.memory}<br/>#{node.nics} Nics"
               %td= text_field_tag "node:#{node.name}:description".to_sym, (node.description(true) || ""), :size => 30
               %td= text_field_tag "node:#{node.name}:group".to_sym, node.group, :size => 15

--- a/crowbar_framework/config/locales/en.yml
+++ b/crowbar_framework/config/locales/en.yml
@@ -104,10 +104,14 @@ en:
   # Model Names / Attributes
   model:
     node:
-      multiple_node: Multiple nodes responded to alias request
-      invalid_dns: Alias not saved because it did not conform to valid DNS hostnames
-      too_long_dns: Alias not saved because it exceeds FQDN 63 character length
+      multiple_node_alias: Multiple nodes responded to alias request
+      multiple_node_public_name: Multiple nodes responded to public name request
+      invalid_dns_alias: Alias not saved because it did not conform to valid DNS hostnames
+      too_long_dns_alias: Alias not saved because it exceeds FQDN 63 character length
       duplicate_alias: Alias not saved because a node already has the same alias
+      invalid_dns_public_name: Public name not saved because it did not conform to valid DNS hostnames
+      too_long_dns_public_name: Public name not saved because it exceeds FQDN 255 character length
+      duplicate_public_name: Public name not saved because a node already has the same alias
     proposal: Proposal
     service:
       name_exists: Name already exists. Please choose another.
@@ -121,6 +125,7 @@ en:
     attributes:
       node:
         name: Full Name
+        public_name: Public Name
         mac: MAC Address
         allocated: Allocated
         ip: IP Address
@@ -176,6 +181,7 @@ en:
       name: Name
       group: Group
       alias: Alias  
+      public_name: Public Name
       hw_description: Hardware Information
       description: Description
       bios: BIOS
@@ -227,6 +233,8 @@ en:
       save_node_success: Node saved successfully
       allocate_node_success: Node allocated successfully
       alias: Alias
+      public_name: Public Name
+      public_name_hint: The public name is the hostname that users will use to access services on this node. Re-apply proposals on the node to have this setting taken into account immediately, or wait for an automatic update on the node.
       group: Group
       default: Using Default
       override: Override?


### PR DESCRIPTION
This public name can be used by the user to specify a DNS name that will
point to the the public IP of this node. This is needed since the
deployer might not want to rely on automatic DNS names added for this
host in the subdomain used for the cloud.

See discussion on mailing list: http://lists.us.dell.com/pipermail/crowbar/2013-July/003421.html
