### PR TITLE
add a method for validating the existence of a db proposal

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -754,6 +754,29 @@ class ServiceObject
   def validate_proposal_after_save proposal
   end
 
+  #
+  # Look for a database proposal. If :active is specified, then it will
+  # return the first active database proposal, otherwise both active and
+  # inactive are searched, in that order.
+  #
+  def validate_has_database_proposal(kind=nil)
+    databaseService = DatabaseService.new(@logger)
+
+    dbs = databaseService.list_active[1]
+
+    unless kind == :active
+      dbs = databaseService.proposals[1] if dbs.empty?
+    end
+
+    validation_error("A#{"n active" if kind == :active} database proposal is required.") if dbs.blank? || dbs[0].blank?
+
+    dbs[0]
+  end
+
+  def validate_has_active_database_proposal
+    validate_has_database_proposal :active
+  end
+
   def _proposal_update(proposal)
     data_bag_item = Chef::DataBagItem.new
 


### PR DESCRIPTION
Trying to make the code in https://github.com/crowbar/barclamp-keystone/blob/release/roxy/master/crowbar_framework/app/models/keystone_service.rb#L45 more general so it can be reused in other barclamps and in more methods of the same barclamp

The find_active_database_proposal will be used to validate the existence of an active database proposal before applying a proposal.
