### PR TITLE
Added link for access nova dashboard from admin network [1/2]

### DIFF
--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -58,7 +58,7 @@
       = link_to t('.bmc'), "https://#{@node["crowbar_wall"]["ipmi"]["address"] rescue 'none'}", :target => '_blank'
       - need_sep = true
     - unless @node["crowbar"]["links"].nil?
-      - @node["crowbar"]["links"].each do |name,link|
+      - @node["crowbar"]["links"].sort_by{|name, link| name}.each do |name, link|
         - if need_sep
           , 
         - else


### PR DESCRIPTION
The Nova Dashboard link was changed in the past so that it tries to access the
Nova Dashboard on the public IP address.  This will only work if you are
accessing the Crowbar GUI over a public IP, which in turn you can only do if a
public IP has been assigned to the admin node via a manual CLI command.

Because there is no routing between the admin and public networks, if you are
running the Crowbar GUI from a system on the admin network, the link will not
work.

This fix renames the "Nova Dashboard" link to "Nova Dashboard (public)" and
adds an additional link called "Nova Dashboard (admin)" so that the dashboard
can be accessed from a browser running on a system in either network.

Also added sorting to the links for a little polish.

 crowbar_framework/app/views/nodes/_show.html.haml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 258608da6e26a0df1972264ab112042f1ef6d9c0

Crowbar-Release: roxy
