### PR TITLE
Add rake tasks for migration of data bags / roles

### DIFF
--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -1,0 +1,166 @@
+module SchemaMigration
+
+  require 'chef'
+
+  public
+  def self.run
+    ServiceObject.barclamp_catalog['barclamps'].each do |bc_name, details|
+      run_for_bc bc_name
+    end
+  end
+
+  public
+  def self.run_for_bc bc_name
+    template = ProposalObject.find_proposal("template", bc_name)
+    return if template.nil?
+    return if template['deployment'].nil?
+    return if template['deployment'][bc_name].nil?
+    return if template['deployment'][bc_name]['schema-revision'].nil?
+
+    all_scripts = find_scripts_for_bc(bc_name)
+    return if all_scripts.empty?
+
+    props = ProposalObject.find_proposals bc_name
+    props.each do |prop|
+      migrate_proposal(bc_name, template, all_scripts, prop)
+
+      # Attempt to do migration for the matching committed proposal
+      # Note: we don't want to commit the proposal we just migrated, because it
+      # might have other uncommitted changes that are not wanted.
+      role_name = prop['id'].gsub("bc-#{bc_name}-", "#{bc_name}-config-")
+      role = RoleObject.find_role_by_name(role_name)
+      unless role.nil?
+        migrate_role(bc_name, template, all_scripts, role)
+      end
+    end
+  end
+
+### Private methods
+
+  private
+  def self.get_migrate_dir(bc_name)
+    data_bags_path_prefix = "/opt/dell/chef/data_bags/crowbar"
+    return File.join(data_bags_path_prefix, 'migrate', bc_name)
+  end
+
+  private
+  def self.find_scripts_for_bc(bc_name)
+    all_scripts = []
+
+    migrate_dir = get_migrate_dir(bc_name)
+    return all_scripts unless File.directory?(migrate_dir)
+
+    Dir.entries(migrate_dir).sort.each do |file|
+      next if ['.', '..'].include?(file)
+      next if File.directory?(File.join(migrate_dir, file))
+      all_scripts << file
+    end
+
+    return all_scripts
+  end
+
+  private
+  def self.find_scripts_for_migration(bc_name, all_scripts, old_revision, new_revision)
+    scripts = []
+    migrate_dir = get_migrate_dir(bc_name)
+
+    return scripts if old_revision == new_revision
+
+    is_upgrade = old_revision < new_revision
+    if is_upgrade
+      start_revision = old_revision + 1
+      end_revision = new_revision
+    else
+      start_revision = new_revision
+      end_revision = old_revision - 1
+    end
+
+    Range.new(start_revision, end_revision).each do |rev|
+      all_scripts.each do |script|
+        next unless script =~ /^0*#{rev}_.*\.rb$/
+        scripts << File.join(migrate_dir, script)
+      end
+    end
+
+    scripts.reverse! unless is_upgrade
+
+    return scripts
+  end
+
+  private
+  def self.run_script(script, is_upgrade, template_attributes, template_deployment, attributes, deployment)
+    # redefine upgrade/downgrade to no-op before each load
+    def upgrade ta, td, a, d
+      return a, d
+    end
+    def downgrade ta, td, a, d
+      return a, d
+    end
+
+    load script
+
+    if is_upgrade
+      attributes, deployment = upgrade(template_attributes, template_deployment, attributes, deployment)
+    else
+      attributes, deployment = downgrade(template_attributes, template_deployment, attributes, deployment)
+    end
+  end
+
+  private
+  def self.migrate_object(bc_name, template, all_scripts, attributes, deployment)
+    attributes ||= Mash.new
+    deployment ||= Mash.new
+
+    current_schema_revision = deployment['schema-revision']
+    if current_schema_revision.nil?
+      current_schema_revision = 0
+    end
+
+    schema_revision = template['deployment'][bc_name]['schema-revision']
+
+    return [nil, nil] if current_schema_revision == schema_revision
+
+    is_upgrade = current_schema_revision < schema_revision
+    scripts = self.find_scripts_for_migration(bc_name, all_scripts, current_schema_revision, schema_revision)
+    return [nil, nil] if scripts.empty?
+
+    scripts.each do |script|
+      # we only pass attributes and deployment to not encourage direct access
+      # to the proposal
+      attributes, deployment = run_script(script, is_upgrade, template['attributes'][bc_name], template['deployment'][bc_name], attributes, deployment)
+    end
+
+    deployment['schema-revision'] = schema_revision
+
+    return attributes, deployment
+  end
+
+  private
+  def self.migrate_proposal(bc_name, template, all_scripts, proposal)
+    attributes = proposal['attributes'][bc_name]
+    deployment = proposal['deployment'][bc_name]
+
+    (attributes, deployment) = migrate_object(bc_name, template, all_scripts, attributes, deployment)
+
+    return if attributes.nil? || deployment.nil?
+
+    proposal['attributes'][bc_name] = attributes
+    proposal['deployment'][bc_name] = deployment
+    proposal.save
+  end
+
+  private
+  def self.migrate_role(bc_name, template, all_scripts, role)
+    attributes = role.default_attributes[bc_name]
+    deployment = role.override_attributes[bc_name]
+
+    (attributes, deployment) = migrate_object(bc_name, template, all_scripts, attributes, deployment)
+
+    return if attributes.nil? || deployment.nil?
+
+    role.default_attributes[bc_name] = attributes
+    role.override_attributes[bc_name] = deployment
+    role.save
+  end
+
+end

--- a/crowbar_framework/lib/tasks/crowbar.rake
+++ b/crowbar_framework/lib/tasks/crowbar.rake
@@ -1,0 +1,25 @@
+namespace :crowbar do
+
+  desc "Run schema migration on proposals"
+  task :schema_migrate, [:barclamps] => :environment do |t, args|
+    args.with_defaults(:barclamps => 'all')
+    barclamps = args[:barclamps].split(' ')
+
+    require 'schema_migration'
+
+    if barclamps.include?('all')
+        SchemaMigration.run
+    else
+      barclamps.each do |barclamp|
+        SchemaMigration.run_for_bc barclamp
+      end
+    end
+  end
+
+  desc "Run schema migration on proposals for production environment"
+  task :schema_migrate_prod, [:barclamps] do |t, args|
+    RAILS_ENV = 'production'
+    Rake::Task['crowbar:schema_migrate'].invoke(args[:barclamps])
+  end
+
+end


### PR DESCRIPTION
There are two new tasks:
- crowbar:schema_migrate -- this migrates data bags / roles to the
  current revision of the schema
- crowbar:schema_migrate_prod -- this is a convenience wrapper task to
  call crowbar:schema_migrate with the production environment

By default, this will migrate data bags / roles for all barclamps. It's
possible to restrict this to one or several barclamps:

```
 rake crowbar:schema_migrate_prod[nova]
 rake crowbar:schema_migrate_prod[keystone nova]
```

The migration works the following way:
- it supports upgrades and downgrades.
- schemas supporting migration must have a schema-revision int
  attribute in the deployment part; the template will contain the
  version of the schema revision in this attribute.
  (Reason this is in the deployment part: this will be available in
  the committed role too)
- there are migration scripts in
  /opt/dell/chef/data_bags/crowbar/migrate/$barclamp/. The scripts
  must be named $rev_$somedescription.rb; the filename can have
  0 (001_foobar.rb will work as well as 1_foobar.rb). There can be
  multiple scripts per revision; they will be executed by alphabetical
  order (or reverse alphabetical order in case of downgrades).
- a script can provide two functions (they are optional):
  - an upgrade function
  - a downgrade function

The functions must take as parameters:
- the barclamp attributes of the template
- the barclamp deployment information of the template
- the barclamp attributes of the proposal / role
- the barclamp deployment information of the proposal / role

The functions must return:
- the updated barclamp attributes of the proposal / role
- the updated barclamp deployment information of the proposal / role

We are explicitly restricting acces to the barclamp attributes and
barclamp deployment information to forbid the migration scripts to
change anything outside of the perimeter of each barclamp.

As an example, for nova, we could have
/opt/dell/chef/data_bags/crowbar/migrate/nova/001_add_vuntz_attribute.rb
with the following content:

``` ruby
def upgrade ta, td, a, d
  a['vuntz'] = ta['vuntz']
  return a, d
end

def downgrade ta, td, a, d
  a.delete('vuntz')
  return a, d
end
```

This will update the attributes.nova.vuntz attribute in the proposal
data bag, and the default_attributes.nova.vuntz attribute in the role.
