### PR TITLE
Only display relevant IP addresses on the node page

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -328,28 +328,35 @@ class NodesController < ApplicationController
         @node.target_platform = find_default_os
         @node.save
       end
-      intf_if_map = @node.build_node_map
-      # build network information (this may need to move into the object)
-      @node.networks.each do |intf, data|
-        if data["usage"] == "bmc"
-          ifname = "bmc"
-          address = @node["crowbar_wall"]["ipmi"]["address"] rescue nil
-        else
-          ifname, ifs, team = @node.lookup_interface_info(data["conduit"])
-          if ifname.nil? or ifs.nil?
-            ifname = "Unknown"
+      # If we're in discovery mode, then we have a temporary DHCP IP address.
+      if not ['discovering', 'discovered', 'hardware-installing', 'hardware-installed'].include? @node.state
+        intf_if_map = @node.build_node_map
+        # build network information (this may need to move into the object)
+        @node.networks.each do |intf, data|
+          if data["usage"] == "bmc"
+            ifname = "bmc"
+            address = @node["crowbar_wall"]["ipmi"]["address"] rescue nil
           else
-            ifname = "#{ifname}[#{ifs.join(",")}]" if ifs.length > 1
+            ifname, ifs, team = @node.lookup_interface_info(data["conduit"])
+            if ifname.nil? or ifs.nil?
+              ifname = "Unknown"
+            else
+              ifname = "#{ifname}[#{ifs.join(",")}]" if ifs.length > 1
+            end
+            address = data["address"]
           end
-          address = data["address"]
+          if address
+            network[data["usage"]] = {} if network[data["usage"]].nil?
+            network[data["usage"]][ifname] = address
+          end
         end
-        if address
-          network[data["usage"]] = {} if network[data["usage"]].nil?
-          network[data["usage"]][ifname] = address
-        end
+        @network = network.sort
+        @network << ['[not managed]', @node.unmanaged_interfaces] unless @node.unmanaged_interfaces.empty?
+      elsif @node.state == 'discovering'
+        @network = [ ['[dhcp]', 'discovering'] ]
+      else
+        @network = [ ['[dhcp]', @node[:ipaddress]] ]
       end
-      @network = network.sort
-      @network << ['[not managed]', @node.unmanaged_interfaces] unless @node.unmanaged_interfaces.empty?
     end
 
     @network

--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -32,7 +32,7 @@ module NodesHelper
     html = ""
     ip_list.each do |network, addresses|
       unless network=='~notconnected' && addresses.nil?
-        if network == '[not managed]'
+        if ['[not managed]', '[dhcp]'].include? network
           html += "<li><b>#{network}:</b> #{addresses.to_a.join(',')}</li>"
         else
           html += "<li><b>#{network}:</b> #{addresses.keys.collect {|k| "#{k}: #{addresses[k]}"}.join(',')}</li>"


### PR DESCRIPTION
When a node is being discovered, what matters is not the allocated IP address (which the node is not using yet), but the temporary DHCP address.

This is important as otherwise, there's no way for people to know how to connect to the node when it's running sledgehammer (for debug purposes, for instance).
