### PR TITLE
Catch change in return due to erlang version changes [1/1]

### DIFF
--- a/BDD/simple_auth.erl
+++ b/BDD/simple_auth.erl
@@ -124,7 +124,10 @@ request(Config, Method, {URL, Headers, ContentType, Body}, HTTPOptions, Options)
     302 ->
       % we have to shoehorn the port number back into the redirect URL - erlang bug?
       Location = proplists:get_value("location", ResponseHeaders),
-      {http, _, NHost, _Port, NURI, _Params} = http_uri:parse(Location),
+      {http, _, NHost, _Port, NURI, _Params} = case http_uri:parse(Location) of
+	{ok, {http, A, B, C, D, E}} -> {http, A, B, C, D, E};
+        {http, A, B, C, D, E} -> {http, A, B, C, D, E}
+      end,
       CorrectURL = assemble_url(NHost,Port,NURI),
       request(Method, CorrectURL, TrialHeaders, ContentType, Body, HTTPOptions2, Options);
 


### PR DESCRIPTION
Some calls changed with the latest erlang.  This protects against both old and new.

 BDD/simple_auth.erl | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: a3753c2a3ec2775a1d4b33c93364838d0de845e4

Crowbar-Release: development
