### PR TITLE
Do not call humanize on role names

### DIFF
--- a/crowbar_framework/app/views/barclamp/_node_selector.html.haml
+++ b/crowbar_framework/app/views/barclamp/_node_selector.html.haml
@@ -33,9 +33,9 @@
         %div
           %div.droptarget{ :id=>element, :draggable=>'true'}
             - if CONVERGED_ADMIN
-              %b= link_to element.humanize, "http://#{request.host}:4040/roles/#{element}", :target => '_blank'
+              %b= link_to element, "http://#{request.host}:4040/roles/#{element}", :target => '_blank'
             - else
-              %b= element.humanize
+              %b= element
             %img{ :src=>'/images/icons/server_add.png', :title=>t('.add') }
           %ul.ddlist{ :id=>element }
 


### PR DESCRIPTION
We should really not have "Nova-multi-controller", but
"nova-multi-controller": if people then try to use the capitalized name
with knife, it'll just fail.
