### PR TITLE
Inter-doc navigation + some minor changes [1/1]

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/_common.sass
+++ b/crowbar_framework/app/assets/stylesheets/_common.sass
@@ -12,7 +12,6 @@ h3, label.h3
   font-style: normal
   font-weight: bold
   text-transform: normal
-  color: #47433A
 
 h4
   font-size: 15px

--- a/crowbar_framework/app/assets/stylesheets/_nav.sass
+++ b/crowbar_framework/app/assets/stylesheets/_nav.sass
@@ -1,0 +1,57 @@
+.nav-container
+  position: relative
+  width: 100%
+  height: 1em
+  padding-bottom: 1em
+  margin-bottom: 1em
+  text-align: center
+  font-size: small
+  border-bottom-style: solid
+  border-bottom-width: thin
+
+.nav-prev, .nav-up, .nav-next
+  display: inline-block
+  position: relative
+  width: 0
+  z-index: 2
+  & a
+    white-space: nowrap
+    position: absolute
+
+.nav-prev
+  text-align: left
+  float: left
+  & a
+    left: 0
+  & a:before
+    content: '<-- '
+
+.nav-up
+  width: 100%
+  text-align: center
+  float: left
+  z-index: 1
+  & a
+    position: relative
+  & a:before
+    content: '^ '
+  & a:after
+    content: ' ^'
+
+.nav-next
+  text-align: right
+  float: right
+  & a
+    right: 0
+  & a:after
+    content: ' -->'
+
+.edit-link
+  float: right
+  font-size: small
+  &:hover
+    text-decoration: none
+
+.mini-edit-link, a.mini-edit-link, .mini-edit-link a
+  font-size: small
+  color: tomato

--- a/crowbar_framework/app/assets/stylesheets/_toc.sass
+++ b/crowbar_framework/app/assets/stylesheets/_toc.sass
@@ -1,11 +1,11 @@
 .toc
   float: right
   font-size: 12px
-  line-height: 12px
+  line-height: 15px
   margin-left: 50px
   margin-right: 50px
 
-.toc ol
+.toc ol, .toc ul
   margin-left: 1em
   padding-left: 1em
   margin-right: 1em

--- a/crowbar_framework/app/assets/stylesheets/application.sass
+++ b/crowbar_framework/app/assets/stylesheets/application.sass
@@ -13,6 +13,7 @@ header, section, article, footer, nav
 @import formtastic
 @import errors
 @import toc
+@import nav
 @import layercake
 
 @import variables

--- a/crowbar_framework/app/views/docs/_tree.html.haml
+++ b/crowbar_framework/app/views/docs/_tree.html.haml
@@ -1,4 +1,7 @@
-%li= link_to tree.description, Doc.doc_path(tree.name)
+%li{:id=>tree.id.to_s}
+  %a{:class=>"mini-edit-link", :href=>tree.git_url}<
+    [e]
+  = link_to tree.description, Doc.doc_path(tree.name)
 - if tree.children.length > 0
   %ul
     = render partial: 'tree', collection: tree.children.sort

--- a/crowbar_framework/app/views/docs/index.html.haml
+++ b/crowbar_framework/app/views/docs/index.html.haml
@@ -3,29 +3,13 @@
 / Table of Contents
 %div(class="toc box")
   %h2= t('.toc_title')
-  %ol(type="A")
-    %li
-      %a(href="#framework")= t('.framework_display')
-    %li
-      %a(href="#barclamps")= t('.barclamps_display')
-    %ol(type="1")
-      - Barclamp.all.each do |bc|
-        %li
-          %a{:href=>"##{bc.name}"}= bc.display
+  %ol(type="1")
+    - Doc.roots.sort.each do |x|
+      %li
+        %a{:href=>"##{x.id}"}= truncate(x.description)
 
-/ Crowbar Framework docs
-%h2
-  %div{:title=>t('.framework_description'), :id=>'framework'}= t('.framework_display')
+/ Full Index
 %ul
-  = render partial: 'tree', collection: Doc.roots_by_barclamp(nil).sort
-
-/ Barclamp docs
-%h2
-  %div{:title=>t('.barclamps_description'), :id=>'barclamps'}= t('.barclamps_display')
-- Barclamp.all.each do |bc|
-  %h3
-    %div{:title=>bc.description, :id=>bc.name}= bc.display
-  %ul
-    = render partial: 'tree', collection: Doc.roots_by_barclamp(bc.id).sort
+  = render partial: 'tree', collection: Doc.roots.sort
 
 .clear

--- a/crowbar_framework/app/views/docs/show.html.haml
+++ b/crowbar_framework/app/views/docs/show.html.haml
@@ -2,4 +2,21 @@
 
 -# %p= @doc.inspect
 
+%div(class='nav-container')
+  - if @nav_prev
+    %div(class='nav-prev')
+      %a{:href=>"/docs/#{@nav_prev.name}"}
+        = "previous page (#{truncate @nav_prev.description})"
+  - if @nav_up
+    %div(class='nav-up')
+      %a{:href=>"/docs/#{@nav_up.name}"}
+        = "up (#{truncate @nav_up.description})"
+  - if @nav_next
+    %div(class='nav-next')
+      %a{:href=>"/docs/#{@nav_next.name}"}
+        = "next page (#{truncate @nav_next.description})"
+
+%a{:href=>@doc.git_url, :class=>"edit-link box"}
+  Edit this page on GitHub
+
 %p.topic= @text.html_safe rescue "oops, render broken"

--- a/crowbar_framework/db/migrate/20120722130500_create_docs.rb
+++ b/crowbar_framework/db/migrate/20120722130500_create_docs.rb
@@ -16,9 +16,9 @@ class CreateDocs < ActiveRecord::Migration
   def self.up
 
     create_table :docs do |t|
-      t.string      :name
+      t.text        :name
       t.belongs_to  :barclamp, :null=>true
-      t.string      :description, :null=>true
+      t.text        :description, :null=>true
       t.belongs_to  :parent, :null=>true
       t.string      :order, :length=>5, :default => '009999'
       t.timestamps

--- a/doc/devguide/documentation.md
+++ b/doc/devguide/documentation.md
@@ -8,21 +8,21 @@ This information is available as a video! see http://youtu.be/eWHeEWiOEvo
 
 #### Composite Documentation
 
-It is vital to understand that the Crowbar documentation system is _composite documentation._  That means that the information is assembled from multiple barclamps on the fly.  This is required because the Crowbar framework is really a collection of barclamps and each barclamp has its own capabilities and features.
+It is vital to understand that the Crowbar documentation system is _composite documentation._  That means that the information is assembled from multiple barclamps on the fly. This is required because the Crowbar framework is really a collection of barclamps and each barclamp has its own capabilities and features.
 
 The design of the documentation system allows each barclamp to contribute parts to the overall whole _and also_ allows parts to cross reference each other.
 
-For example, each barclamp is expected to contribute "barclamp" and "license" information.  These pages only refer to the individual barclamp's data; however, they are rolled up under the barclamp and license sections of the documentation.  For Crowbar suite barclamps, they are further grouped under the master Crowbar set.  That means that the Deployer license information depends on the Crowbar Meta information.
+For example, each barclamp is expected to contribute "barclamp" and "license" information. These pages only refer to the individual barclamp's data; however, they are rolled up under the barclamp and license sections of the documentation. For Crowbar suite barclamps, they are further grouped under the master Crowbar set. That means that the Deployer license information depends on the Crowbar Meta information.
 
-While this adds complexity for the documentation author, it greatly simplify the documentation reading experience for the user.  It also allows developers to isolate documentation changes.
+While this adds complexity for the documentation author, it greatly simplify the documentation reading experience for the user. It also allows developers to isolate documentation changes.
 
 #### Table of Contents - Directory Tree Layout
 
-By design, the table of contents generally follows the directory structure of the documentation.  This is intentional because it simplifies composition.
+By design, the table of contents generally follows the directory structure of the documentation. This is intentional because it simplifies composition.
 
 Each subdirectory should be paired with a matching topic document that functions as the index for the items in the subdirectory.
 
-For example, 
+For example,
 
     devguide.md
     devguide/
@@ -33,18 +33,18 @@ For example,
         testing.md
         testing/
 
-In the above example, the `devguide` topic layout out general information for the developer guide.  The `api` and `testing` sections would be shown as sections of the Developer Guide.  Individual API topics `node` and `group` are subsections of the API topic.
+In the above example, the `devguide` topic layout out general information for the developer guide. The `api` and `testing` sections would be shown as sections of the Developer Guide. Individual API topics `node` and `group` are subsections of the API topic.
 
 > The convention of having an the index topic name (`api.md`) match the subfolder (`api/`) makes it easier for Crowbar to assemble to table of contents without extra meta data.
 
 If no hints (see index below) are given, Crowbar will automatically scan the subdirectory tree and build the table of contents based on the file path naming convention.
 
 #### Index
-There is a documentation tree index (`[barclamp].yml`) for each barclamp.  The index is a yml file which builds the documentation tree by deep merging all the barclamp indexes together.
+There is a documentation tree index (`[barclamp].yml`) for each barclamp. The index is a yml file which builds the documentation tree by deep merging all the barclamp indexes together.
 
-> The index _must_ be named the same as the barclamp.  So each barclamp provides "barclamp.yml" in the `doc` directory.  These files are merged together during the barclamp install. 
+> The index _must_ be named the same as the barclamp. So each barclamp provides "barclamp.yml" in the `doc` directory. These files are merged together during the barclamp install.
 
-The index has an entry for each topic page that follows the following pattern: `barclamp/topic`.  The `/` is required!
+The index has an entry for each topic page that follows the following pattern: `barclamp/topic`. The `/` is required!
 
 > You can comment out a page from being automatically index by prefixing its name with `#`
 
@@ -56,9 +56,9 @@ The index file should be nested so that topics have correct parents.
 
 ##### Ordering
 
-You can control the order of documents within a directory by prefixing the file with a number followed by the underscore.
+You can control the order of documents within a directory by prefixing the file with a number followed by an underscore.
 
-For example, a file named 333_sample_order.md would be ordered as 333.
+For example, a file named `333_sample_order.md` would be ordered as 333.
 
 > If you omit order, the system defaults to 9999.
 


### PR DESCRIPTION
- Inter-doc navigation (previous, next, up).
- Removed organization of index by barclamp.
- Fixed some minor issues.
- Add edit links to GitHub.
  
  .../app/assets/stylesheets/_common.sass            |    1 -
  crowbar_framework/app/assets/stylesheets/_nav.sass |   44 ++++++++++++++++++++
  crowbar_framework/app/assets/stylesheets/_toc.sass |    4 +-
  .../app/assets/stylesheets/application.sass        |    1 +
  .../app/controllers/docs_controller.rb             |   43 ++++++++++++++++---
  crowbar_framework/app/models/doc.rb                |   18 ++++----
  crowbar_framework/app/views/docs/_tree.html.haml   |    3 +-
  crowbar_framework/app/views/docs/index.html.haml   |   28 +++----------
  crowbar_framework/app/views/docs/show.html.haml    |   14 +++++++
  doc/devguide/documentation.md                      |   22 +++++-----
  10 files changed, 125 insertions(+), 53 deletions(-)

Crowbar-Pull-ID: 2cc39cf3de5eeeb81349f7ed27534f2335009f68

Crowbar-Release: development
