### PR TITLE
Fix several Run-related race conditions [1/4]

### DIFF
--- a/crowbar_framework/app/models/barclamp_crowbar/jig.rb
+++ b/crowbar_framework/app/models/barclamp_crowbar/jig.rb
@@ -50,7 +50,11 @@ class BarclampCrowbar::Jig < Jig
     return [out, false]
   end
 
-  def run(nr)
+  def stage_run(nr)
+    return nr.all_transition_data
+  end
+
+  def run(nr,data)
     # Hardcode this for now
     login = "root@#{nr.node.name}"
     local_scripts = "/opt/dell/barclamps/#{nr.barclamp.name}/script/roles/#{nr.role.name}"
@@ -64,7 +68,7 @@ class BarclampCrowbar::Jig < Jig
     end
     local_tmpdir = %x{mktemp -d /tmp/local-scriptjig-XXXXXX}.strip
     Rails.logger.info("Using local temp dir: #{local_tmpdir}")
-    attr_to_shellish(nr.all_transition_data).each do |k,v|
+    attr_to_shellish(data).each do |k,v|
       target = File.join(local_tmpdir,"attrs",k)
       FileUtils.mkdir_p(target)
       File.open(File.join(target,"attr"),"w") do |f|

--- a/crowbar_framework/app/models/jig.rb
+++ b/crowbar_framework/app/models/jig.rb
@@ -76,11 +76,20 @@ class Jig < ActiveRecord::Base
     res
   end
 
+  # Gather all of the data needed for a single noderole run.
+  # This function needs to be overridden by the actual jigs.
+  # It should be run to create whatever information will be needed
+  # for the actual run before doing the actual run in a delayed job.
+  def stage_run(nr)
+    raise "Cannot call stage_run on the top-level jig!"
+  end
+
   # Run a single noderole.
   # The noderole must be in TRANSITION state.
   # This function is intended to be overridden by the jig subclasses,
   # and only used for debugging purposes.
-  def run(nr)
+  # Runs will be run in the background by the dalayed_job information.
+  def run(nr,data)
     raise "Cannot call run on the top-level Jig!"
   end
 
@@ -109,7 +118,11 @@ end
 
 class NoopJig < Jig
 
-  def run(nr)
+  def stage_run(nr)
+    return nil
+  end
+
+  def run(nr,data)
     nr.state = NodeRole::ACTIVE
     nr
   end

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -240,9 +240,7 @@ class Node < ActiveRecord::Base
     if changes["available"] || changes["alive"]
       if alive && available
         Rails.logger.info("Node: #{name} is alive and available, enqueing noderoles to run.")
-        node_roles.runnable.each do |nr|
-          Run.enqueue(nr)
-        end
+        Run.run!
       end
       if changes["alive"] && !alive
         Rails.logger.info("Node: #{name} is not alive, deactivating noderoles on this node.")

--- a/crowbar_framework/app/models/node_role.rb
+++ b/crowbar_framework/app/models/node_role.rb
@@ -324,7 +324,7 @@ class NodeRole < ActiveRecord::Base
       write_attribute("state",TODO)
       save!
     end
-    Run.enqueue(self) if self.runnable?
+    Run.run!
   end
 
   def deactivate
@@ -427,10 +427,8 @@ class NodeRole < ActiveRecord::Base
       # No idea what this is.  Just die.
       raise InvalidState.new("Unknown state #{s.inspect}")
     end
-    # If the new state is TODO, enqueue ourself.
-    Run.enqueue(self) if self.runnable? && val == TODO
-    # Kick the runner every time something transitions to ACTIVE.
-    Run.run! if val == ACTIVE
+    # Kick the runner every time something transitions.
+    Run.run! if val == ACTIVE || val == TODO
     self
   end
 

--- a/crowbar_framework/app/models/snapshot.rb
+++ b/crowbar_framework/app/models/snapshot.rb
@@ -129,6 +129,7 @@ class Snapshot < ActiveRecord::Base
     parent.archive unless parent.nil?
     write_attribute("state",COMMITTED)
     save!
+    Run.run!
     self
   end
   

--- a/script/runner
+++ b/script/runner
@@ -1,4 +1,6 @@
 #!/bin/bash
+export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+set -x
 export TMPDIR=$1
 export ROLE=$2
 


### PR DESCRIPTION
Fix a few races around Runs:
- Only one caller at a time should mess with the Run table.
  Since we are using a database that has the right capabilities,
  throw a table lock into all top-level transactions that mess with
  the Runs table in any way.
- Refactor Run.enqueue and Run.run! to make the former a
  special-purpose function used to bypass some of the one-job-per-node
  rules, and let Run.run! handle all the usual use cases.
- Refactor the jigs to let Run.run! precalculate what any given jig
  will need for a run and then pass that in instead of letting the run
  use whatever state happens to be lying around when delayed_jobs gets
  around to doing its thing.  This helps keep parallel Jig runs
  interconsistent.
  
  .../app/models/barclamp_crowbar/jig.rb             |   8 +-
  crowbar_framework/app/models/jig.rb                |  17 +++-
  crowbar_framework/app/models/node.rb               |   4 +-
  crowbar_framework/app/models/node_role.rb          |   8 +-
  crowbar_framework/app/models/run.rb                | 100 +++++++++++++++------
  crowbar_framework/app/models/snapshot.rb           |   1 +
  script/runner                                      |   2 +
  7 files changed, 99 insertions(+), 41 deletions(-)

Crowbar-Pull-ID: 7e4d4af3d6449b9d69d65e99a3e4e9c72ba47979

Crowbar-Release: development
