### PR TITLE
CB2.0: Chef jig bootstrapped to be able to run the deployer-client role on the admin node. [1/4]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -37,6 +37,11 @@ roles:
     flags:
       - bootstrap
 
+jigs:
+  - name: script
+    class: 'BarclampCrowbar::Jig'
+    description: 'Run arbitrary scripts on nodes via SSH'
+
 crowbar:
   layout: 2.0
   order: 0

--- a/crowbar_framework/app/models/jig.rb
+++ b/crowbar_framework/app/models/jig.rb
@@ -27,7 +27,7 @@
 class Jig < ActiveRecord::Base
 
   attr_accessible :id, :name, :description, :type, :order
-  attr_accessible :server, :client_name, :key, :active
+  attr_accessible :server, :client_name, :client_role_name, :key, :active
 
   # 
   # Validate the name should unique 
@@ -55,6 +55,18 @@ class Jig < ActiveRecord::Base
   def create_node(node)
     Rails.logger.debug("jig.create_node(#{node.name}) not implemented for #{self.class}.  This may be OK")
     {}
+  end
+
+  def client_role
+    crn = client_role_name
+    return nil if crn.nil?
+    res = Role.where(:name => crn).first
+    # Jig client roles must be implicit roles.
+    raise "#{crn} is not an implicit role!" unless res.implicit
+    # Jig client roles cannot be implemented by the jig they implement
+    # client-side functionality for.
+    raise "#{crn} is implemented by and requires #{name}!" if res.jig_name == name
+    res
   end
 
   # Run a single noderole.

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -209,8 +209,12 @@ class Node < ActiveRecord::Base
   def add_default_roles
     raise "you must have at least 1 deployment" unless Deployment.count > 0
     Deployment.first.recommit do |snap|
-      Role.bootstrap.each {|r| r.add_to_node_in_snapshot(self,snap) } if self.admin
-      Role.discovery.each {|r| r.add_to_node_in_snapshot(self,snap) }
+      Role.bootstrap.each do |r|
+        r.add_to_node_in_snapshot(self,snap) if r.active?
+      end if self.admin
+      Role.discovery.each do |r|
+        r.add_to_node_in_snapshot(self,snap) if r.active?
+      end
     end
   end
 end

--- a/crowbar_framework/app/models/node_role.rb
+++ b/crowbar_framework/app/models/node_role.rb
@@ -205,10 +205,11 @@ class NodeRole < ActiveRecord::Base
     state == PROPOSED
   end
 
-  def walk(&block)
-    raise "Must be passed a block" unless block_given?
+  def walk(block)
+    raise "Must be passed a block" unless block.kind_of?(Proc)
     block.call(self)
     children.each do |c|
+      Rails.logger.info("NodeRole: Walking from #{self.name} to #{c.name}")
       c.walk(block)
     end
   end
@@ -254,7 +255,7 @@ class NodeRole < ActiveRecord::Base
         save!
         # All children of a node_role in ERROR go to BLOCKED.
         children.each do |c|
-          c.walk{|n|n.state = BLOCKED}
+          c.walk(lambda{|n|n.state = BLOCKED})
         end
       when ACTIVE
         # We can only go to ACTIVE from TRANSITION
@@ -288,7 +289,7 @@ class NodeRole < ActiveRecord::Base
         save!
         # Going into TODO transitions all our children into BLOCKED.
         children.each do |c|
-          c.walk{|n|n.state = BLOCKED}
+          c.walk(lambda{|n|n.state = BLOCKED})
         end
       when TRANSITION
         # We can only go to TRANSITION from TODO
@@ -313,7 +314,7 @@ class NodeRole < ActiveRecord::Base
         save!
         # If we are blocked, so are all our children.
         children.each do |c|
-          c.walk{|n|n.state = BLOCKED}
+          c.walk(lambda{|n|n.state = BLOCKED})
         end
       when PROPOSED
         # Only new node_roles can be in proposed

--- a/crowbar_framework/db/migrate/20120730225300_create_jigs.rb
+++ b/crowbar_framework/db/migrate/20120730225300_create_jigs.rb
@@ -15,20 +15,19 @@
 class CreateJigs < ActiveRecord::Migration
   def self.up
     create_table :jigs do |t|
-      t.string  :name
-      t.string  :description,  :null=>true
-      t.integer :order,        :default=>10000
-      t.string  :type,         :null=>false
-      t.boolean :active,       :default => false 
-      t.string  :server,       :null=>true
-      t.string  :client_name,  :null=>true
-      t.string  :key,          :null=>true
+      t.string      :name
+      t.string      :description,         :null=>true
+      t.integer     :order,               :default=>10000
+      t.string      :type,                :null=>false
+      t.boolean     :active,              :default => false
+      t.string      :client_role_name,    :null => true
+      t.string      :server,              :null=>true
+      t.string      :client_name,         :null=>true
+      t.string      :key,                 :null=>true
       t.timestamps
     end
     #natural key
-    add_index(:jigs, :name, :unique => true)   
-    # create Script jig 
-    BarclampCrowbar::Jig.find_or_create_by_name(:name =>'script', :order=>100, :active=>true, :description=>'Direct actions on local server')
+    add_index(:jigs, :name, :unique => true)
   end
 
   def self.down


### PR DESCRIPTION
The Chef jig can now run the deployer-client role on the admin node.

It still needs work to be able to intelligently extract attributes
from the chef-client run back out to Crowbar, and its run-list
management is abysmally stupid, but it should work well enough to
start bootstrapping the rest of the recipes.

 crowbar.yml                                        |    5 +++
 crowbar_framework/app/models/barclamp.rb           |   23 +++++++++---
 .../app/models/barclamp_crowbar/jig.rb             |   39 ++++++++++++--------
 crowbar_framework/app/models/jig.rb                |   14 ++++++-
 crowbar_framework/app/models/node.rb               |    8 +++-
 crowbar_framework/app/models/node_role.rb          |   11 +++---
 crowbar_framework/app/models/role.rb               |   22 ++++++++++-
 .../db/migrate/20120730225300_create_jigs.rb       |   21 +++++------
 8 files changed, 102 insertions(+), 41 deletions(-)

Crowbar-Pull-ID: 902d456b04f9723fcdadbee1c7540b8a939fc3f1

Crowbar-Release: development
