### PR TITLE
Correct mode of /var/log/crowbar for use in nfs mounting sledgehammer log files [1/1]

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -142,10 +142,11 @@ else
   end
 end
 
+# mode 0755 so subdirs can be nfs mounted to admin-exported shares
 directory logdir do
   owner "crowbar"
   group "crowbar"
-  mode "0750"
+  mode "0755"
   action :create
 end
 


### PR DESCRIPTION
Correct mode of /var/log/crowbar for use in nfs mounting sledgehammer log files
- was 0750
- now 0755
  
  chef/cookbooks/crowbar/recipes/default.rb |    3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 6b43a039cee56aa82dc10472f6e5a936e22c9031

Crowbar-Release: roxy
