### PR TITLE
Fix utils_line

### DIFF
--- a/chef/cookbooks/utils/providers/line.rb
+++ b/chef/cookbooks/utils/providers/line.rb
@@ -66,7 +66,7 @@ def add_and_filter(file, add, filter_re)
 	lines << l
       end
     else 
-      lines << 1
+      lines << l
     end
   } 
   
@@ -74,7 +74,7 @@ def add_and_filter(file, add, filter_re)
   updated =  need_to_add or need_to_remove
   
   if need_to_remove
-    lines << add if need_to_add
+    lines << "#{add}\n" if need_to_add
     need_to_add = false
     open(file, "w+") {|f| f.write lines }
   end


### PR DESCRIPTION
Fix one obvious typo (1 instead of l, which could break everything --
we're lucky it never did), and always append \n to the line to add (we
were not doing that when also removing a line).
