### PR TITLE
generalize the one-role validation

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -41,6 +41,10 @@ class ServiceObject
     false
   end
 
+  def validation_error message
+    @logger.warn message
+    @validation_errors << message
+  end
 
   def simple_proposal_ui?
     proposals = ProposalObject.find_proposals("crowbar")
@@ -757,7 +761,7 @@ class ServiceObject
     elements = proposal["deployment"][@bc_name]["elements"]
 
     if not elements.has_key?(role) or elements[role].length != 1
-      @validation_errors << "Need one (and only one) #{role} node."
+      validation_error("Need one (and only one) #{role} node.")
     end
   end
 


### PR DESCRIPTION
This moves the one role validation method upper in the inheritance chain so it can be used in all the barclamps which need it. The code mostly comes from https://github.com/crowbar/barclamp-rabbitmq/pull/7/files
