### PR TITLE
ruby1.9.1-dev is a pkg, not a gem

### DIFF
--- a/doc/devguide/devtool-build.md
+++ b/doc/devguide/devtool-build.md
@@ -40,7 +40,8 @@ _note:_ use sudo as instructed.  Do not use the Dev tool as root!
 1. For Trunk CB2 Dev on Ruby 1.9 you need the following (do NOT do this for 1.x dev work!)
    1. `sudo update-alternatives --config ruby` (to make Ruby 1.9.1 the default. ruby -v will report version 1.9.3)
    1. `sudo update-alternatives --config gem` (to make Gem 1.9 the default, gem -v will report version 1.9)
-   1. `sudo gem install ruby1.9.1-dev builder bluecloth`
+   1. `sudo apt-get install ruby1.9.1-dev` 
+   1. `sudo gem install builder bluecloth`
    1. continue with steps below
 1. `sudo gem install json net-http-digest_auth kwalify bundler rake rcov rspec`
   1. note: rcov does not work in ruby-1.8 - use 'simplecov' instead


### PR DESCRIPTION
ruby1.9.1-dev has to be installed using apt-get
