### PR TITLE
Add UI (and tests) for deployments and snapshots [1/1]

### DIFF
--- a/BDD/bdd_crud.erl
+++ b/BDD/bdd_crud.erl
@@ -32,6 +32,9 @@ read(Path) ->
 
 % given a path + key, uses API to get the ID of the object 
 read_id(Path, Key) -> read_id(eurl:path([Path, Key])).
+read_id(Atom) when is_atom(Atom) ->
+  O = read_obj(Atom),
+  O#obj.id;
 read_id(Path) -> 
   case read(Path) of
     [_]     -> "-1";
@@ -40,6 +43,8 @@ read_id(Path) ->
 
 % given a path + key, uses API to get the record of the object 
 read_obj(Path, Key) -> read_obj(eurl:path([Path, Key])).
+read_obj(Atom) when is_atom(Atom) ->
+  bdd_utils:config(Atom);
 read_obj(Path) -> 
   case read(Path) of
     [_]     -> #obj{id = "-1"};

--- a/BDD/bdd_restrat.erl
+++ b/BDD/bdd_restrat.erl
@@ -14,7 +14,7 @@
 % 
 -module(bdd_restrat).
 -export([step/2]).
--export([get_object/1, get_result/2, parse_object/1, alias/1]).
+-export([get_object/1, get_result/2, parse_object/1, alias/1, alias/3]).
 -include("bdd.hrl").
 
 % HELPERS ============================

--- a/BDD/dev.erl
+++ b/BDD/dev.erl
@@ -15,7 +15,6 @@
 
 -module(dev).
 -export([pop/0, pop/1, unpop/0]).  
--export([storename/2]).  
 -import(bdd_utils).
 -import(digest_auth).
 -include("bdd.hrl").
@@ -27,9 +26,7 @@ pop(ConfigRaw) ->
   bdd_utils:config_set(global_setup, dev),
   bdd_utils:config_set(inspect, false),
   {ok, Build} = file:consult(bdd_utils:config(simulator, "dev.config")),
-  [ add_group(G) || G <- buildlist(Build, groups) ],
   [ add_node(N) || N <- buildlist(Build, nodes) ],
-  map_node_attribs(get({dev, node}),get({dev, attrib})),
   bdd_utils:config_unset(global_setup),
   bdd_utils:config_set(inspect, true),
   io:format("Done.~n").
@@ -37,48 +34,19 @@ pop(ConfigRaw) ->
 % tear it down
 unpop()       ->  
   {ok, Build} = file:consult(bdd_utils:config(simulator, "dev.config")),
-  [ remove(nodes, N) || {N, _, _, _, _} <- buildlist(Build, nodes) ], 
-  [ remove(groups, G) || {G, _, _, _} <- buildlist(Build, groups) ],
+  [ remove(N) || {N, _, _, _, _} <- buildlist(Build, nodes) ], 
   bdd:stop([]). 
 
 buildlist(Source, Type) ->
   {Type, R} = lists:keyfind(Type, 1, Source),
   R.
 
-storename(Type, Name) ->
-  List = get({dev, Type}),
-  Add = case List of 
-    undefined -> [Name];
-    L         -> L ++ [Name]
-  end,
-  put({dev, Type}, Add).
-  
-remove(Type, Atom) ->
-  crowbar_rest:destroy([], apply(Type, g, [path]), Atom),
-  bdd_utils:config_unset(Atom),
-  bdd_utils:log(info, "Removed ~p with tag ~p", [Type, Atom]).
-
-add_group({Atom, Name, Descripton, Order}) ->
-  JSON = group_cb:json(Name, Descripton, Order, 'ui'),
-  Path = apply(group_cb, g, [path]),
-  Result = json:parse(bdd_restrat:create([], Path, JSON)),
-  Key = json:keyfind(Result, id),
-  bdd_utils:config_set(Atom, Key),
-  storename(group_cb, Name),
-  bdd_utils:log(info, "Created Group ~p=~p named ~p", [Atom, Key, Name]).
+remove(Atom) ->
+  bdd_crud:delete(Atom).
 
 add_node({Atom, Name, Description, Order, Group}) ->
   JSON = node:json(Name, Description, Order),
-  Path = apply(node, g, [path]),
-  Result = json:parse(bdd_restrat:create([], Path, JSON)),
-  Key = json:keyfind(Result, id),
-  group_cg:step([], [], {step_when, 0, ["REST adds the node",Name,"to",Group]}),
-  bdd_utils:config_set(Atom, Key),
-  storename(node, Name),
-  bdd_utils:log(info, "Created Node ~p=~p named ~p in group ~p", [Atom, Key, Name, Group]).
+  Path = bdd_restrat:alias(node, g, [path]),
+  [_R, O] = bdd_crud:create(Path, JSON, Atom),
+  bdd_utils:log(info, "Created Node ~p=~p named ~p in group ~p", [Atom, O#obj.id, Name, Group]).
 
-map_node_attribs([], _Attribs)         -> done;
-map_node_attribs([N | Nodes], Attribs) ->
-  [attrib:node_add_attrib([], N, A) || A <- Attribs],
-  map_node_attribs(Nodes, Attribs).
-  

--- a/BDD/features/deployment.feature
+++ b/BDD/features/deployment.feature
@@ -11,8 +11,14 @@ Feature: Deployments
     When REST gets the {object:deployment} "system"
     Then the {object:deployment} is properly formatted
     
-  Scenario: The Deployment page renders
+  Scenario: The Deployment UI page renders
     Given I am on the "deployments" page
     Then I should see a heading {bdd:crowbar.i18n.deployments.index.title}
       And I should see "system"
       And there are no localization errors
+
+  Scenario: Deployment UI click to Snapshot
+    Skip ZEHICLE this should work when the system deployment gets active automatically
+    Given I am on the "deployments" page
+    When I click on the "Active system" link
+    Then I should see "system"

--- a/BDD/features/role.feature
+++ b/BDD/features/role.feature
@@ -16,3 +16,13 @@ Feature: Role
     Then I should see a heading {bdd:crowbar.i18n.roles.index.title}
       And I should see "crowbar"
       And there are no localization errors
+
+  Scenario: Roles UI click to a snapshot
+    Given I am on the "roles" page
+    When I click on the "crowbar" link
+    Then I should see "crowbar"
+
+  Scenario: Role Page renders
+    When I go to the "roles/crowbar" page
+    Then I should see "crowbar"
+      And there are no localization errors

--- a/BDD/features/snapshot.feature
+++ b/BDD/features/snapshot.feature
@@ -16,3 +16,20 @@ Feature: Snapshot
     Then I should see a heading {bdd:crowbar.i18n.snapshots.index.title}
       And I should see "system"
       And there are no localization errors
+
+  Scenario: Snapshots UI click to a snapshot
+    Given I am on the "snapshots" page
+    When I click on the "system: Created Automatically by System" link
+    Then I should see "system"
+
+  Scenario: Snapshot Page renders
+    When I go to the "snapshots/system" page
+    Then I should see "system"
+      And I should see {bdd:crowbar.i18n.snapshots.show.nodes}
+      And there are no localization errors
+
+  Scenario: Snapshot Page link to Roles 
+    Given I am on the "snapshots/system" page
+    When I click on the "crowbar" link
+    Then I should see "crowbar"
+      And there are no localization errors

--- a/crowbar_framework/app/controllers/deployments_controller.rb
+++ b/crowbar_framework/app/controllers/deployments_controller.rb
@@ -25,7 +25,7 @@ class DeploymentsController < ApplicationController
 
   def show
     respond_to do |format|
-      format.html {       } # show.html.erb
+      format.html { @deployment = Deployment.find_key params[:id] } 
       format.json { render api_show :deployment, Deployment }
     end
   end

--- a/crowbar_framework/app/controllers/snapshots_controller.rb
+++ b/crowbar_framework/app/controllers/snapshots_controller.rb
@@ -25,7 +25,22 @@ class SnapshotsController < ApplicationController
 
   def show
     respond_to do |format|
-      format.html { @snapshot = Snapshot.find_key params[:id] }
+      format.html { 
+        @snapshot = Snapshot.find_key params[:id] 
+        @nodes = {}
+        @roles = {}
+        @snapshot.node_roles.each do |nr|
+          n = nr.node
+          r = nr.role
+          @nodes[n.id] = n unless n.nil? or @nodes.has_key? n.id
+          @roles[r.id] = r unless r.nil? or @roles.has_key? r.id
+        end
+        # make sure we have at least 1 role
+        if @roles.length == 0
+          r = Role.find_key 'crowbar'
+          @roles[r.id] = r
+        end
+        }
       format.json { render api_show :snapshot, Snapshot }
     end
   end

--- a/crowbar_framework/app/views/deployments/index.html.haml
+++ b/crowbar_framework/app/views/deployments/index.html.haml
@@ -8,16 +8,21 @@
         - if i.proposed?
           - p = i.proposed
           %li
-            = "#{p.name}: #{p.description}" 
+            = link_to "#{t '.proposed'} #{p.name}",snapshot_path(:id=>p.id) 
+            = ": #{p.description}" 
             %ul 
               - p.deployment_roles.each do |r|
                 %li= "#{r.jig.name} jig: #{r.name} role"
         - if i.committed?
-          %li "committed > need status!"
+          %li
+            - c = i.committed
+            = link_to "#{t '.committed'} #{c.name}", snapshot_path(:id=>c.id) 
+            = ": #{c.description}" 
         - if i.active?
           - a = i.active
           %li
-            = "#{a.name}: #{a.description}" 
+            = link_to "#{t '.active'} #{a.name}", snapshot_path(:id=>a.id)
+            = ": #{a.description}"
             %ul 
               - a.deployment_roles.each do |r|
                 %li= "#{r.jig.name} jig: #{r.name} role"

--- a/crowbar_framework/app/views/roles/index.html.haml
+++ b/crowbar_framework/app/views/roles/index.html.haml
@@ -3,7 +3,8 @@
 %ul
   - @list.each do |i|
     %li
-      = "#{i.name}: #{i.description}"
+      = link_to i.name, role_path(:id=>i.id)
+      = ": #{i.description}"
       %ul
         %li= "jig: #{i.jig.name}"
         %li= "barclamp: #{i.barclamp.name}"

--- a/crowbar_framework/app/views/roles/show.html.haml
+++ b/crowbar_framework/app/views/roles/show.html.haml
@@ -1,0 +1,3 @@
+%h1= @role.name
+
+= @role.inspect

--- a/crowbar_framework/app/views/snapshots/index.html.haml
+++ b/crowbar_framework/app/views/snapshots/index.html.haml
@@ -3,7 +3,7 @@
 %ul
   - @list.each do |i|
     %li
-      = "#{i.name}: #{i.description}"
+      = link_to "#{i.name}: #{i.description}", snapshot_path(:id=>i.id) 
       %ul
         %li= "deployment: #{i.deployment.name}"
         - i.node_roles do |nr|

--- a/crowbar_framework/app/views/snapshots/show.html.haml
+++ b/crowbar_framework/app/views/snapshots/show.html.haml
@@ -1,0 +1,14 @@
+%h1= @snapshot.name
+
+%table.data.box
+  %thead
+    %tr
+      %th= t '.nodes'
+      - @roles.each do |rid, role|
+        %th= link_to role.name, role_path(rid)
+  %tbody
+    - @nodes.each do |nid, node|
+      %tr
+        %td= link_to node.name, node_path(nid)
+        -@roles.each do |rid, role|
+          %td "x"

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -119,6 +119,9 @@ en:
   deployments:
     index:
       title: "Deployments"
+      proposed: "Proposed"
+      committed: "Committed"
+      active: "Active"
   deployment_roles:
     index:
       title: "Deployment Roles"
@@ -148,6 +151,8 @@ en:
   snapshots:
     index:
       title: "Snapshots"
+    show:
+      nodes: "Nodes"
   support:
     index:
       title: Exported Files


### PR DESCRIPTION
This pull improves the deployments page with drill down to snapshots and roles

The snapshot UI page is setup to create a node-role table (but we don't have enough working yet).

I've also updated the erlang simulator dev:pop() to use the latest bdd_crud code.

BDD tests cover the new pages and test the links between them.

 BDD/bdd_crud.erl                                   |    5 +++
 BDD/bdd_restrat.erl                                |    2 +-
 BDD/dev.erl                                        |   44 +++-----------------
 BDD/features/deployment.feature                    |    8 +++-
 BDD/features/role.feature                          |   10 +++++
 BDD/features/snapshot.feature                      |   17 ++++++++
 .../app/controllers/deployments_controller.rb      |    2 +-
 .../app/controllers/snapshots_controller.rb        |   17 +++++++-
 .../app/views/deployments/index.html.haml          |   11 +++--
 crowbar_framework/app/views/roles/index.html.haml  |    3 +-
 crowbar_framework/app/views/roles/show.html.haml   |    3 ++
 .../app/views/snapshots/index.html.haml            |    2 +-
 .../app/views/snapshots/show.html.haml             |   14 +++++++
 crowbar_framework/config/locales/crowbar/en.yml    |    5 +++
 14 files changed, 96 insertions(+), 47 deletions(-)

Crowbar-Pull-ID: 276f0e1a3716376355ffe0e0411339acfdd85686

Crowbar-Release: development
