### PR TITLE
Do not save node on allocate if already node is already allocated

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -975,6 +975,7 @@ class NodeObject < ChefObject
   def allocate
     return if @node.nil?
     return if @role.nil?
+    return if self.allocated?
     self.allocated = true
     save
   end


### PR DESCRIPTION
This fixes an issue where the save call done for the allocation is
racing with the save call of a state transition for the same node.

It's not optimal for sure, though.
