### PR TITLE
Fix error handling in find_role_by_name

### DIFF
--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -70,8 +70,9 @@ class RoleObject < ChefObject
       begin
         chef_init
         return RoleObject.new Chef::Role.load(name)
-      rescue
-        return nil
+      rescue Net::HTTPServerException => e
+        return nil if e.response.code == "404"
+        raise e
       end
     else
       answer = self.recover_json(self.nfile('role',name))


### PR DESCRIPTION
When find_role_by_name was called while the chef-server was restarting
(Chef::Role.load throwing a connecting refused exception) this was handled as
if the role was not present in chef. This can lead to a problem where the
Node Role of the admin node will be overwritten, when the chef-server is
restarted while a client tries to load http://<admin>:3000/nodes/status.

This patch changes find_role_by_name to only return nil if Chef::Role.load
returns "Not found". All other exception thrown by Chef::Role.load are treated
as errors.
