### PR TITLE
Fix style issue w/ error led being too large [1/1]

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/_errors.sass
+++ b/crowbar_framework/app/assets/stylesheets/_errors.sass
@@ -1,4 +1,4 @@
-.error
+.fail
   margin: 1em auto
   padding: 2em 4em 2em 250px
   background-image: url('/images/failbunny.png')

--- a/crowbar_framework/app/views/snapshots/anneal.html.haml
+++ b/crowbar_framework/app/views/snapshots/anneal.html.haml
@@ -2,7 +2,7 @@
 - if @snapshot and state == NodeRole::TODO
   %p{:style => 'float:right'}
     = link_to t('.anneal'), snapshot_anneal_path(@snapshot.id, :step=>Rails.env.development?), :class => 'button', :"data-method"=>:put
-%table
+%table.plane
   %tr
     %td
       .led{:class => NodeRole::STATES[state || NodeRole::ERROR], :title=>NodeRole.state_name(state)}

--- a/crowbar_framework/public/404.html
+++ b/crowbar_framework/public/404.html
@@ -15,7 +15,7 @@
       </div>
     </header>
     <div class='container'>
-      <div id="error_404" class="error box">
+      <div id="error_404" class="fail box">
       <div class="message">
         <h2>We can't find the page you're looking for</h2>
         <p>Please double check the URL you're trying to reach or consult your <a href="/utils">log files</a>.</p>

--- a/crowbar_framework/public/500.html
+++ b/crowbar_framework/public/500.html
@@ -15,7 +15,7 @@
       </div>
     </header>
     <div class='container'>
-      <div width=100px id="error_500" class="error box">
+      <div width=100px id="error_500" class="fail box">
       <div class="message">
         <h2>We're sorry, but something went wrong.</h2>
         <p>Please consult your <a href="/utils">log files</a> or double check the URL you're trying to reach.</p>


### PR DESCRIPTION
Minor style glitch created when I added a led error class.

 .../app/assets/stylesheets/_errors.sass            |    2 +-
 .../app/views/snapshots/anneal.html.haml           |    2 +-
 crowbar_framework/public/404.html                  |    2 +-
 crowbar_framework/public/500.html                  |    2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: de578b20048cc7b48ec2024b277cbaf74444b4ad

Crowbar-Release: development
