### PR TITLE
DE1362: Alias name not allowed to be longer than 63 and combination of alias and host cannot exceed 254 chars.  Fix for fix. [1/1]

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -166,12 +166,12 @@ class NodeObject < ChefObject
   def alias=(value)
     return value if self.alias==value
     value = value.strip.sub(/\s/,'-')
-    # valid DNS Name
-      if !(value =~ /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/)
+    # valid DNS Name 
+    if !(value =~ /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/)
       Rails.logger.warn "Alias #{value} not saved because it did not conform to valid DNS hostnames"
       raise "#{I18n.t('model.node.invalid_dns')}: #{value}"
-    elsif value.length+ChefObject.cloud_domain.length>63  
-      Rails.logger.warn "Alias #{value}.#{ChefObject.cloud_domain} FQDN not saved because it exceeded the 63 character length limit"
+    elsif value.length>63 || value.length+ChefObject.cloud_domain.length>254  
+      Rails.logger.warn "Alias #{value}.#{ChefObject.cloud_domain} FQDN not saved because it exceeded the 63 character length limit or it's length (#{value.length}) will cause the total DNS max of 255 to be exeeded."
       raise "#{I18n.t('too_long_dns', :scope=>'model.node')}: #{value}.#{ChefObject.cloud_domain}"
     else
       # don't allow duplicate alias


### PR DESCRIPTION
 crowbar_framework/app/models/node_object.rb |    8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 22ad5af347fb38f77c4f542475c88e3cf4d48898

Crowbar-Release: mesa-1.6
