### PR TITLE
Fix crash when bios/raid options are empty in proposal

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -265,6 +265,9 @@ class CrowbarService < ServiceObject
     unless proposals[0]["attributes"].nil? or proposals[0]["attributes"]["crowbar"].nil?
       options[:raid] = proposals[0]["attributes"]["crowbar"]["raid-settings"]
       options[:bios] = proposals[0]["attributes"]["crowbar"]["bios-settings"]
+      options[:raid] = {} if options[:raid].nil?
+      options[:bios] = {} if options[:bios].nil?
+
       options[:show] << :raid if options[:raid].length > 0
       options[:show] << :bios if options[:bios].length > 0
     end


### PR DESCRIPTION
This works well when they are absent, but not when they are empty.
