### PR TITLE
Always show reboot/shutdown, except for admin node

### DIFF
--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -3,11 +3,15 @@
 %h1{:title=>@node.description}= "#{@node.alias} (#{link_to t('edit'), edit_node_path(@node.handle)})"#.html_safe
 
 %ul.buttons
-  %li= link_to "Reboot", hit_node_path(@node.handle, 'reboot'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure') 
-  %li= link_to "Shutdown", hit_node_path(@node.handle, 'shutdown'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-  - if @node.bmc_set?
-    %li= link_to "Power On", hit_node_path(@node.handle, 'poweron'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
-    %li= link_to "Identify", hit_node_path(@node.handle, 'identify'), :class => 'button', :'data-remote' => true
+  - unless @node.admin?
+    %li= link_to "Reboot", hit_node_path(@node.handle, 'reboot'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure') 
+    %li= link_to "Shutdown", hit_node_path(@node.handle, 'shutdown'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+    - if @node.bmc_set?
+      %li= link_to "Power On", hit_node_path(@node.handle, 'poweron'), :class => 'button', :'data-remote' => true, :'data-confirm' => t('are_you_sure')
+      %li= link_to "Identify", hit_node_path(@node.handle, 'identify'), :class => 'button', :'data-remote' => true
+  - else
+    - if @node.bmc_set?
+      %li= link_to "Identify", hit_node_path(@node.handle, 'identify'), :class => 'button', :'data-remote' => true
 
 .column_50.first
   %dl


### PR DESCRIPTION
Reboot/shutdown will also work without IPMI (there's a ssh-based fallback).

For the admin node, poweron doesn't make sense. Also I don't think we want to allow rebooting/shutting down the admin node this way, as there's a risk of the task not completing and therefore breaking some internal consistency.
