### PR TITLE
Do not crash when viewing a node at the beginning of its discovery

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -389,6 +389,7 @@ class NodeObject < ChefObject
   end
 
   def number_of_drives
+    return -1 if @node[:block_device].nil?
     # This needs to be kept in sync with the fixed method in
     # barclamp_library.rb in in the deployer barclamp.
     @node[:block_device].find_all do |disk,data|

--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -24,10 +24,12 @@
     = dl_item(t('model.attributes.node.asset_tag'), @node.asset_tag)
     = dl_item(t('model.attributes.node.cpu'), @node.cpu)
     = dl_item(t('model.attributes.node.memory'), format_memory(@node.memory))
+    - number_of_drives = @node.number_of_drives
+    - number_of_drives = t('unknown') if number_of_drives < 0
     -if options[:show].include? :raid
-      = dl_item(t('model.attributes.node.number_of_drives'), "#{@node.number_of_drives}, #{t('.raid')}: #{t('raid.'+@node.raid_set)}")
+      = dl_item(t('model.attributes.node.number_of_drives'), "#{number_of_drives}, #{t('.raid')}: #{t('raid.'+@node.raid_set)}")
     -else
-      = dl_item(t('model.attributes.node.number_of_drives'), "#{@node.number_of_drives}")
+      = dl_item(t('model.attributes.node.number_of_drives'), "#{number_of_drives}")
     = dl_item(t('model.attributes.node.mac'), @node.mac || t('unknown'))
     - if @node.switch_unit.nil?
       = dl_item(t('model.attributes.node.switch_name_port'), "#{@node.switch_name || t('unknown') } / #{@node.switch_port || t('unknown')}")


### PR DESCRIPTION
The number_of_drives method will raise an exception if the node was not
fully discovered yet, so catch that.
