### PR TITLE
extending 'wait for chef' for other states

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -940,7 +940,7 @@ class NodeObject < ChefObject
       save
     end
 
-    if state == "reset" or state == "reinstall" or state == "update"
+    if %w(reset reinstall update).include? state
       # wait with reboot for the finish of configuration update by local chef-client
       # (so dhcp & PXE config is prepared when node is rebooted)
       while File.exist?("/var/run/crowbar/chef-client.lock")


### PR DESCRIPTION
Before the node is rebooted for reinstallation or after de-allocation, we need to wait for local chef-client to write pxe/dhcp config, so rebooted nodes can correctly pxe-boot.

https://bugzilla.novell.com/show_bug.cgi?id=844681
