### PR TITLE
webui: In streamlined mode, do not show proposal name on edit page

### DIFF
--- a/crowbar_framework/app/views/barclamp/proposal_show.html.haml
+++ b/crowbar_framework/app/views/barclamp/proposal_show.html.haml
@@ -18,7 +18,10 @@
         %input.button{:type => "submit", :name=>"submit", :source=> "dequeue1", :match=>'dequeue2', :value => t('.dequeue_proposal'), :'data-remote'=>'true'}
       %input.button{:type => "submit", :name=>"submit", :source => "commit1", :match=>'commit2', :value => t('.commit_proposal'), :'data-remote'=>'true', :'data-confirm' => t('.apply_changes')}
       %input.button{:type => "submit", :name => "submit", :source=>"save1", :match=>"save2", :value => t('.save_proposal'), :'data-remote'=>"true"}
-  %h2= link_to "#{@proposal.barclamp.titlecase}: #{@proposal.name.titlecase}", barclamp_modules_path(:id=>@proposal.barclamp)
+  - if @service_object.simple_proposal_ui? && !Kernel.const_get("#{barclamp.camelize}Service").method(:allow_multiple_proposals?).call
+    %h2= link_to "#{@proposal.barclamp.titlecase}", barclamp_modules_path(:id=>@proposal.barclamp)
+  - else
+    %h2= link_to "#{@proposal.barclamp.titlecase}: #{@proposal.name.titlecase}", barclamp_modules_path(:id=>@proposal.barclamp)
 
   %input#barclamp{:type => "hidden", :name => "barclamp", :value => @proposal.barclamp}
   %input#name{:type => "hidden", :name => "name", :value => @proposal.name}

--- a/crowbar_framework/app/views/barclamp/show.html.haml
+++ b/crowbar_framework/app/views/barclamp/show.html.haml
@@ -5,7 +5,10 @@
   = link_to t('.edit'), "/crowbar/#{@role.barclamp}/1.0/proposals/#{@role.inst}", :class => 'button'
 
 .led.unknown{:id => prop, :title=>t('proposal.status.unknown'), :style=>'float:left;'}
-%h1= link_to "#{@role.barclamp.titlecase}: #{@role.inst.titlecase}", barclamp_modules_path(:id=>@role.barclamp)
+- if @service_object.simple_proposal_ui? && !Kernel.const_get("#{barclamp.camelize}Service").method(:allow_multiple_proposals?).call
+  %h1= link_to "#{@role.barclamp.titlecase}", barclamp_modules_path(:id=>@role.barclamp)
+- else
+  %h1= link_to "#{@role.barclamp.titlecase}: #{@role.inst.titlecase}", barclamp_modules_path(:id=>@role.barclamp)
 
 .box
   %h2= t '.attributes'


### PR DESCRIPTION
We will have "Nova", instead of "Nova: Default".

The default mode isn't changed.
