### PR TITLE
Better error reporting in Crowbar webui

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1099,7 +1099,7 @@ class ServiceObject
             unless badones.empty?
               message = "Failed to apply the proposal to: "
               badones.each do |baddie|
-                message = message + "#{pids[baddie[0]]} "
+                message = message + "#{pids[baddie[0]]} \n"+ get_log_lines("#{pids[baddie[0]]}")
               end
               update_proposal_status(inst, "failed", message)
               restore_to_ready(all_nodes)
@@ -1134,7 +1134,7 @@ class ServiceObject
             unless badones.empty?
               message = "Failed to apply the proposal to: "
               badones.each do |baddie|
-                message = message + "#{pids[baddie[0]]} "
+                message = message + "#{pids[baddie[0]]} \n "+ get_log_lines("#{pids[baddie[0]]}")
               end
               update_proposal_status(inst, "failed", message)
               restore_to_ready(all_nodes)
@@ -1302,6 +1302,29 @@ class ServiceObject
     if @validation_errors && @validation_errors.length > 0
       Rails.logger.info "validation errors in proposal #{@bc_name}"
       raise Chef::Exceptions::ValidationFailed.new("#{@validation_errors.join("\n")}\n")
+    end
+  end
+
+  def get_log_lines(pid)
+    begin
+      l_counter = 1
+      find_counter = 0
+      f = File.open("/var/log/crowbar/chef-client/#{pid}.log")
+      f.each do |line|
+        if line == "="*80
+           find_counter = l_counter
+        end
+        l_counter += 1
+      end
+      f.seek(0, IO::SEEK_SET)
+      if (find_counter > 0) && (l_counter - find_counter) < 50
+        "Most recent logged lines from the Chef run: \n\n" + f.readlines[find_counter -3..l_counter].join(" ")
+      else
+        "Most recent logged lines from the Chef run: \n\n" + f.readlines[l_counter-50..l_counter].join(" ")
+      end
+    rescue
+      @logger.error("Error reporting: Couldn't open /var/log/crowbar/chef-client/#{pid}.log ")
+      raise "Error reporting: Couldn't open  /var/log/crowbar/chef-client/#{pid}.log"
     end
   end
 end


### PR DESCRIPTION
After adding the feature to release/pebbles/master, this is now the pull request to bring it to release/roxy/master

Better error reporting in Crowbar via the web interface to support the user:
The last logged lines of the respective chef client run are now displayed if
a propsal fails.

This change has been discussed in https://github.com/crowbar/barclamp-crowbar/pull/747 before.
