### PR TITLE
Update role binding logic to facilitate running a real workload on Crowbar 2.0 [1/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -32,10 +32,34 @@ barclamp:
     - fedora-18
 
 roles:
-  - name: crowbar
-    jig: script
+  - name: crowbar-admin-node
+    jig: noop
     flags:
       - bootstrap
+      - implicit
+    requires:
+      - deployer-client
+      - network-server
+      - dns-database
+      - provisioner-dhcp-database
+      - provisioner-repos
+  - name: crowbar-managed-node
+    jig: noop
+    flags:
+      - discovery
+      - implicit
+    requires:
+      - deployer-client
+      - logging-client
+      - ntp-client
+      - provisioner-repos
+  - name: crowbar-installed-node
+    jig: noop
+    flags:
+      - implicit
+    requires:
+      - crowbar-managed-node
+      - provisioner-os-install
 
 jigs:
   - name: script

--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -188,7 +188,8 @@ class Barclamp < ActiveRecord::Base
                             :implicit=>flags.include?('implicit'),
                             :bootstrap=>flags.include?('bootstrap'),
                             :discovery=>flags.include?('discovery'),
-                            :server=>flags.include?('server'))
+                            :server=>flags.include?('server'),
+                            :cluster=>flags.include?('cluster'))
         RoleRequire.where(:role_id=>r.id).delete_all
         r.save!
         prerequisites.each { |req| RoleRequire.create :role_id => r.id, :requires => req }

--- a/crowbar_framework/app/models/deployment_role.rb
+++ b/crowbar_framework/app/models/deployment_role.rb
@@ -18,6 +18,8 @@ require 'json'
 class DeploymentRole < ActiveRecord::Base
 
   attr_accessible :id, :role_id, :snapshot_id
+  after_create :role_create_hook
+  before_destroy  :role_delete_hook
 
   belongs_to :snapshot
   has_one    :deployment, :through => :snapshot
@@ -59,4 +61,14 @@ class DeploymentRole < ActiveRecord::Base
     write_attribute("wall",arg)
   end
 
+  private
+
+  def role_create_hook
+    role.on_deployment_create(self)
+  end
+
+  def role_delete_hook
+    role.on_deployment_delete(self)
+  end
+  
 end

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -167,7 +167,11 @@ class Node < ActiveRecord::Base
   end
 
   def active_node_roles
-    NodeRole.on_node(self).in_state(NodeRole::ACTIVE).committed.order("cohort")
+    res = NodeRole.on_node(self).in_state(NodeRole::ACTIVE).committed.order("cohort ASC")
+    res.each do |nr|
+      Rails.logger.info("Node: Found active noderole #{nr.name} in cohort #{nr.cohort}")
+    end
+    res
   end
 
   def all_active_data
@@ -280,7 +284,7 @@ class Node < ActiveRecord::Base
   def add_default_roles
     raise "you must have at least 1 deployment" unless Deployment.count > 0
     Deployment.system_root.first.recommit do |snap|
-      Role.expand(self.admin ? Role.bootstrap.active : Role.discovery.active).sort.each do |r|
+      (self.admin ? Role.bootstrap.active : Role.discovery.active).sort.each do |r|
         r.add_to_node_in_snapshot(self,snap)
       end
     end

--- a/crowbar_framework/db/migrate/20120731225510_create_roles.rb
+++ b/crowbar_framework/db/migrate/20120731225510_create_roles.rb
@@ -30,7 +30,12 @@ class CreateRoles < ActiveRecord::Migration
       t.boolean     :discovery,         :null=>false, :default=>false
       # Indicates that the attributes used by this node should be made available to
       # its children in the noderole graph.
-      t.boolean     :server,            :null=>false, :default=>false  
+      t.boolean     :server,            :null=>false, :default=>false
+      # Indicates that this role implements a clustered service.
+      # When the noderole graph is built, any child noderoles of this service
+      # will be bound to all of the noderoled for this role in the deployment.
+      # The cluster flag and the implicit flag are mutually exclusive.
+      t.boolean     :cluster,           :null=>false, :default=>false
       t.belongs_to  :barclamp,          :null=>false
       t.integer     :cohort
       t.timestamps


### PR DESCRIPTION
 Fix up role logic to help support Ceph
- Add utility roles that other roles can easily depend on to tell when a
  node is in certian states.  Currently, these are:
  - crowbar-managed-node, which indicates that a node has completed the
    initial discovery process,
  - crowbar-admin-node, which indicates that the admin node is alive and
    ready to manage other nodes, and
  - crowbar-installed-node, which indicates that the node has an
    operating system installed and is ready to have a workload deployed on
    it.
- Add on_deployemnt_create and on_deployment_delete hooks to the role
  model.  These are called whenever a deployment role is created or
  destroyed to allow roles to preseed deployment-specific values.  They
  are currently used by the Ceph barclamp to randomly generate unique
  fsid and monitor secrets..
- Add a cluster flag and accompaining logic to roles.  When a role has
  the cluster flag set, add_to_node_in_snapshot will ensure that all of
  the noderoles created as children of any noderoles created for
  noderoles with the cluster flag are fully connected -- all the
  children will depend on all the parents.  This is used to ensure that
  no child noderole will start deploying until all of its parents have
  completed their deploys.
- Modified add_to_node_in_snapshot to recursively create all parent
  noderoles, instead of only doing so with implicit noderoles.
- Modify how we queue roles up for delayed_jobs to be a little more
  stable.
  
  crowbar.yml                                        |  28 ++++-
  crowbar_framework/app/models/barclamp.rb           |   3 +-
  crowbar_framework/app/models/deployment_role.rb    |  12 ++
  crowbar_framework/app/models/node.rb               |   8 +-
  crowbar_framework/app/models/node_role.rb          |  17 ++-
  crowbar_framework/app/models/role.rb               | 140 +++++++++++----------
  crowbar_framework/app/models/run.rb                |   8 +-
  .../db/migrate/20120731225510_create_roles.rb      |   7 +-
  8 files changed, 151 insertions(+), 72 deletions(-)

Crowbar-Pull-ID: f28b0c0c0dce9879a7994eaa07e17b3068198e63

Crowbar-Release: development
