### PR TITLE
Add tighter control over how jig runs are queued on a per-node basis, and rework the DNS barclamp to use the new runs infrastructure. [1/4]

### DIFF
--- a/crowbar_framework/app/controllers/node_roles_controller.rb
+++ b/crowbar_framework/app/controllers/node_roles_controller.rb
@@ -101,7 +101,7 @@ class NodeRolesController < ApplicationController
     respond_to do |format|
       format.html { }
       format.json {
-        if NodeRole.anneal! || NodeRole.committed.in_state(NodeRole::TODO).count > 0
+        if NodeRole.committed.in_state(NodeRole::TODO).count > 0
           render :json => { "message" => "scheduled" }, :status => 202
         elsif NodeRole.committed.in_state(NodeRole::TRANSITION).count > 0
           render :json => { "message" => "working" }, :status => 202

--- a/crowbar_framework/app/models/run.rb
+++ b/crowbar_framework/app/models/run.rb
@@ -1,0 +1,74 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Run < ActiveRecord::Base
+
+  belongs_to :node
+  belongs_to :node_role
+
+  attr_accessible :node_role_id, :node_id
+
+  scope :runnable,   -> { where(:running => false).order("id ASC") }
+  scope :running,    -> { where(:running => true) }
+  scope :running_on, ->(node_id) { running.where(:node_id => node_id) }
+
+  def self.cleanup
+    # Clear out any stale runs.
+    Run.running.each do |j|
+      next if j.node_role.state == NodeRole::TRANSITION
+      j.destroy
+    end
+  end
+
+  def self.empty?
+    cleanup
+    Run.all.count == 0
+  end
+  
+  def self.queued?(nr)
+    cleanup
+    Run.where(:node_role_id => nr.id).count > 0
+  end
+
+  # Queue up a job to run.
+  def self.enqueue(nr)
+    Rails.logger.info("Run: Starting Run enqueue for #{nr.inspect}")
+    if nr.todo? && queued?(nr)
+      Rails.logger.info("Run: Already enqueued!")
+      return
+    end
+    Rails.logger.info("Run: Enqueing #{nr.inspect}")
+    Run.create!(:node_id => nr.node_id,
+                :node_role_id => nr.id)
+    run!
+  end
+
+  # Run up to maxjobs jobs.
+  def self.run!(maxjobs=10)
+    cleanup
+    queued = 0
+    Run.runnable.each do |j|
+      next unless Run.running_on(j.node_id).count == 0
+      Rails.logger.info("Run: Running #{j.node_role.inspect}")
+      j.node_role.state = NodeRole::TRANSITION
+      j.running = true
+      j.save!
+      j.node_role.jig.delay(:queue => "NodeRoleRunner").run(j.node_role)
+      queued += 1
+      break if queued >= maxjobs
+    end
+    return queued
+  end
+end

--- a/crowbar_framework/db/migrate/20130928_create_runs.rb
+++ b/crowbar_framework/db/migrate/20130928_create_runs.rb
@@ -1,0 +1,28 @@
+# Copyright 2013, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class CreateRuns < ActiveRecord::Migration
+  def change
+    create_table :runs do |t|
+      t.belongs_to  :node_role,         :null=>false
+      t.belongs_to  :node,              :null=>false
+      t.boolean     :running,           :null=>false, :default => false
+    end
+
+    add_index(:runs, :node_role_id)
+    add_index(:runs, :node_id)
+    add_index(:runs, :running)
+  end
+end


### PR DESCRIPTION
This pull request adds a few new features:
- Move most of the annealing responsibilites to a newly-created Run
  class.  This allows to to more easily enforce our one jig run at a
  time per node rule, and gives us a nicer place to control what kind
  of parallelism we use.
- Fix up the DNS barclamp to use the new Run infrastructure and the
  on_node_\* hooks to manage our DNS infrastructure.  This will also
  act as a template for similar changes needed for the DHCP
  infrastructure.
- Minor update to the provisioner barclamp to handle bringing up the
  node properly in the face of the Runs and DNS barclamp changes.
  
  .../app/controllers/node_roles_controller.rb       |  2 +-
  crowbar_framework/app/models/node.rb               | 14 ++--
  crowbar_framework/app/models/node_role.rb          | 64 ++++++-------------
  crowbar_framework/app/models/run.rb                | 74 ++++++++++++++++++++++
  .../db/migrate/20130928_create_runs.rb             | 28 ++++++++
  5 files changed, 125 insertions(+), 57 deletions(-)

Crowbar-Pull-ID: b8895885003093f140e37ed4f5efc36a05f38852

Crowbar-Release: development
