### PR TITLE
Add support for non-idempotent roles. [1/3]

### DIFF
--- a/bin/crowbar_nodes
+++ b/bin/crowbar_nodes
@@ -24,13 +24,16 @@ NODES_PATH = "api/v2/nodes"
   "list_status" => [ "list_status", "list_status - show a list of nodes and their status" ],
   "show" => [ "show ARGV.shift, ARGV.shift", "show <name> [arg] - show a specific node" ],
   "show_status" => [ "show_status ARGV.shift", "show_status <name> - show a specific node status" ],
+  "reboot" => [ "reboot ARGV.shift", "reboot <name> - reboot a node" ],
+  "debug" => [ "debug ARGV.shift", "debug <name> - reboot a node into Sledgehammer for debugging."],
+  "undebug" => [ "undebug ARGV.shift", "debug <name> - Let a node boot up normally."]
 }
 
 =begin
   "create" => [ "create ARGV.shift", "create <name> - create a specific node" ],
   "edit" => [ "edit ARGV.shift", "edit <name> - edit a new node" ],
   "delete" => [ "delete ARGV.shift", "delete <name> - delete a node" ],
-  "reboot" => [ "action \"reboot\", ARGV.shift", "reboot <name> - reboot a node" ],
+
   "shutdown" => [ "action \"shutdown\", ARGV.shift", "shutdown <name> - shutdown a node" ],
   "poweron" => [ "action \"poweron\", ARGV.shift", "poweron <name> - poweron a node" ],
   "identify" => [ "action \"identify\", ARGV.shift", "identify <name> - identify a node" ],
@@ -39,6 +42,21 @@ NODES_PATH = "api/v2/nodes"
   "reinstall" => [ "action \"reinstall\", ARGV.shift", "reinstall <name> - reinstall a node" ],
   "update" => [ "action \"update\", ARGV.shift", "update <name> - update a node (hardware only)" ] 
 =end
+
+def reboot(name)
+  res = put_json2(NODES_PATH+"/"+name+"/reboot")
+  res[1] == 200
+end
+
+def debug(name)
+  res = put_json2(NODES_PATH+"/"+name+"/debug")
+    res[1] == 200
+end
+
+def undebug(name)
+  res = put_json2(NODES_PATH+"/"+name+"/undebug")
+  res[1] == 200
+end
 
 def list
   struct = get_json2(NODES_PATH)
@@ -99,64 +117,6 @@ def show_status(name_or_id)
   end
 end
 
-=begin
-def create(name)
-  usage -1 if name.nil? or name == ""
 
-  @data = "{\"name\":\"#{name}\"}" if @data.nil? or @data == ""
-
-  struct = put_json("/", @data)
-
-  if struct[1] == 200
-    [ "Created #{name}", 0 ]
-  else
-    [ "Failed to talk to service create: #{struct[1]}: #{struct[0]}", 1 ]
-  end
-end
-
-def edit(name)
-  usage -1 if name.nil? or name == ""
-
-  struct = post_json("/#{name}", @data)
-
-  if struct[1] == 200
-    [ "Edited #{name}", 0 ]
-  elsif struct[1] == 404
-    [ "Failed to edit: #{name} : Not Found", 1 ]
-  elsif struct[1] == 400
-    [ "Failed to edit: #{name} : Errors in data\n#{struct[0]}", 1 ]
-  else
-    [ "Failed to talk to service edit: #{struct[1]}: #{struct[0]}", 1 ]
-  end
-end
-
-def delete(name)
-  usage -1 if name.nil? or name == ""
- 
-  struct = delete_json("?name=#{name}")
-
-  if struct[1] == 200
-    [ "Deleted #{name}", 0 ]
-  elsif struct[1] == 404
-    [ "Delete failed for #{name}: Not Found", 1 ] 
-  else
-    [ "Failed to talk to service delete: #{struct[1]}: #{struct[0]}", 1 ]
-  end
-end
-
-def action(aaa, name)
-  usage -1 if name.nil? or name == ""
-
-  @data = "{\"name\":\"#{name}\"}" if @data.nil? or @data == ""
-
-  struct = post_json("/#{aaa}/0", @data)
-
-  if struct[1] == 200
-    [ "#{aaa} #{name}", 0 ]
-  else
-    [ "Failed to talk to service #{aaa}: #{struct[1]}: #{struct[0]}", 1 ]
-  end
-end
-=end
 main
 

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -54,7 +54,19 @@ class NodesController < ApplicationController
     n = Node.find_key(params[:id] || params[:name])
     render api_delete Node
   end
-  
+
+  def reboot
+    node_action :reboot
+  end
+
+  def debug
+    node_action :debug
+  end
+
+  def undebug
+    node_action :undebug
+  end
+
   # RESTfule POST of the node resource
   def create
     params[:deployment_id] = Deployment.find_key(params[:deployment]).id if params.has_key? :deployment
@@ -93,6 +105,14 @@ class NodesController < ApplicationController
     @node.save!
     redirect_to :action=>:show
 
+  end
+
+  private
+
+  def node_action(meth)
+    n = Node.find_key(params[:id] || params[:name] || params[:node_id])
+    n.send(meth)
+    render api_show :node, Node, nil, nil, n
   end
 
 end

--- a/crowbar_framework/app/models/barclamp.rb
+++ b/crowbar_framework/app/models/barclamp.rb
@@ -189,6 +189,7 @@ class Barclamp < ActiveRecord::Base
                             :bootstrap=>flags.include?('bootstrap'),
                             :discovery=>flags.include?('discovery'),
                             :server=>flags.include?('server'),
+                            :destructive=>flags.include?('destructive'),
                             :cluster=>flags.include?('cluster'))
         RoleRequire.where(:role_id=>r.id).delete_all
         r.save!

--- a/crowbar_framework/app/models/jig.rb
+++ b/crowbar_framework/app/models/jig.rb
@@ -94,6 +94,12 @@ class Jig < ActiveRecord::Base
     raise "Cannot call run on the top-level Jig!"
   end
 
+  def finish_run(nr)
+    nr.run_count += 1 if nr.active?
+    nr.save!
+    return nr
+  end
+
   # Return all keys from hash A that do not exist in hash B, recursively
   def deep_diff(a,b)
     raise "Only pass hashes to deep_diff" unless a.kind_of?(Hash) && b.kind_of?(Hash)
@@ -148,7 +154,7 @@ class NoopJig < Jig
 
   def run(nr,data)
     nr.state = NodeRole::ACTIVE
-    nr
+    finish_run(nr)
   end
 
 end

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -54,6 +54,7 @@ class Node < ActiveRecord::Base
   has_many    :snapshots,          :through => :node_roles
   has_many    :deployments,        :through => :snapshots
   belongs_to  :deployment
+  belongs_to  :target_role,        :class_name => "Role", :foreign_key => "target_role_id"
 
   scope    :admin,              -> { where(:admin => true) }
   scope    :alive,              -> { where(:alive => true) }
@@ -114,37 +115,6 @@ class Node < ActiveRecord::Base
   #
   def is_admin?
     admin
-  end
-
-  # CB1 these are really IMPI actions - please move!
-  def ipmi_cmd(cmd)
-    bmc          = jig_hash.address("bmc").addr rescue nil
-    bmc_user     = jig_hash.get_bmc_user
-    bmc_password = jig_hash.get_bmc_password
-    system("ipmitool -I lanplus -H #{bmc} -U #{bmc_user} -P #{bmc_password} #{cmd}") unless bmc.nil?
-  end
-
-  # CB1 these are really IMPI actions - please move!
-  def reboot
-    set_state("reboot")
-    ipmi_cmd("power cycle")
-  end
-
-  # CB1 these are really IMPI actions - please move!
-  def shutdown
-    set_state("shutdown")
-    ipmi_cmd("power off")
-  end
-
-  # CB1 these are really IMPI actions - please move!
-  def poweron
-    set_state("poweron")
-    ipmi_cmd("power on")
-  end
-
-  # CB1 these are really IMPI actions - please move!
-  def identify
-    ipmi_cmd("chassis identify")
   end
 
   def virtual?
@@ -238,6 +208,69 @@ class Node < ActiveRecord::Base
     data = discovery.merge arg
     write_attribute("discovery",JSON.generate(data))
     data
+  end
+
+  def reboot
+    BarclampCrowbar::Jig.ssh("root@#{self.name} reboot")
+  end
+  
+  def debug
+    self.alive = false
+    self.bootenv = "sledgehammer"
+    self.target = Role.where(:name => "crowbar-managed-node").first
+    self.reboot
+  end
+
+  def undebug
+    self.alive = false
+    self.bootenv = "local"
+    self.target = nil
+    self.reboot
+  end
+
+  def target
+    return target_role
+  end
+  # Set the annealer target for this node, which will restrict the annealer
+  # to considering the noderole for this role bound to this node and its parents
+  # for converging.  If nil is passed, then all the noderoles are marked as available.
+  def target=(r)
+    if r.nil?
+      NodeRole.transaction do
+        old_alive = self.alive
+        self.save!
+        node_roles.each do |nr|
+          nr.available = true
+        end
+        self.target_role_id = nil
+        self.alive = old_alive
+        self.save!
+      end
+      return self
+    elsif r.kind_of?(Role) &&
+        roles.member?(r) &&
+        r.barclamp.name == "crowbar" &&
+        r.jig.name == "noop"
+      NodeRole.transaction do
+        old_alive = self.alive
+        self.alive = false
+        self.save!
+        self.target_role = r
+        node_roles.each do |nr|
+          nr.available = false
+        end
+        target_nr = self.node_roles.where(:role_id => r.id).first
+        target_nr.all_parents.each do |nr|
+          next unless nr.node_id == self.id
+          nr.available = true
+        end
+        target_nr.available = true
+        self.save!
+      end
+      return self
+    else
+      raise("Cannot set target role #{r.name} for #{self.name}")
+    end
   end
 
   def alive?

--- a/crowbar_framework/app/models/role.rb
+++ b/crowbar_framework/app/models/role.rb
@@ -31,6 +31,7 @@ class Role < ActiveRecord::Base
   attr_accessible :discovery
   attr_accessible :server
   attr_accessible :cluster
+  attr_accessible :destructive
   attr_accessible :template
 
   validates_uniqueness_of   :name,  :scope => :barclamp_id

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -144,6 +144,9 @@ Crowbar::Application.routes.draw do
           resources :nodes do
             resources :node_roles
             resources :attribs
+            put :reboot
+            put :debug
+            put :undebug
           end
           resources :node_roles do
             put :retry

--- a/crowbar_framework/db/migrate/20120731225510_create_roles.rb
+++ b/crowbar_framework/db/migrate/20120731225510_create_roles.rb
@@ -36,6 +36,9 @@ class CreateRoles < ActiveRecord::Migration
       # will be bound to all of the noderoled for this role in the deployment.
       # The cluster flag and the implicit flag are mutually exclusive.
       t.boolean     :cluster,           :null=>false, :default=>false
+      # Indicates that the role is not idempotent -- once a noderole binding
+      # it has transitioned to active, it will not be run again.
+      t.boolean     :destructive,       :null=>false, :default=>false
       t.belongs_to  :barclamp,          :null=>false
       t.integer     :cohort
       t.timestamps

--- a/crowbar_framework/db/migrate/20120731225516_create_nodes.rb
+++ b/crowbar_framework/db/migrate/20120731225516_create_nodes.rb
@@ -20,6 +20,7 @@ class CreateNodes < ActiveRecord::Migration
       t.string      :description,   :null=>true
       t.integer     :order,         :default=>10000
       t.boolean     :admin,         :default=>false
+      t.integer     :target_role_id,:null=>true
       t.belongs_to  :deployment     # should be system by default
       t.text        :discovery,     :null=>false, :default=>'{}'
       t.text        :hint,          :null=>false, :default=>'{}'
@@ -30,6 +31,6 @@ class CreateNodes < ActiveRecord::Migration
       t.timestamps
     end
     #natural key
-    add_index(:nodes, :name, :unique => true)   
+    add_index(:nodes, :name, :unique => true)
   end
 end

--- a/crowbar_framework/db/migrate/20120731310000_create_node_roles.rb
+++ b/crowbar_framework/db/migrate/20120731310000_create_node_roles.rb
@@ -13,22 +13,24 @@
 # limitations under the License.
 #
 class CreateNodeRoles < ActiveRecord::Migration
-  def change  
+  def change
     create_table :node_roles do |t|
       t.belongs_to  :snapshot,          :null=>false
       t.belongs_to  :role,              :null=>false
       t.belongs_to  :node,              :null=>false
       t.integer     :state,             :null=>false, :default => NodeRole::PROPOSED
       t.integer     :cohort,            :null=>false, :default => 0
+      t.integer     :run_count,         :null=>false, :default => 0
       t.string      :status,            :null=>true   # expected for error, blocked, transistioning
       t.text        :userdata,          :null=>false, :default => '{}'
       t.text        :systemdata,        :null=>false, :default => '{}'
       t.text        :wall,              :null=>true
       t.text        :runlog,            :null=>false, :default => ""
+      t.boolean     :available,         :null=>false, :default => true
       t.integer     :order,             :default=>Random.rand(1000000)
       t.timestamps
     end
-    #natural key 
+    #natural key
     add_index(:node_roles, [:snapshot_id, :role_id, :node_id], :unique => true)
   end
 

--- a/doc/devguide/model/role.md
+++ b/doc/devguide/model/role.md
@@ -4,60 +4,82 @@
 
 Roles have several flags that detemrine how Crowbar manages relationships when creating the node-role graph.
 
-#### Implicit
+#### implicit
 
-Any role that depends on this role must have the parent bound to the same node.
-So, if a parent role requires a role then the child must be attached to that node.
+Any role that depends on a parent role with the implicit flag will
+automatically bind a noderole for the parent role to the same node.
 
-Generally, these roles can be automatically added to any node that
-
-#### Bootstrap
-
-When we have a set of roles that we want to be bound to the admin node, this happens for these roles.
-
-You only need to do this to a few roles (ONE, crowbar-admin-node) because the role dependency logic flags will take care of the rest of the binding.
+#### bootstrap
 
 Indicates that this role will be automatically bound to the first admin node.
 
-#### Discovery
+You only need to do this to a few roles (by default, crowbar-admin-node)
+because the role dependency logic flags will take care of the rest of
+the bindings.  
 
-"Crowbar-managed-node" is the only one that uses this.  All the other things that need to be done when a node is discovered are triggered as dependencies on this role.
 
-Indicates that this role will be automatically bound to all newly discovered nodes.
+#### discovery
 
-#### Server
+Indicates that this role will be automatically bound to all newly
+discovered nodes.
 
-By default when a node-role is run, we push/pull data from it.  This flag tells the child roles that data from this role should be shared with them.
+"crowbar-managed-node" is the only one that uses this by default, and
+we let the binding logic pull in the rest of the roles that it
+requires.  Other barclamps that have roles that need ot be
+automatically bound should add this flag.
 
-Indicates that userdata, system data, and wall data for this node will be visible to child nodes.  As the name of the flag indicates,
-the only roles that will generally require that are ones that implement servers that other roles need to talk to.
+#### server
 
-Indicates that the attributes used by this node should be made available to its children in the noderole graph.
+Indicates that the attributes used by this node should be made
+available to its children in the noderole graph.
 
-#### Cluster
+By default when a node-role is run, we push/pull data from it.  This
+flag tells the the annealer that child noderoles should be able to see
+data that roles with this flag push back into Crowbar.  Once we flesh
+out attribute support, this flag will go away.
 
-Needed to create linked set of services like the ceph-mons.  When we add a new monitor then we want all the children of the monitor to be held until all the other cluster node-roles are updated together.  Basically, all of the children are bound to all of the cluster siblings automatically.
+#### cluster
 
 Indicates that all noderoles for this role in a given deployment should be
 bound as parents instead of just one.  This ensures that all instances of
-a clsutered service are up instead of just the first one.
+a clustered service are up instead of just the first one.
 
-Indicates that this role implements a clustered service.
+It is needed to create linked set of services like the ceph-mons.
+When we add a new monitor then we want all the children of the monitor
+to be held until all the other cluster noderoles are updated together.
 
-When the noderole graph is built, any child noderoles of this service will be bound to all of the noderoled for this role in the deployment.
+#### destructive
 
+Indicates that this role is not idempotent, and that after it
+transitions to active for the first time it should never be run
+again. The only user of this flag is the provisioner-os-install role.
 
-### Hooks / In-line Calls 
+### Hooks / In-line Calls
 
-To integrate Roles, the following hooks can be overriden.
+Roles have several different hooks that are called as part of the
+deployment and/or node role lifecycle.  These hooks allow you to
+customize how a role behaves in the crowbar framework.  Hooks should
+be kept short and fast so that they do not block the API or the UI --
+if you want to do something that takes a long time, you should create
+a new role.
 
-#### On Deployment Create (optional)
+#### Deployment hooks
 
-Called when this role is added to a deployment (the [[deployment_role]] is created).  
+There are two hooks for letting roles interact with deployment roles:
+`on_deployment_create` and `on_deployment_delete`.  They are called
+passing the relavent deployment as a parameter just after a
+[[deployment_role]] is created or just before it is destroyed.
 
-#### On Deployment Delete (optional)
+#### Noderole hooks
 
-Called when this role is removed from a deployment (the [[deployment_role]] is deleted).  
+There are five hooks that get called as part of the state transitions
+for node roles:
 
-> At present, you cannot remove roles from a deployment.
+* `on_proposed`
+* `on_todo`
+* `on_transition`
+* `on_active`
+* `on_error`
 
+Each of these hooks is called with the noderole as a parameter just
+after the noderole transitions to the state for the hook in question.


### PR DESCRIPTION
This pull request series adds support for:
- Declaring that a role is non-idempotent, which will tell the
  annealer that noderoles for that role should not be rerun after it
  has sucessfully transitioned to active.
- Rebooting a node, putting a node into debug mode, and pulling it out
  of debug mode via the API and CLI interfaces.
  
  bin/crowbar_nodes                                  | 78 +++++-------------
  .../app/controllers/nodes_controller.rb            | 24 +++++-
  crowbar_framework/app/models/barclamp.rb           |  1 +
  .../app/models/barclamp_crowbar/jig.rb             |  9 +-
  crowbar_framework/app/models/jig.rb                |  8 +-
  crowbar_framework/app/models/node.rb               | 95 +++++++++++++++-------
  crowbar_framework/app/models/node_role.rb          | 42 ++++++++--
  crowbar_framework/app/models/role.rb               |  1 +
  crowbar_framework/app/models/run.rb                |  9 +-
  crowbar_framework/config/routes.rb                 |  3 +
  .../db/migrate/20120731225510_create_roles.rb      |  3 +
  .../db/migrate/20120731225516_create_nodes.rb      |  3 +-
  .../db/migrate/20120731310000_create_node_roles.rb | 80 +++++++++---------
  doc/devguide/model/role.md                         | 82 ++++++++++++-------
  14 files changed, 261 insertions(+), 177 deletions(-)

Crowbar-Pull-ID: 711cb679ae93eb9648f168e599dceeeb06524c9a

Crowbar-Release: development
