### PR TITLE
Network Map prototype and expose Parent Deployment [1/2]

### DIFF
--- a/BDD/crowbar.erl
+++ b/BDD/crowbar.erl
@@ -117,14 +117,8 @@ step(Global, {step_setup, {Scenario, _N}, Test}) ->
   bdd_crud:create(node:g(path), Node, g(node_atom));
 
 % find the node from setup and remove it
-step(Global, {step_teardown, {Scenario, _N}, _}) -> 
+step(_Global, {step_teardown, {_Scenario, _N}, _}) -> 
   bdd_utils:log(debug, crowbar, step, "Global Teardown running",[]),
-  % turn on the delays in the test jig
-  role:step(Global, {step_given, {Scenario, _N}, ["I set the",role, "test-admin", "property", "test", "to", "true"]}), 
-  role:step(Global, {step_given, {Scenario, _N}, ["I set the",role, "test-server", "property", "test", "to", "true"]}), 
-  role:step(Global, {step_given, {Scenario, _N}, ["I set the",role, "test-client", "property", "test", "to", "true"]}), 
-  role:step(Global, {step_given, {Scenario, _N}, ["I set the",role, "test-library", "property", "test", "to", "true"]}), 
-  role:step(Global, {step_given, {Scenario, _N}, ["I set the",role, "test-discovery", "property", "test", "to", "true"]}), 
   % remove node for testing
   bdd_crud:delete(g(node_atom));
 

--- a/BDD/features/deployment.feature
+++ b/BDD/features/deployment.feature
@@ -15,6 +15,7 @@ Feature: Deployments
     Given I am on the "deployments" page
     Then I should see a heading {bdd:crowbar.i18n.deployments.index.title}
       And I should see "system"
+      And I should see {apply:crowbar.i18n.deployments.index.parent}
       And there are no localization errors
 
   Scenario: Deployment UI click to Snapshot
@@ -48,3 +49,17 @@ Feature: Deployments
       And I should not see "something went wrong"
       And there should be no translation errors
     Finally REST removes the {object:deployment} "bdd_deploy_showme"
+
+  Scenario: New Deployment is child of System
+    Given there is a {object:deployment} "bdd_deploy_child"
+    When REST gets the {object:deployment} "bdd_deploy_child"
+    Then key "parent_id" should be "1"
+    Finally REST removes the {object:deployment} "bdd_deploy_child"
+
+  Scenario: Parent Deployment shown on UI
+    Given there is a {object:deployment} "bdd_deploy_child_ui"
+    When I go to the "deployments/bdd_deploy_child_ui" page
+    Then I should see "Child of"
+      And I should see a link to "system"
+    Finally REST removes the {object:deployment} "bdd_deploy_child_ui"
+  

--- a/crowbar_framework/app/models/deployment.rb
+++ b/crowbar_framework/app/models/deployment.rb
@@ -32,7 +32,7 @@ class Deployment < ActiveRecord::Base
   has_one           :snapshot,            :class_name => "Snapshot", :primary_key => "snapshot_id", :foreign_key => 'id', :dependent => :destroy
   alias_attribute   :head,                :snapshot
 
-  belongs_to        :parent,              :class_name => "Deployment", :primary_key => "parent_id"
+  belongs_to        :parent,              :class_name => "Deployment"
   has_many          :nodes
 
   scope             :system_root,         -> { where(:system=>true) }   # cannot be named 'system' because of internal method name conflicts

--- a/crowbar_framework/app/views/deployments/index.html.haml
+++ b/crowbar_framework/app/views/deployments/index.html.haml
@@ -14,6 +14,7 @@
       %th= t '.description'
       %th= t '.status'
       %th= t '.active'
+      %th= t '.parent'
       %th= t '.actions'
   %tbody
     - @list.each do |d|
@@ -23,5 +24,8 @@
         %td= d.description
         %td
           .led{:class => Snapshot::STATES[state], :title=>Snapshot.state_name(state)}
-        %td= link_to d.head.name, snapshot_path(d.head.id)
+        %td= link_to d.head.name, snapshot_path(d.head.id), :title=>d.head.description
+        %td
+          - if d.parent_id
+            = link_to d.parent.name, deployment_path(d.parent_id), :title=>d.parent.description
         %td= render :partial => 'buttons', :locals => { :state=>state, :snapshot=>d.head } rescue 'buttons?'

--- a/crowbar_framework/app/views/deployments/show.html.haml
+++ b/crowbar_framework/app/views/deployments/show.html.haml
@@ -1,4 +1,4 @@
-- state = @deployment.state
+- state = @deployment.state rescue Snapshot::ERROR
 
 %h1
   = "#{@deployment.name} #{Snapshot.state_name(state)}"
@@ -10,9 +10,17 @@
   %tr
     %td
       .led{:class => Snapshot::STATES[state], :title=>Snapshot.state_name(state)}
-    %td= @deployment.description
+    %td
+      = @deployment.description
     %td{:align=>'right'}
       = render :partial => 'buttons', :locals => { :state=>state, :snapshot=>@deployment.head }
+  - if @deployment.parent_id
+    %tr
+      %td
+      %td
+        = t '.parent'
+        = link_to @deployment.parent.name, deployment_path(@deployment.parent.id), :title=>@deployment.parent.description
+      %td
 
 = form_for :deployment, :'data-remote' => true, :url => deployment_roles_path(:deployment_id=>@deployment.id), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
   - aroles = @deployment.available_roles

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -201,12 +201,14 @@ en:
       actions: "Actions"
       default: "default"
       create: "Add"
+      parent: "Parent"
       <<: *deployment_common
     show:
       snapshots: "History"
       assign: "Assign Nodes to Roles"
       roles: "Assigned Roles"
       nodes: "Available Nodes"
+      parent: "Child of "
       <<: *deployment_common
       add_role: "Add"
     buttons:

--- a/doc/devguide/devtool-build.md
+++ b/doc/devguide/devtool-build.md
@@ -43,7 +43,10 @@ During the build process the Dev Tool has to perform certain tasks which require
     sudo apt-get update
     sudo apt-get install git rpm ruby rubygems1.9 curl build-essential debootstrap \
     mkisofs binutils markdown erlang debhelper python-pip \
-    build-essential libopenssl-ruby1.9 libssl-dev zlib1g-dev
+    build-essential libopenssl-ruby1.9 libssl-dev zlib1g-dev 
+    # Crowbar 2 uses PostgreSQL 9.3, you may have to install that via download (http://www.postgresql.org/download) if the following does not work
+    sudo apt-get install postgresql-9.3 pgadmin3
+
 
     # switch to Ruby 1.9 you need the following (do NOT do this for 1.x dev work!)
     sudo update-alternatives --config ruby (to make Ruby 1.9.1 the default. ruby -v will report version 1.9.3)
@@ -51,7 +54,7 @@ During the build process the Dev Tool has to perform certain tasks which require
 
     # let's install some needed gems next
     sudo gem install ruby1.9.1-dev builder bluecloth
-    sudo gem install json net-http-digest_auth kwalify bundler delayed_job delayed_job_active_record rake rcov rspec --no-ri --no-rdoc
+    sudo gem install json net-http-digest_auth kwalify bundler delayed_job delayed_job_active_record rake rcov rspec pg --no-ri --no-rdoc
 
 #### Put the needed base ISOs in place
 As a starting point for the build process we will need the ISOs [mentioned above](#pre-requisites) placed where the Dev Toll can find them. The Dev Tool will then use them during the build process described below.


### PR DESCRIPTION
Adds initial Network/Map view to the Network Barclamp
Adds UI to expose Deploy Parent

BDD testing minimal - needs to be addressed.

1 test fails because of timing issues to be addressed by migrating to postgresql for dev.

 BDD/crowbar.erl                                    |    8 +------
 BDD/dev.erl                                        |   22 +++++++++++++++-----
 BDD/features/deployment.feature                    |   15 +++++++++++++
 crowbar_framework/app/models/deployment.rb         |    2 +-
 .../app/views/deployments/index.html.haml          |    6 +++++-
 .../app/views/deployments/show.html.haml           |   12 +++++++++--
 crowbar_framework/config/locales/crowbar/en.yml    |    2 ++
 doc/devguide/devtool-build.md                      |    7 +++++--
 8 files changed, 56 insertions(+), 18 deletions(-)

Crowbar-Pull-ID: 818ff63843f8669dd6672b800daf568c7aff605f

Crowbar-Release: development
