### PR TITLE
Allow jigs to do nothing, successfully. [1/1]

### DIFF
--- a/crowbar_framework/app/models/barclamp_crowbar/jig.rb
+++ b/crowbar_framework/app/models/barclamp_crowbar/jig.rb
@@ -17,9 +17,25 @@
 # It is NOT installed by default, but can be used for testing or as a model
 
 require 'json'
+require 'fileutils'
 
 class BarclampCrowbar::Jig < Jig
 
+  def run(nr)
+    raise "Cannot call ScriptJig::Run on #{nr.name}" unless nr.state == NodeRole::TRANSITION
+    # Hardcode this for now
+    login = "root@#{nr.node.name}"
+    local_scripts = "/opt/dell/barclamps/#{nr.barclamp.name}/script/#{nr.role.name}"
+    remote_tmpdir = %x{ssh #{login} -- mktemp -d /tmp/scriptjig-XXXXXX}
+    Dir.glob(File.join(local_scripts,"*.sh")).sort.each do |scriptpath|
+      script = scriptpath.split("/")[-1]
+      system("scp",scriptpath,"#{login}:#{remote_tmpdir}/#{script}") &&
+        system("ssh",login,"--","/bin/bash","#{remote_tmpdir}/#{script}") && continue
+      nr.state = NodeRole::ERROR
+    end
+    nr.state = NodeRole::ACTIVE
+  end
+  
   def execute(cycle)
     Rails.logger.info("ScriptJig Cycle #{cycle.name}")
     # retrieve the next turn for jig

--- a/crowbar_framework/app/models/jig.rb
+++ b/crowbar_framework/app/models/jig.rb
@@ -65,6 +65,14 @@ Delete a node from all jig. The exact actions depend on the jig.
     {}
   end
 
+  # Run a single noderole.
+  # The noderole must be in TRANSITION state.
+  # This function is intended to be overridden by the jig subclasses,
+  # and only used for debugging purposes.
+  def run(nr)
+    raise "Cannot call run on the top-level Jig!"
+  end
+
   def execute(cycle)
     Rails.logger.debug("jig.turn(#{turn.name}) not implemented for #{self.class}.  This may be OK")
   end


### PR DESCRIPTION
This allows us to start testing the noderole state machine, write the annealer, and get to work bootstrapping chef-server.

 .../app/models/barclamp_crowbar/jig.rb             |   16 ++++++++++++++++
 crowbar_framework/app/models/jig.rb                |    8 ++++++++
 crowbar_framework/app/models/node_role.rb          |    6 ++++++
 3 files changed, 30 insertions(+)

Crowbar-Pull-ID: d77471cb3d047446bc81454717d2e028dd5bd3f7

Crowbar-Release: development
