### PR TITLE
Simplified interface for unique proposals ( Allow proposal name edits) [1/1]

### DIFF
--- a/chef/cookbooks/crowbar/attributes/default.rb
+++ b/chef/cookbooks/crowbar/attributes/default.rb
@@ -1,0 +1,16 @@
+# Copyright 2012, Dell Inc., Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default[:crowbar][:edit_proposal_name] = true

--- a/chef/data_bags/crowbar/bc-template-crowbar.json
+++ b/chef/data_bags/crowbar/bc-template-crowbar.json
@@ -21,7 +21,8 @@
       "users": {
         "machine-install": { "password": "machine_password" },
         "crowbar": { "password": "crowbar" }
-      }
+      },
+      "edit_proposal_name": true
     },
     "rails": {
       "max_pool_size": 256,

--- a/chef/data_bags/crowbar/bc-template-crowbar.schema
+++ b/chef/data_bags/crowbar/bc-template-crowbar.schema
@@ -20,6 +20,7 @@
                 }
               }
             },
+            "edit_proposal_name": { "type": "bool", "required": false },
 	    "bios-settings": { "type": "map", "required": false, "mapping": {
 		    = : { "type": "str", "required": true }
 	        }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -42,6 +42,7 @@ locale_additions:
       crowbar:
         edit_attributes:
           attributes: Attributes
+          edit_proposal_name: Edit Proposal Name
         edit_deployment:
           deployment: Deployment
 

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -35,7 +35,22 @@ class ServiceObject
   def self.allow_multiple_proposals?
     false
   end
-  
+
+  def edit_proposal_name?
+    proposals = ProposalObject.find_proposals("crowbar")
+    raise "Can't find any crowbar proposal" if proposals.nil? or proposals[0].nil?
+
+    unless proposals[0]["attributes"].nil? or proposals[0]["attributes"]["crowbar"].nil?
+        if not proposals[0]["attributes"]["crowbar"]["edit_proposal_name"].nil?
+          return proposals[0]["attributes"]["crowbar"]["edit_proposal_name"]
+        else
+          return false
+        end
+    else
+      raise "Can't find any crowbar attributes in the proposal?"
+    end
+  end
+
   def self.bc_name
     self.name.underscore[/(.*)_service$/,1]
   end

--- a/crowbar_framework/app/views/barclamp/_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/_index.html.haml
@@ -5,74 +5,8 @@
     %th{:style => "width:75%"}= t('.description')
     %th{:style => "width:5%"}
 
-%tbody
-  - catalog = ServiceObject.barclamp_catalog
-  - @modules.each do |name, barclamp|
-    - display_name = catalog['barclamps'][name]['display']
-    - display_name = name.titlecase if display_name.nil? or display_name == ""
-    %tr{:id=>name, :class => ["barclamp", cycle(:odd, :even, :name => "barclamps")]}
-      - if not barclamp[:allow_multiple_proposals] or barclamp[:proposals].length == 0
-        %td
-          = display_name
-        %td
-          - if barclamp[:proposals].length == 0
-            .led{:id => "#{name.parameterize}_none", :class => 'none', :style => "float:left", :title=>t('proposal.status.none')}
-          - else
-            - barclamp[:proposals].sort.each do |proposal_name, proposal|
-              .led{:id => "#{name.parameterize}_#{proposal_name}", :class => proposal[:status], :style => "float:left", :title=>"#{t 'proposal.status.'+proposal[:status]}"}
-        %td= "#{barclamp[:description]}"
-        %td
-          - if barclamp[:proposals].length == 0
-            - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
-              = hidden_field_tag :barclamp, name
-              -# Hard-coding "default" as name for unique proposals: it's the same name used for proposals during crowbar install process
-              = hidden_field_tag :name, "default"
-              = hidden_field_tag :description, "#{t 'created_on'} #{l(Time.now) }"
-              %input.button{:type => "submit", :value => t('proposal.actions.create')}
-          - else
-            - proposal_name, proposal = barclamp[:proposals].take(1)[0]
-            = link_to t('proposal.actions.edit'), proposal_barclamp_path(:controller=>name, :id=>proposal_name), :class => 'button'
-      - else
-        %td
-          = display_name
-        %td
-          - if barclamp[:proposals].length == 0
-            .led{:id => "#{name.parameterize}_none", :class => 'none', :style => "float:left", :title=>t('proposal.status.none')}
-          - else
-            - barclamp[:proposals].sort.each do |proposal_name, proposal|
-              .led{:id => "#{name.parameterize}_#{proposal_name}", :class => proposal[:status], :style => "float:left", :title=>"#{proposal_name.titlecase} - #{t 'proposal.status.'+proposal[:status]}"}
-        %td= "#{barclamp[:description]}"
-        %td
-          %a.toggle.with_label.button{:href => "#", :id => "#{name.parameterize}_details_toggle", :rel => "#{name.parameterize}_details"}= t('proposal.actions.edit')
+- if @service_object.edit_proposal_name?
+  = render :partial => 'barclamp/show_index'
 
-    - if barclamp[:allow_multiple_proposals] and barclamp[:proposals].length != 0
-      %tr{:class => current_cycle("barclamps"), :style => "display:#{params[:id]==name or barclamp[:expand] ? 'float' : 'none'}", :id => "#{name.parameterize}_details"}
-        %td.container{:colspan => "3"}
-          .box
-            %table.data
-              %tbody
-                - if barclamp[:proposals].length > 0
-                  - barclamp[:proposals].sort.each do |proposal_name, proposal|
-                    - prop_id = "#{name}_#{proposal_name}"
-                    %tr{:class => ["proposal", cycle(:odd, :even)], :id => barclamp[:id]}
-                      %td.status
-                        .led{:class => proposal[:status], :id => "#{prop_id}_details", :title=> t('proposal.status.'+proposal[:status])}
-                      %td{:style => "width:10%"}
-                        = proposal_name.titlecase
-                      %td
-                        - unless proposal[:status] === 'failed'
-                          = proposal[:description].capitalize
-                        - else
-                          = "#{t('.failed')} - #{proposal[:message]}"
-                      %td
-                        = link_to t('proposal.actions.edit'), proposal_barclamp_path(:controller=>name, :id=>proposal_name), :class => 'button'
-                - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
-                  %tr{:class => ["proposal", cycle(:odd, :even)]}
-                    %td{:style => "text-align:center"} +
-                    %td
-                      = hidden_field_tag :barclamp, name
-                      = text_field_tag :name, t('proposal.items.default'), :size => 15
-                    %td
-                      = text_field_tag :description, "#{t 'created_on'} #{l(Time.now) }", :size => 60
-                    %td
-                      %input.button{:type => "submit", :value => t('proposal.actions.create')}
+- if not @service_object.edit_proposal_name?
+  = render :partial => 'barclamp/show_simplified_index'

--- a/crowbar_framework/app/views/barclamp/_show_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/_show_index.html.haml
@@ -1,0 +1,49 @@
+%tbody
+  - catalog = ServiceObject.barclamp_catalog
+  - @modules.each do |name, barclamp|
+    %tr{:id=>name, :class => ["barclamp", cycle(:odd, :even, :name => "barclamps")]}
+      %td
+        %a.toggle.with_label{:href => "#", :id => "#{name.parameterize}_details_toggle", :rel => "#{name.parameterize}_details"}= name.titlecase
+      %td
+        - if barclamp[:proposals].length == 0
+          .led{:id => "#{name.parameterize}_none", :class => 'none', :style => "float:left", :title=>t('proposal.status.none')}
+        - else
+          - barclamp[:proposals].sort.each do |proposal_name, proposal|
+            .led{:id => "#{name.parameterize}_#{proposal_name}", :class => proposal[:status], :style => "float:left", :title=>"#{proposal_name.titlecase} - #{t 'proposal.status.'+proposal[:status]}"}
+      %td= "#{barclamp[:description].capitalize}"
+
+      %tr{:class => current_cycle("barclamps"), :style => "display:#{params[:id]==name or barclamp[:expand] ? 'float' : 'none'}", :id => "#{name.parameterize}_details"}
+        %td.container{:colspan => "3"}
+          .box
+            %table.data
+              %tbody
+                - if barclamp[:proposals].length > 0
+                  - barclamp[:proposals].sort.each do |proposal_name, proposal|
+                    - prop_id = "#{name}_#{proposal_name}"
+                    %tr{:class => ["proposal", cycle(:odd, :even)], :id => barclamp[:id]}
+                      %td.status
+                        .led{:class => proposal[:status], :id => "#{prop_id}_details", :title=> t('proposal.status.'+proposal[:status])}
+                      %td{:style => "width:10%"}
+                        - if proposal[:active]
+                          = link_to proposal_name.titlecase, show_barclamp_path(:controller=>name, :id=>proposal_name)
+                        -else
+                          = link_to proposal_name.titlecase, proposal_barclamp_path(:controller=>name, :id=>proposal_name)
+                      %td
+                        - unless proposal[:status] === 'failed'
+                          = proposal[:description].capitalize
+                        - else
+                          = "#{t('.failed')} - #{proposal[:message]}"
+                      %td
+                        = link_to t('proposal.actions.edit'), proposal_barclamp_path(:controller=>name, :id=>proposal_name), :class => 'button'
+                - if barclamp[:allow_multiple_proposals] or barclamp[:proposals].length == 0
+                  - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
+                    %tr{:class => ["proposal", cycle(:odd, :even)]}
+                      %td{:style => "text-align:center"} +
+                      %td
+                        = hidden_field_tag :barclamp, name
+                        = text_field_tag :name, t('proposal.items.default'), :size => 15
+                      %td
+                        = text_field_tag :description, "#{t 'created_on'} #{l(Time.now) }", :size => 60
+                      %td
+                        %input.button{:type => "submit", :value => t('proposal.actions.create')}
+

--- a/crowbar_framework/app/views/barclamp/_show_simplified_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/_show_simplified_index.html.haml
@@ -1,0 +1,71 @@
+%tbody
+  - catalog = ServiceObject.barclamp_catalog
+  - @modules.each do |name, barclamp|
+    - display_name = catalog['barclamps'][name]['display']
+    - display_name = name.titlecase if display_name.nil? or display_name == ""
+    %tr{:id=>name, :class => ["barclamp", cycle(:odd, :even, :name => "barclamps")]}
+      - if not barclamp[:allow_multiple_proposals] or barclamp[:proposals].length == 0
+        %td
+          = display_name
+        %td
+          - if barclamp[:proposals].length == 0
+            .led{:id => "#{name.parameterize}_none", :class => 'none', :style => "float:left", :title=>t('proposal.status.none')}
+          - else
+            - barclamp[:proposals].sort.each do |proposal_name, proposal|
+              .led{:id => "#{name.parameterize}_#{proposal_name}", :class => proposal[:status], :style => "float:left", :title=>"#{t 'proposal.status.'+proposal[:status]}"}
+        %td= "#{barclamp[:description]}"
+        %td
+          - if barclamp[:proposals].length == 0
+            - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
+              = hidden_field_tag :barclamp, name
+              -# Hard-coding "default" as name for unique proposals: it's the same name used for proposals during crowbar install process
+              = hidden_field_tag :name, "default"
+              = hidden_field_tag :description, "#{t 'created_on'} #{l(Time.now) }"
+              %input.button{:type => "submit", :value => t('proposal.actions.create')}
+          - else
+            - proposal_name, proposal = barclamp[:proposals].take(1)[0]
+            = link_to t('proposal.actions.edit'), proposal_barclamp_path(:controller=>name, :id=>proposal_name), :class => 'button'
+      - else
+        %td
+          = display_name
+        %td
+          - if barclamp[:proposals].length == 0
+            .led{:id => "#{name.parameterize}_none", :class => 'none', :style => "float:left", :title=>t('proposal.status.none')}
+          - else
+            - barclamp[:proposals].sort.each do |proposal_name, proposal|
+              .led{:id => "#{name.parameterize}_#{proposal_name}", :class => proposal[:status], :style => "float:left", :title=>"#{proposal_name.titlecase} - #{t 'proposal.status.'+proposal[:status]}"}
+        %td= "#{barclamp[:description]}"
+        %td
+          %a.toggle.with_label.button{:href => "#", :id => "#{name.parameterize}_details_toggle", :rel => "#{name.parameterize}_details"}= t('proposal.actions.edit')
+
+    - if barclamp[:allow_multiple_proposals] and barclamp[:proposals].length != 0
+      %tr{:class => current_cycle("barclamps"), :style => "display:#{params[:id]==name or barclamp[:expand] ? 'float' : 'none'}", :id => "#{name.parameterize}_details"}
+        %td.container{:colspan => "3"}
+          .box
+            %table.data
+              %tbody
+                - if barclamp[:proposals].length > 0
+                  - barclamp[:proposals].sort.each do |proposal_name, proposal|
+                    - prop_id = "#{name}_#{proposal_name}"
+                    %tr{:class => ["proposal", cycle(:odd, :even)], :id => barclamp[:id]}
+                      %td.status
+                        .led{:class => proposal[:status], :id => "#{prop_id}_details", :title=> t('proposal.status.'+proposal[:status])}
+                      %td{:style => "width:10%"}
+                        = proposal_name.titlecase
+                      %td
+                        - unless proposal[:status] === 'failed'
+                          = proposal[:description].capitalize
+                        - else
+                          = "#{t('.failed')} - #{proposal[:message]}"
+                      %td
+                        = link_to t('proposal.actions.edit'), proposal_barclamp_path(:controller=>name, :id=>proposal_name), :class => 'button'
+                - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
+                  %tr{:class => ["proposal", cycle(:odd, :even)]}
+                    %td{:style => "text-align:center"} +
+                    %td
+                      = hidden_field_tag :barclamp, name
+                      = text_field_tag :name, t('proposal.items.default'), :size => 15
+                    %td
+                      = text_field_tag :description, "#{t 'created_on'} #{l(Time.now) }", :size => 60
+                    %td
+                      %input.button{:type => "submit", :value => t('proposal.actions.create')}

--- a/crowbar_framework/app/views/barclamp/crowbar/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/crowbar/_edit_attributes.html.haml
@@ -3,5 +3,10 @@
 %p
   %label{:for => "proposal_attributes"}= t('.attributes')
   = link_to t('raw'), proposal_barclamp_path(:id => @proposal.name, :controller => @proposal.barclamp, :dep_raw => @dep_raw, :attr_raw => true), :style => "float: right;"
+
+%p
+  %label{ :for => :edit_proposal_name }= t('.edit_proposal_name')
+  = select_tag :edit_proposal_name, options_for_select([['false', 'false'], ['true', 'true']], @proposal.raw_data['attributes'][@proposal.barclamp]["edit_proposal_name"].to_s), :onchange => "update_value('edit_proposal_name', 'edit_proposal_name', 'boolean')"
+
   %div.container
 


### PR DESCRIPTION
A simplied interface for unique proposals. UI support for a new attribute option in the crowbar proposal  to enable proposal name edits.

 chef/cookbooks/crowbar/attributes/default.rb       |   16 +++++
 chef/data_bags/crowbar/bc-template-crowbar.json    |    3 +-
 chef/data_bags/crowbar/bc-template-crowbar.schema  |    1 +
 crowbar.yml                                        |    1 +
 crowbar_framework/app/models/service_object.rb     |   17 ++++-
 .../app/views/barclamp/_index.html.haml            |   74 ++------------------
 .../app/views/barclamp/_show_index.html.haml       |   49 +++++++++++++
 .../barclamp/_show_simplified_index.html.haml      |   71 +++++++++++++++++++
 .../barclamp/crowbar/_edit_attributes.html.haml    |    5 ++
 9 files changed, 165 insertions(+), 72 deletions(-)

Crowbar-Pull-ID: 36f945ea301693bc18e307db8bb3518dc4667b41

Crowbar-Release: pebbles
