### PR TITLE
When all node-roles are active, make the snapshot active [1/2]

### DIFF
--- a/crowbar_framework/app/models/node_role.rb
+++ b/crowbar_framework/app/models/node_role.rb
@@ -203,6 +203,13 @@ class NodeRole < ActiveRecord::Base
         children.each do |c|
           c.state = TODO
         end
+        # if all the node-roles in the snapshot are active, then we are done!
+        if self.snapshot.node_roles.all? { |nr| nr.active? }
+          d = self.snapshot.deployment
+          d.committed_snapshot_id = nil
+          d.active_snapshot_id = self.snapshot_id
+          d.save!
+        end
       when TODO
         # We can only go to TODO when:
         # 1. We were in PROPOSED or BLOCKED


### PR DESCRIPTION
This pull is the last yard, when you set a node-role to active
it will check to see if all the other node-roles in the snapshot are active.

If so, it will activate the snapshot.

 crowbar_framework/app/models/node_role.rb |    7 +++++++
 1 file changed, 7 insertions(+)

Crowbar-Pull-ID: 297efb9d2eccac3982d6e3a1f8c7ea7fe0d4ec68

Crowbar-Release: development
