### PR TITLE
Stablize barclamp display order in the snapshots screen. [1/1]

### DIFF
--- a/crowbar_framework/app/controllers/snapshots_controller.rb
+++ b/crowbar_framework/app/controllers/snapshots_controller.rb
@@ -35,7 +35,7 @@ class SnapshotsController < ApplicationController
           n = nr.node
           bc = nr.role.barclamp
           @nodes[n.id] = n unless n.nil? or @nodes.has_key? n.id
-          @barclamps[bc.id] = bc unless bc.nil? or @barclamps.has_key? bc.id            
+          @barclamps[bc.id] = bc unless bc.nil? or @barclamps.has_key? bc.id
           # build the node_role grid
           unless n.nil? or bc.nil?
             @node_roles[n.id] ||= []
@@ -48,6 +48,7 @@ class SnapshotsController < ApplicationController
           b = Barclamp.find :first
           @barclamps[b.id] = b
         end
+        @barclamps = @barclamps.values.sort
         }
       format.json { render api_show :snapshot, Snapshot }
     end

--- a/crowbar_framework/app/views/snapshots/show.html.haml
+++ b/crowbar_framework/app/views/snapshots/show.html.haml
@@ -1,7 +1,7 @@
 - state = @snapshot.state
 %table{:width=>'100%'}
   %tr
-    %td 
+    %td
       .led{:class => Snapshot::STATES[state], :title=>Snapshot.state_name(state)}
     %td
       %h1
@@ -15,17 +15,17 @@
   %thead
     %tr
       %th= t '.nodes'
-      - @barclamps.each do |bcid, barclamp|
-        %th= link_to barclamp.name, barclamp_path(bcid)
+      - @barclamps.each do |barclamp|
+        %th= link_to barclamp.name, barclamp_path(barclamp.id)
   %tbody
     - @nodes.each do |nid, node|
       %tr{:class => ["node", cycle(:odd, :even)], :id => nid}
         %td{:width=>'5%'}= link_to node.alias, node_path(nid), :title=>node.description
-        -@barclamps.each do |bid, bc|
+        -@barclamps.each do |bc|
           %td
-            - if @node_roles[nid][bid]
+            - if @node_roles[nid][bc.id]
               %span
-                - @node_roles[nid][bid].each do |nr|
+                - @node_roles[nid][bc.id].each do |nr|
                   - unless nr.nil?
                     %span.led{:style=>"float:left", :class => NodeRole::STATES[nr.state || NodeRole::ERROR], :title=>nr.role.name}
                       = link_to "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;".html_safe, node_role_path(nr.id)


### PR DESCRIPTION
This makes barclamps display in dependency order in the snapshots screen.

Now the display order of the barclamps approximates the order in which noderoles will be run, and will be stable across installs.

 .../app/controllers/snapshots_controller.rb        |  3 +-
 .../app/views/snapshots/show.html.haml             | 80 +++++++++++-----------
 2 files changed, 42 insertions(+), 41 deletions(-)

Crowbar-Pull-ID: 9a766224a2a9ed389353e08743c12edad8b490ff

Crowbar-Release: development
