### PR TITLE
Bind bootstrap and discovery roles to newly-discovered nodes by default. [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -35,6 +35,8 @@ jigs:
   - name: script
     roles:
       - name: crowbar
+        flags:
+          - bootstrap
 
 crowbar:
   layout: 2.0

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -86,12 +86,8 @@ class NodesController < ApplicationController
   # RESTfule POST of the node resource
   def create
     n = Node.create! params
-    
-    # TODO ZEHICLE DIRTY HACK: Migrate when the Chef jig knows how to add roles to nodes.
-    # All nodes need to have the deployer-client present.
     Jig.create_node(n)
-    # this should move to the chef jig create_node
-  render api_show :node, Node, n.id.to_s, nil, n
+    render api_show :node, Node, n.id.to_s, nil, n
   end
   
   def update

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -16,6 +16,7 @@
 class Node < ActiveRecord::Base
 
   before_validation :default_population
+  after_create :add_default_roles
 
   attr_accessible   :id, :name, :description, :alias, :order, :admin, :allocated
 
@@ -188,4 +189,11 @@ class Node < ActiveRecord::Base
     end
   end
 
+  def add_default_roles
+    proposal = Deployment.all.first.proposal
+    Role.all.select{|r|r.discovery || (self.admin && r.bootstrap)}.each do |role|
+      role.add_to_node_in_snapshot(self,proposal)
+    end
+  end
+  
 end

--- a/crowbar_framework/app/models/node_role.rb
+++ b/crowbar_framework/app/models/node_role.rb
@@ -27,11 +27,12 @@ class NodeRole < ActiveRecord::Base
   has_one         :deployment,        :through => :snapshot
 
   # find other node-roles in this snapshot using their role or node
-  scope           :peers_by_role,     ->(r) { where(['snapshot_id=? AND role_id=?', snapshot.id, r.id]) }
-  scope           :peers_by_node,     ->(n) { where(['snapshot_id=? AND node_id=?', snapshot.id, n.id]) }
+  scope           :peers_by_role,     ->(s,r) { where(['snapshot_id=? AND role_id=?', s.id, r.id]) }
+  scope           :peers_by_node,     ->(s,n) { where(['snapshot_id=? AND node_id=?', s.id, n.id]) }
+  scope           :peers_by_node_and_role,     ->(s,n,r) { where(['snapshot_id=? AND role_id=? AND node_id=?', s.id, r.id, n.id]) }
 
   # make sure that new node-roles have require upstreams 
-  validate        :deployable,        :if => :deployable?
+  # validate        :deployable,        :if => :deployable?
   has_and_belongs_to_many :parents, :class_name => "NodeRole", :join_table => "node_role_pcm", :foreign_key => "parent_id", :association_foreign_key => "child_id"
     has_and_belongs_to_many :children, :class_name => "NodeRole", :join_table => "node_role_pcm", :foreign_key => "child_id", :association_foreign_key => "parent_id"
 
@@ -73,7 +74,7 @@ class NodeRole < ActiveRecord::Base
 
   # are the upstream required node-roles included in this snapshot
   def deployable?
-    role.upsteam.nil? or upsteam.count > 0
+    role.upstream.nil? or upstream.count > 0
   end
 
   # unblocked? are the upstream required node-roles in a ready state
@@ -108,7 +109,7 @@ class NodeRole < ActiveRecord::Base
   end
 
   def get_template
-    data ||= role.node_template
+    data ||= role.node_template || '{}'
   end
 
 end


### PR DESCRIPTION
As the title suggests.

 crowbar.yml                                        |    2 +
 .../app/controllers/nodes_controller.rb            |    6 +-
 crowbar_framework/app/models/node.rb               |    8 +
 crowbar_framework/app/models/node_role.rb          |  229 ++++++++++----------
 crowbar_framework/app/models/role.rb               |   34 ++-
 5 files changed, 159 insertions(+), 120 deletions(-)

Crowbar-Pull-ID: f2dad2c18398d692a3bb26eb5af182c27059631e

Crowbar-Release: development
