### PR TITLE
backport support for Gemfile.d and routes.d plugin mechanisms (bnc#835514)

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -24,3 +24,12 @@ group :test do
   # gem "rspec"
   # gem "faker"
 end
+
+# Install gems from each barclamp.  The crowbar_path variable is
+# needed by Gemfile.d/*.gemfile so that they can determine the correct
+# path at run-time rather than having to hard-code a path at
+# install-time which may be different and therefore incorrect.
+crowbar_path = File.dirname(__FILE__)
+Dir.glob(File.join(crowbar_path, 'Gemfile.d', '*.gemfile')) do |gemfile|
+    eval(IO.read(gemfile), binding)
+end

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -15,6 +15,10 @@
 # Author: RobHirschfeld 
 # 
 ActionController::Routing::Routes.draw do |map|
+  # Install route from each barclamp
+  Dir.glob(File.join(File.dirname(__FILE__), 'routes.d', '*.routes')) do |routes_file|
+      eval(IO.read(routes_file), binding)
+  end
 
   map.root :controller => "nodes", :action=>'index'
 


### PR DESCRIPTION
This is a backport of functionality from Crowbar 2.0.  It is required by the new Cisco UCS barclamp, but should not make any difference to any existing barclamps.

This fixes https://bugzilla.novell.com/show_bug.cgi?id=835514
