### PR TITLE
Can create new deployments from API and UI [1/1]

### DIFF
--- a/BDD/deployment.erl
+++ b/BDD/deployment.erl
@@ -32,9 +32,10 @@ g(Item) ->
 validate(JSON) when is_record(JSON, obj) ->
   J = JSON#obj.data,
   R =[JSON#obj.type == "deployment",
-      bdd_utils:is_a(J, length, 9),
+      bdd_utils:is_a(J, length, 8),
       bdd_utils:is_a(J, boolean, system),
       bdd_utils:is_a(J, dbid, snapshot_id),
+      bdd_utils:is_a(J, dbid, parent_id),
       crowbar_rest:validate(J)],
   bdd_utils:assert(R);
 validate(JSON) -> 
@@ -56,7 +57,7 @@ inspector(Deployment) ->
 % Common Routine
 % Creates JSON used for POST/PUT requests
 json(Name, Description, Order) ->
-  json:output([{"name",Name},{"description", Description}, {"order", Order}]).
+  crowbar:json([{name, Name}, {description, Description}, {order, Order}]).
 
 % TEMPORARY REMAPPING
 % -include("bdd.hrl").

--- a/BDD/dev.config
+++ b/BDD/dev.config
@@ -19,8 +19,10 @@
               ]}.
 {groups,  [ {group1, "Rack1", "North Pole", 1000},
             {group2, "Rack2", "South Pole", 2000}
+          ]}.          
+{deployments,  [ {deploy1, "Dev", [{description, "Tron MCP"}, {order, 1000}]},
+                 {deploy2, "Prod", [{description, "The Matrix"}, {order, 2000}]}
           ]}.
-          
           
             %nodes
 % Rob's Attribute list  

--- a/BDD/dev.erl
+++ b/BDD/dev.erl
@@ -39,6 +39,7 @@ pop(ConfigRaw)  ->
   Admin = crowbar:json([{name, g(node_name)}, {description, "dev" ++ g(description)}, {order, 100}, {admin, "true"}]),
   bdd_crud:create(node:g(path), Admin, g(node_atom)),
   % rest of the nodes
+  [ add_deployment(D) || D <- buildlist(Build, deployments) ],
   [ add_node(N) || N <- buildlist(Build, nodes) ],
   bdd_utils:config_unset(global_setup),
   bdd_utils:config_set(inspect, true),
@@ -59,8 +60,14 @@ remove(Atom) ->
   bdd_crud:delete(Atom).
 
 add_node({Atom, Name, Description, Order, Group}) ->
-  JSON = node:json(Name, Description, Order),
+  JSON = crowbar:json([{name, Name}, {description, Description}, {order, Order}, {group, Group}]),
   Path = bdd_restrat:alias(node, g, [path]),
   [_R, O] = bdd_crud:create(Path, JSON, Atom),
   bdd_utils:log(info, "Created Node ~p=~p named ~p in group ~p", [Atom, O#obj.id, Name, Group]).
+
+add_deployment({Atom, Name, Extras }) ->
+  JSON = crowbar:json([{name, Name} | Extras]),
+  Path = bdd_restrat:alias(deployment, g, [path]),
+  [_R, O] = bdd_crud:create(Path, JSON, Atom),
+  bdd_utils:log(info, "Created Deployment ~p=~p named ~p", [Atom, O#obj.id, Name]).
 

--- a/BDD/features/deployment.feature
+++ b/BDD/features/deployment.feature
@@ -22,3 +22,9 @@ Feature: Deployments
     Given I am on the "deployments" page
     When I click on the "Active system" link
     Then I should see "system"
+
+  Scenario: Can create new deployment from API
+    Given there is not a {object:deployment} "bdd_deploy_test"
+    When REST creates the {object:deployment} "bdd_deploy_test"
+    Then there is a {object:deployment} "bdd_deploy_test"
+    Finally REST removes the {object:deployment} "bdd_deploy_test"

--- a/crowbar_framework/app/controllers/deployments_controller.rb
+++ b/crowbar_framework/app/controllers/deployments_controller.rb
@@ -31,9 +31,10 @@ class DeploymentsController < ApplicationController
   end
 
   def create
+    @deployment = Deployment.create! params
     respond_to do |format|
-      format.html {  }
-      format.json { render api_show :deployment, Deployment, nil, nil, deploy }
+      format.html { redirect_to deployment_path(@deployment.id)}
+      format.json { render api_show :deployment, Deployment, @deployment.id.to_s, nil, @deployment }
     end
   end
 

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -221,7 +221,7 @@ class Node < ActiveRecord::Base
 
   def add_default_roles
     raise "you must have at least 1 deployment" unless Deployment.count > 0
-    Deployment.system.first.recommit do |snap|
+    Deployment.system_root.first.recommit do |snap|
       Role.bootstrap.each do |r|
         r.add_to_snapshot(snap,self) if r.active?
       end if self.admin

--- a/crowbar_framework/app/views/deployments/index.html.haml
+++ b/crowbar_framework/app/views/deployments/index.html.haml
@@ -1,4 +1,11 @@
-%h1= t '.title'
+%table{:width=>'100%'}
+  %tr
+    %td
+      %h1= t '.title'
+    %td{:align=>'right'}
+      = form_for :deployment, :'data-remote' => true, :url => deployments_path(), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
+        = text_field_tag :name, t('.default'), :size => 15
+        %input.button{:type => "submit", :name => "create", :method=>:post, :value => t('.create')}
 
 %table.data.box
   %thead

--- a/crowbar_framework/config/initializers/crowbar_deployment.rb
+++ b/crowbar_framework/config/initializers/crowbar_deployment.rb
@@ -29,9 +29,5 @@ begin
     # Make it a system deployment
     d.send(:write_attribute,"system",true)
     d.save!
-    snap = Snapshot.create(:deployment_id=>d.id, :name => d.name, :description => d.description)
-    snap.save!
-    d.snapshot_id = snap.id
-    d.save!
   end
 end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -142,6 +142,8 @@ en:
     index:
       title: "Deployments"
       actions: "Actions"
+      default: "default"
+      create: "Add"
       <<: *deployment_common
     show:
       snapshots: "History"
@@ -155,7 +157,7 @@ en:
       recall: "Interrupt"
       propose: "Propose"
       correct: "Correct"
-      anneal: "Run Annealer"
+      anneal: "Annealer"
   deployment_roles:
     index:
       title: "Deployment Roles"
@@ -222,11 +224,11 @@ en:
       <<: *deployment_common
     show:
       nodes: "Nodes"
-      anneal: "Run Annealer"
+      anneal: "Anneal"
       <<: *deployment_common      
     anneal:
       title: "annealing activity"
-      anneal: "Run Annealer"
+      anneal: "Anneal"
       annealling: "Annealer Started by User Action"
       <<: *deployment_common      
       <<: *node_role_states

--- a/crowbar_framework/db/migrate/20120731225466_create_deployments.rb
+++ b/crowbar_framework/db/migrate/20120731225466_create_deployments.rb
@@ -19,7 +19,7 @@ class CreateDeployments < ActiveRecord::Migration
       t.string      :description,                 :null=>true
       t.boolean     :system,                      :null=>false, :default=>false
       t.references  :snapshot,                    :null=>true
-      t.references  :parent, :deployment
+      t.references  :parent
       t.timestamps
     end
     #natural key


### PR DESCRIPTION
Added the code AND TESTS to allow creating a new deployment (auto parent to system).

I removed the deployment.deployment_id field because I could not find any references to 
it at all.  It appears to be redundant with parent and parent is clearer.

Also, expanded the simulator to install more nodes and two deployments for testing.

This step was needed so that I could write annealer tests (that is my current objective)

Next: adding more deployment tests!

 BDD/deployment.erl                                 |    5 ++--
 BDD/dev.config                                     |   18 +++++++++-----
 BDD/dev.erl                                        |   20 +++++++++++++---
 BDD/features/deployment.feature                    |    8 ++++++-
 .../app/controllers/deployments_controller.rb      |    5 ++--
 crowbar_framework/app/models/deployment.rb         |   25 +++++++++++++++-----
 crowbar_framework/app/models/node.rb               |    2 +-
 .../app/views/deployments/index.html.haml          |    9 ++++++-
 .../config/initializers/crowbar_deployment.rb      |    4 ----
 crowbar_framework/config/locales/crowbar/en.yml    |    8 ++++---
 .../migrate/20120731225466_create_deployments.rb   |    2 +-
 11 files changed, 76 insertions(+), 30 deletions(-)

Crowbar-Pull-ID: 6e1ccf2914cdbe9f0638c4ee55121dfd57dd5311

Crowbar-Release: development
