### PR TITLE
avoid undefined method `foo' for nil:NilClass when state is nil

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -300,7 +300,7 @@ class NodeObject < ChefObject
       since_last = Time.now.to_i-@node['ohai_time'].to_i
       return 'noupdate' if since_last > 1200 # or 20 mins
     end
-    return self.crowbar['state']
+    return self.crowbar['state'] || 'unknown'
   end
 
   def ip


### PR DESCRIPTION
[Sometimes node state can be `nil`](https://bugzilla.novell.com/show_bug.cgi?id=838142#c3).  We should consistently return a String (`"unknown"`) even in these cases, to ensure that code like

  node.state.titlecase

doesn't barf.
