### PR TITLE
Avoid browser password safe dialog in barclamp edit forms

### DIFF
--- a/crowbar_framework/app/views/barclamp/_show_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/_show_index.html.haml
@@ -36,7 +36,7 @@
                       %td
                         = link_to t('proposal.actions.edit'), proposal_barclamp_path(:controller=>name, :id=>proposal_name), :class => 'button'
                 - if barclamp[:allow_multiple_proposals] or barclamp[:proposals].length == 0
-                  - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic"} do |f|
+                  - form_for :proposal, :remote => true, :url => create_proposal_barclamp_path(:controller => name), :html => { :'data-type' => 'html', :'data-method' => 'put', :method => :put, :id => 'create_proposal_form', :class => "formtastic", :autocomplete => "off"} do |f|
                     %tr{:class => ["proposal", cycle(:odd, :even)]}
                       %td{:style => "text-align:center"} +
                       %td

--- a/crowbar_framework/app/views/barclamp/proposal_show.html.haml
+++ b/crowbar_framework/app/views/barclamp/proposal_show.html.haml
@@ -7,7 +7,7 @@
 .led.unknown{:id => prop, :title=>t('proposal.status.unknown'), :style=>'float:left'} 
 %h1= t '.title'
 -# Rails 2 needs - and Rails 3 needs =
-- form_for :proposal, :url => update_proposal_barclamp_path(:id => @proposal.name, :controller => @proposal.barclamp), :html => { :method => :post, :'data-type' => 'html', :id => 'update_proposal_form', :class => "box" } do |f|
+- form_for :proposal, :url => update_proposal_barclamp_path(:id => @proposal.name, :controller => @proposal.barclamp), :html => { :method => :post, :'data-type' => 'html', :id => 'update_proposal_form', :class => "box", :autocomplete => "off" } do |f|
   %p{:style=>'float:right'}
     - if @proposal["deployment"][@proposal.barclamp]["crowbar-committing"].nil? or !@proposal["deployment"][@proposal.barclamp]["crowbar-committing"]
       - if @active


### PR DESCRIPTION
For example, cinder backend password input tags trigger that but the only password worth storing would be the crowbar admin password (if we would use Rails instead of digest-auth).
