### PR TITLE
Fix destroy_active again to not use role name as instance name

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -587,7 +587,7 @@ class ServiceObject
       dep[@bc_name]["config"].delete("crowbar-committing")
       dep[@bc_name]["config"].delete("crowbar-queued")
       role.override_attributes = dep
-      answer = apply_role(role, role_name, false)
+      answer = apply_role(role, inst, false)
       role.destroy
       answer
     end


### PR DESCRIPTION
The original fix was in c4acddc, but it got broken by f7f9c1a.
