### PR TITLE
Use ActiveRecordStore as session store

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -113,7 +113,7 @@ debs:
     - patch
     # crowbar stuff
     - curl
-    - sqlite
+    - sqlite3
     - libsqlite3-dev
     - libshadow-ruby1.8
     - chef
@@ -252,6 +252,7 @@ gems:
     - haml-(~>3.1)
     - net-http-digest_auth
     - rails-2.3.18
+    - activerecord-2.3.11
     - activesupport-2.3.18
     - bundler
     - builder
@@ -259,7 +260,7 @@ gems:
     - eventmachine
     - rainbows
     - sendfile
-    - sqlite3-ruby
+    - sqlite3
     - app_config-1.0.2
     # rdoc
     - net-ssh-multi

--- a/crowbar_framework/config/environment.rb
+++ b/crowbar_framework/config/environment.rb
@@ -30,7 +30,6 @@ Rails::Initializer.run do |config|
   # Skip frameworks you're not going to use. To use Rails without a database,
   # you must remove the Active Record framework.
   # config.frameworks -= [ :active_record, :active_resource, :action_mailer ]
-  config.frameworks -= [ :active_record ]
   
   # Activate observers that should always be running
   # config.active_record.observers = :cacher, :garbage_collector, :forum_observer

--- a/crowbar_framework/config/initializers/session_store.rb
+++ b/crowbar_framework/config/initializers/session_store.rb
@@ -12,4 +12,4 @@ ActionController::Base.session = {
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rake db:sessions:create")
-# ActionController::Base.session_store = :active_record_store
+ActionController::Base.session_store = :active_record_store


### PR DESCRIPTION
When saving a proposal fails due to JSON validation errors (missing
mappings / options / typos), Crowbar presents a flash message with the
JSON parsing error. However, messages like "743: unexpected token at
'{234 "use_virtualenv": false,..." may easily cross the 4k border that
the default session store (CookieStore) can handle. In these cases,
Crowbar just bails out with a 500.

The only solution is to set a different session_store. MemCacheStore
would probably work too but needs more refactoring due to more funny
session object fiddling inside ApplicationController.rb. Therefore it's
probably best to use good old ActiveRecordStore. However, this
re-introduces the dependency on ActiveRecord and it needs a database.
The default sqlite3 should be sufficient since we don't expect many
users to use crowbar at the same time.

Require sqlite3 gem (sqlite3-ruby was renamed)
