### PR TITLE
Make jigs even more late-bound. [1/5]

### DIFF
--- a/BDD/role.erl
+++ b/BDD/role.erl
@@ -38,7 +38,7 @@ validate(JSON) when is_record(JSON, obj) ->
       bdd_utils:is_a(J, boolean, implicit),
       bdd_utils:is_a(J, boolean, bootstrap),
       bdd_utils:is_a(J, boolean, discovery),
-      bdd_utils:is_a(J, dbid, jig_id),
+      bdd_utils:is_a(J, string, jig_name),
       bdd_utils:is_a(J, dbid, barclamp_id),
       bdd_utils:is_a(J, string, role_template),
       bdd_utils:is_a(J, string, node_template),

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -31,12 +31,11 @@ barclamp:
     - opensuse-12.2
     - fedora-18
 
-jigs:
-  - name: script
-    roles:
-      - name: crowbar
-        flags:
-          - bootstrap
+roles:
+  - name: crowbar
+    jig: script
+    flags:
+      - bootstrap
 
 crowbar:
   layout: 2.0

--- a/crowbar_framework/app/models/deployment_role.rb
+++ b/crowbar_framework/app/models/deployment_role.rb
@@ -20,12 +20,11 @@ class DeploymentRole < ActiveRecord::Base
   attr_accessible :data, :wall
   attr_accessible :id, :role_id, :snapshot_id
 
-  belongs_to 		:snapshot
-  has_one			  :deployment, 	:through => :snapshot
+  belongs_to :snapshot
+  has_one    :deployment, :through => :snapshot
 
-  belongs_to		:role
-  has_one 			:jig,			:through =>	:role
-  has_one 			:barclamp, 		:through => :role
+  belongs_to :role
+  has_one    :barclamp, :through => :role
 
   # convenience methods
   def name

--- a/crowbar_framework/app/models/jig.rb
+++ b/crowbar_framework/app/models/jig.rb
@@ -35,8 +35,6 @@ class Jig < ActiveRecord::Base
   #
   validates_uniqueness_of :name, :case_sensitive => false, :message => I18n.t("db.notunique", :default=>"Name item must be unique")
   validates_format_of     :name, :with=> /^[a-zA-Z][_a-zA-Z0-9]*$/, :message => I18n.t("db.lettersnumbers", :default=>"Name limited to [_a-zA-Z0-9]")
-  
-  has_many        :roles,      :dependent => :destroy
 
 =begin 
 Create a node in all jig. The exact actions depend on the jig.

--- a/crowbar_framework/app/models/role.rb
+++ b/crowbar_framework/app/models/role.rb
@@ -18,17 +18,15 @@ class Role < ActiveRecord::Base
 
   class Role::MISSING_DEP < Exception
   end
-  attr_accessible :id, :description, :name, :jig_id, :barclamp_id
+  attr_accessible :id, :description, :name, :jig_name, :barclamp_id
   attr_accessible :library, :implicit, :bootstrap, :discovery     # flags
   attr_accessible :role_template, :node_template, :min_nodes      # template info
 
   validates_uniqueness_of   :name,  :scope => :barclamp_id
-  validates_uniqueness_of   :name,  :scope => :jig_id
   validates_format_of       :name,  :with=>/^[a-zA-Z][-_a-zA-Z0-9]*$/, :message => I18n.t("db.lettersnumbers", :default=>"Name limited to [_a-zA-Z0-9]")
 
   belongs_to      :barclamp
-  belongs_to      :jig
-  
+
   has_many        :attribs,           :dependent => :destroy
 
   has_many        :role_requires,     :dependent => :destroy
@@ -90,6 +88,10 @@ class Role < ActiveRecord::Base
       end
       return res
     end
+  end
+
+  def jig
+    Jig.where(["name = ?",jig_name]).first
   end
 
   def <=>(other)

--- a/crowbar_framework/app/views/barclamps/index.html.haml
+++ b/crowbar_framework/app/views/barclamps/index.html.haml
@@ -6,4 +6,4 @@
       = "#{bc.name}: #{bc.description}"
       %ul
         - bc.roles.each do |r|
-          %li= "#{r.jig.name} jig: #{r.name} role"
+          %li= "#{r.jig_name} jig: #{r.name} role"

--- a/crowbar_framework/app/views/deployments/index.html.haml
+++ b/crowbar_framework/app/views/deployments/index.html.haml
@@ -11,7 +11,7 @@
             = "#{p.name}: #{p.description}" 
             %ul 
               - p.deployment_roles.each do |r|
-                %li= "#{r.jig.name} jig: #{r.name} role"
+                %li= "#{r.jig_name} jig: #{r.name} role"
         - if i.committed?
           %li "committed > need status!"
         - if i.active?
@@ -20,4 +20,4 @@
             = "#{a.name}: #{a.description}" 
             %ul 
               - a.deployment_roles.each do |r|
-                %li= "#{r.jig.name} jig: #{r.name} role"
+                %li= "#{r.jig_name} jig: #{r.name} role"

--- a/crowbar_framework/app/views/roles/index.html.haml
+++ b/crowbar_framework/app/views/roles/index.html.haml
@@ -5,7 +5,7 @@
     %li
       = "#{i.name}: #{i.description}"
       %ul
-        %li= "jig: #{i.jig.name}"
+        %li= "jig: #{i.jig_name}"
         %li= "barclamp: #{i.barclamp.name}"
         - i.requires do |req|
           %li= "requires: #{req.requires}"

--- a/crowbar_framework/db/migrate/20120731225510_create_roles.rb
+++ b/crowbar_framework/db/migrate/20120731225510_create_roles.rb
@@ -19,12 +19,12 @@ class CreateRoles < ActiveRecord::Migration
       t.string      :description,       :null=>true
       t.string      :role_template,     :null=>true
       t.string      :node_template,     :null=>true
+      t.string      :jig_name,          :null=>false
       t.boolean     :library,           :null=>false, :default=>false  # brings in library code thats used to access another role (sql client)
       t.boolean     :implicit,          :null=>false, :default=>false  # role is applied automatically to nodes after allocation
       t.boolean     :bootstrap,         :null=>false, :default=>false  # used for the admin node(s) during bring up
       t.boolean     :discovery,         :null=>false, :default=>false  # related to the node being discovered in the system (by deployer)
       t.integer     :min_nodes,         :null=>false, :default=>1      # how many nodes must this role be applied to
-      t.belongs_to  :jig,               :null=>false
       t.belongs_to  :barclamp,          :null=>false
       t.timestamps
     end


### PR DESCRIPTION
This pull request series makes jigs even more late bound, and reworks
how roles are defined and loaded from crowbar.yml to make it a
seperate section from the to-be-written jigs section, as the jigs
section should concern itself with declaring what (if any) jigs a
barclamp provides.

 BDD/role.erl                                       |    2 +-
 crowbar.yml                                        |   11 ++---
 crowbar_framework/app/models/barclamp.rb           |   49 ++++++++++----------
 crowbar_framework/app/models/deployment_role.rb    |   11 ++---
 crowbar_framework/app/models/jig.rb                |    2 -
 crowbar_framework/app/models/role.rb               |   10 ++--
 .../app/views/barclamps/index.html.haml            |    2 +-
 .../app/views/deployments/index.html.haml          |    4 +-
 crowbar_framework/app/views/roles/index.html.haml  |    4 +-
 .../db/migrate/20120731225510_create_roles.rb      |    2 +-
 10 files changed, 48 insertions(+), 49 deletions(-)

Crowbar-Pull-ID: b068d7f10391d12115dc134ecb5708d4b046de93

Crowbar-Release: development
