### PR TITLE
remove imports from BDD (also adds WIP page)

### DIFF
--- a/BDD/bdd_catchall.erl
+++ b/BDD/bdd_catchall.erl
@@ -15,7 +15,6 @@
 % 
 -module(bdd_catchall).
 -export([step/2]).
--import(bdd_utils).
 
 step(_Global, {step_given, {Scenario, _N}, ["I mark the logs with",Mark]}) -> 
   URL = bdd_utils:config(marker_url, undefined),

--- a/BDD/crowbar.erl
+++ b/BDD/crowbar.erl
@@ -16,8 +16,6 @@
 -module(crowbar).
 -export([step/2, g/1, state/1, i18n/1, i18n/2, i18n/3, i18n/4, i18n/5, i18n/6, json/1, json/3, parse_object/1]).
 -export([json_build/1]).
--import(bdd_utils).
--import(json).
 -include("bdd.hrl").
 
 g(Item) ->

--- a/BDD/dev.erl
+++ b/BDD/dev.erl
@@ -15,8 +15,6 @@
 
 -module(dev).
 -export([pop/0, pop/1, unpop/0, g/1]).  
--import(bdd_utils).
--import(digest_auth).
 -include("bdd.hrl").
 
 g(Item)         -> 

--- a/BDD/json.erl
+++ b/BDD/json.erl
@@ -17,7 +17,6 @@
 -module(json).
 -export([parse/1, value/2, output/1, pretty/1, keyfind/2, keyfind/3]).
 -export([json_array/3, json_value/2, json_safe/3]).
--import(bdd_utils).
 -record(json, {list=[], raw=[]}).
 -record(jsonkv, {value=[], raw=[]}).
 

--- a/BDD/swift.erl
+++ b/BDD/swift.erl
@@ -16,7 +16,6 @@
 % 
 -module(swift).
 -export([step/2]).
--import(bdd_utils).
 -include("bdd.hrl").
 
 % TEMPORARY REMAPPING

--- a/crowbar_framework/app/views/errors/500.html.haml
+++ b/crowbar_framework/app/views/errors/500.html.haml
@@ -1,0 +1,11 @@
+%div#error_500{:class=>"fail box"}
+  %div.message
+    %h1= "BE DYNAMIC!"
+    %h2= "We can't find the page you're looking for"
+    %p
+      = "Please double check the URL you're trying to reach or consult your "
+      %a{:href=>"/utils"}= "log files"
+    %p
+      = "If this is an application error, we encourage you to visit the"
+      %a{:href=>"http://crowbar.github.io/issues.html"}= "Crowbar site"
+      = "for more information or to submit a bug report."


### PR DESCRIPTION
imports were breaking the BDD on newer erlang versions.  They are not needed.

(also includes a WIP page for dynamic error reporting)
