### PR TITLE
Use /etc/sysctl.d on all platforms

### DIFF
--- a/chef/cookbooks/kernel-panic/templates/default/sysctl-reboot-on-panic.conf.erb
+++ b/chef/cookbooks/kernel-panic/templates/default/sysctl-reboot-on-panic.conf.erb
@@ -1,0 +1,1 @@
+kernel.panic = <%= @timeout %>


### PR DESCRIPTION
Note: This should only be merged after https://github.com/crowbar/barclamp-deployer/pull/136 was merged

The crowbar-hacks cookbook was updated to create a workaround (via cron) on systems that do not support /etc/sysctl.d/ by default.

The old code was in conflict with code from the network barclamp which unconditionally created /etc/sysctl.d anyway.
