### PR TITLE
Make it possible to disable crowbar users

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -149,10 +149,13 @@ end
 unless node["crowbar"].nil? or node["crowbar"]["users"].nil? or node["crowbar"]["realm"].nil?
   web_port = node["crowbar"]["web_port"]
   realm = node["crowbar"]["realm"]
-  users = node["crowbar"]["users"]
-  # Fix passwords into digests.
-  users.each do |k,h|
+
+  users = {}
+  node["crowbar"]["users"].each do |k,h|
+    next if h["disabled"]
+    # Fix passwords into digests.
     h["digest"] = Digest::MD5.hexdigest("#{k}:#{realm}:#{h["password"]}") if h["digest"].nil?
+    users[k] = h
   end
 
   template "/opt/dell/crowbar_framework/htdigest" do

--- a/chef/data_bags/crowbar/bc-template-crowbar.schema
+++ b/chef/data_bags/crowbar/bc-template-crowbar.schema
@@ -15,7 +15,8 @@
             "users": { "type": "map", "required": true, "mapping": {
                 = : { "type": "map", "required": true, "mapping": { 
                     "password": { "type": "str" },
-                    "digest": { "type": "str" }
+                    "digest": { "type": "str" },
+                    "disabled": { "type": "bool" }
                   }
                 }
               }


### PR DESCRIPTION
In some cases, it might be desirable to add additional users to log in
crowbar, and therefore to also enable/disable them. A new optional
"disabled" attribute can be used for this.
