### PR TITLE
Use chef-solo for all core Crowbar barclamps. [1/10]

### DIFF
--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -183,7 +183,7 @@ class Barclamp < ActiveRecord::Base
         r = Role.find_or_create_by_name(:name=>role_name, :jig_name => role_jig, :barclamp_id=>barclamp.id)
         r.update_attributes(:description=>description,
                             :barclamp_id=>barclamp.id,
-                            :template=>(IO.read(template) rescue "{\"template\":\"none\"}"),
+                            :template=>(IO.read(template) rescue "{}"),
                             :library=>flags.include?('library'),
                             :implicit=>flags.include?('implicit'),
                             :bootstrap=>flags.include?('bootstrap'),


### PR DESCRIPTION
This pull request has the following changes:
- Add a chef-solo jig that uses chef-solo to make changes to nodes.
  The chef jig still exists, but it is not used or installed by
  default.
- Port all roles that used the chef jig to use chef-solo, making
  whatever minor fixups are needed along the way.
  
  crowbar_framework/app/models/barclamp.rb |  2 +-
  crowbar_framework/app/models/jig.rb      | 25 ++++++++++++++++++++++++-
  crowbar_framework/app/models/run.rb      | 12 +++++++++---
  3 files changed, 34 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: bbc20a06dbbdfd0b2f1725d18b4220bf28a9a536

Crowbar-Release: development
