### PR TITLE
Better error reporting in Crowbar webui

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1229,7 +1229,7 @@ class ServiceObject
       find_counter = 0
       f = File.open("/var/log/crowbar/chef-client/#{pid}.log")
       f.each do |line|
-        if line =~ /={80}/
+        if line == "="*80
            find_counter = l_counter
         end
         l_counter += 1


### PR DESCRIPTION
Rewrite after feedback

Better error reporting in Crowbar via the web interface to support the user:
The last logged lines of the respective chef client run are now displayed if
a propsal fails.
## (Internal reference: https://bugzilla.novell.com/show_bug.cgi?id=797059)

Added error handling for the get_log_lines method

Include Chef error report into log excerpt
