### PR TITLE
Consolidate Crowbar documentation under the Crowbar barclamp [1/1]

### DIFF
--- a/doc/devguide/development/BUILD.md
+++ b/doc/devguide/development/BUILD.md
@@ -1,0 +1,303 @@
+This file documents how to build the Crowbar installation DVD image.
+
+Prerequisites:
+
+  * An unfiltered Internet connection and a decent amount of bandwidth.
+    The first time you try to build Crowbar it will need to download
+    all the packages that it will need to stage Crowbar onto an OS install
+    DVD.
+    
+  * bash version 4 or higher
+    
+  * mkisofs
+  
+    The end product of the build script is an ISO image that will be used
+    to bootstrap the Crowbar admin node.
+  * debootstrap (if staging on to Ubuntu)
+    
+    The build process needs to download all the .debs and gems that 
+    Crowbar requires, and we don't want to inadvertently mess up the build
+    machine when we do that.  All extra packages are downloaded into a
+    chrooted minimal Ubuntu intall, and we use debootstrap to enable that.
+
+  * git
+
+    If you are reading this locally, you probably already have git
+    installed. If not, you will need it to allow the dev tool to
+    manage all your barclamps.
+
+  * curl
+
+    The build process may need to download files from the Internet.
+    It uses curl to do this.
+  * ruby
+
+    Most of Crowbar is written in Ruby, and some of the helper
+    programs we use during the build process are also written in Ruby.
+    The Crowbar build process works with all Ruby versions from 1.8.7
+    to 2.0.0.  In addition to the basic Ruby install, the following
+    ruby gems are also required:
+    * json (only on Ruby < 2.0)
+    * libxml-ruby
+    * xml-simple
+    * kwalify
+    * bundler
+    * builder
+
+  * rpm and dpkg
+
+    The build process needs to be able to introspect on package
+    dependencies for the packages it will windo up staging on the
+    final generated ISO.
+
+  * dpkg-buildpackage and debhelper
+
+    These are used to build native .deb packages for Crowbar 2.0 releases.
+
+  * rpm2cpio
+
+    The Sledgehammer build process downloads raw RPM files to build
+    the Sledgehammer system discovery component.  It needs rpm2cpio to
+    create its initial chroot to bootstrap its build process.
+
+  * cpio
+
+    We need to extract the cpio files that rpm2cpio creates, so we
+    have to have cpio as well.
+
+  * createrepo
+
+    If the Sledgehapper and Crowbar build processes need o create a
+    yum or zypper archive, they use createrepo to do this.
+
+  * cabextract
+
+    The dell\_bios barclamp needs to extract its configuration from a
+    .cab file downloaded off of ftp.dell.com so that it can find the
+    latest firmware components for PowerEdge R series hardware.
+
+  * erlang
+
+    The BDD test suite that the Crowbar unit test framework is written
+    in requires Erlang.
+    
+  * Sudo to root privileges for the following commands:
+    * /bin/mount, /bin/umount
+      We have to be able to mount and umount the Ubuntu .iso image, as well as
+      a tmpfs for debootstrap, and we have to be able to bind mount
+      /dev, /dev/pts, /proc, and /sys into the debootstrap chroot environment.
+    * /usr/sbin/debootstrap
+      debootstrap requires root privileges to run.
+    * /bin/cp
+      We need to copy things into and out of the debootstrap environment to
+      ensure it downloads and caches the right packages.
+    * /usr/sbin/chroot
+      All our package caching is done in a chroot environment, and chroot
+      requires root permissions to run.
+
+      Most of the full-time Crowbar developers just arrange to have
+      passwordless sudo rights for their primary development account.
+
+Most builds should be done using the dev tool, which will ensure that
+all the barclamps are checked out to the proper branches and that all
+the trees are clean before starting the build process.  For example,
+to build an Ubuntu 12.04.2 ISO that has just the core Crowbar
+components staged on it, you can run the following commands:
+
+        cd <your top-level crowbar checkout>
+        ./dev switch development/master
+        ./dev build --os ubuntu-12.04
+
+Command Line Parameters:
+
+  * --os
+    The argument to this parameter is the OS to stage Crowbar on to.
+    Crowbar currently understands how to stage itself on:
+    * ubuntu-10.10
+    * ubuntu-12.04
+    * redhat-5.7 and centos-5.7
+    * redhat-6.4 and centos-6.4
+    * fedora-18
+  * --update-cache
+    This parameter forces the build to try and update the build cache again.
+    Use this parameter if you want to pull in updates from the upstream
+    repositories that Crowbar pulls packages from.
+  * --test
+    This tells the build system to try and smoketest the freshly-generated
+    .ISO. Any arguments after this that do not begin with a hyphen are
+    passed to the test framework -- please see test\_framework/README.testing
+    for more information.
+  * --no-iso
+    Do everything but actaully build the iso.
+  * --wild-cache
+    Create a temporary cache directory that is good for this build
+    only. The cache will be deleted when the build exits.  This exists
+    mainly to test what a build that is pulling the latest stuff from
+    the Internet looks like.  You should make sure that you are using
+    a caching web proxy such as polipo or squid, otherwise repeated
+    builds will be very slow.
+  * --no-switch
+    Leave the branches in the barclamp exactly as they are instead of
+    trying to ensure that they are on the proper branch for the build.
+
+Customization:
+
+The build process has several different parameters you can tune, either from
+$HOME/.build-crowbar.conf (for developer use), or from build-crowbar.conf
+in the current directory (for automated builds).
+
+Here are the parameters you can change through the above configuration files:
+
+  * DEBUG
+     If DEBUG is set to anything, build\_crowbar will run in debug mode, and will
+     print a transcript of everything it is doing to standard error.
+     Setting DEBUG will generate a very large about of output, and is
+     useful in diagnosing errors in the build process.
+  * CACHE\_DIR
+     This is the default location where build\_crowbar.sh will keep the files
+     it caches, along with the temporary directories used to mount the
+     ISO image, the debootstrap chroot, and the directory we perform the build
+     in.
+     It defaults to $HOME/.crowbar-build-cache.
+  * ISO\_LIBRARY
+     This is the default location where the ISO we will stage Crowbar
+     on to is stored.
+     It defaults to $CACHE\_DIR/iso
+  * ISO\_DEST
+     This is the location that we will save the Crowbar install image to.
+     It defaults to the current directory.
+  * IMAGE\_DIR
+     This is the location that we will mount isos in.
+     It defaults to $CACHE\_DIR/image
+  * SLEDGEHAMMER\_PXE\_DIR
+     This points to the location we expect to find the unpacked Sledgehammer
+     PXE boot archive.  It defaults to $CACHE\_DIR/tftpboot
+  * VERSION
+     The default version of Crowbar.  Defaults to dev.
+  * BUILT\_ISO
+     The name of the ISO that build\_crowbar.sh generates.
+     Defaults to crowbar-$VERSION.iso
+  * CROWBAR\_DIR
+     The directory that the Crowbar source is cheched out to.
+     Defaults to the directory that build\_crowbar.sh is in.
+  * VCS\_CLEAN\_CMD
+     This is the command that build\_crowbar.sh will run to clean the tree before
+     staging the Crowbar build.
+     Defaults to 'git clean -f -d'
+
+Build System Walkthrough:
+
+When build\_crowbar.sh is invoked, it performs the following processes in order:
+
+ 1. Make sure we are in the C locale, and that $PATH is set to something sane.
+ 2. Pick up any local configuration settings from $HOME/.build\_crowbar.conf
+    or ./build\_crowbar.conf
+ 3. Set any uninitialized config variables to their defaults.
+ 4. Source our generic build and test functions.
+ 5. Figure out what OS we want to stage, and source the build and test
+    libraries.  This will pull in the functions we need to actually stage
+    Crowbar on an OS install ISO.  If we were asked to build on an OS that 
+    we don't have build info for, die and print out the OSes we do know how
+    to stage things on.
+ 6. Make sure that all the commands we will need to stage Crowbar on to an ISO
+    are installed on the system.  If they are not, print a helpful error 
+    message and die.
+ 7. Grab the build lock to make sure that multiple builds do not stomp all
+    over eachother.
+ 8. Do a little bookkeeping to make sure we are on a buildable Git branch.
+    If the build cache is in a git repository, record that information as well.
+ 10. Parse our commandline options. 
+ 11. Make sure our essential build-related directories are present (including
+    the directory we will stage the build into, the directory we will mount
+    the ISO image on, and a chroot that will be used as part of the barclamp
+    staging process), and set up any build parameters that have not already 
+    been set up.
+ 12. If we were not passed a list of barclamps to install on the command line,
+    figure out what barclamps we need based on the submodule information from
+    the git branch we are on.
+ 13. Pull in metadata from the crowbar.yml files for each barclamp.
+    This metadata will drive the rest of the install -- we need it to
+    figure out dependency relations between barclamps, what packages and files
+    to stage, and how to invoke any external build processes we might need.
+ 14. Make sure we have a Sledgehammer image handy, and build it if we don't.
+ 15. If we don't have the OS ISO to stage on, and we know how to get one, then
+    download the .ISO we will need.
+ 16. Clean out any leftovers from the last build, and make sure that
+    we don't inadvertently pull in any VCS cruft.
+ 17. Mount the OS iso as a loopback file system, and index its package
+    pool if we don't already have it cached.
+ 18. Stage some barclamp-independent build information into the build directory.
+ 19. Create the build-info file for this build, and start adding useful 
+    metadata into it.
+ 20. Loop over the list of barclamps want to stage, and stage each one.  
+    This is covered in more detail in the Barclamp Staging Walkthrough below.
+ 21. Bundle each barclamp and its package cache into a per-barclamp tarball.
+ 22. Create some legacy symlinks, and stage any custom proposals that this
+    iso will use.
+ 23. Perform any OS specific fixups that are needed to make this image deploy
+    correctly.
+ 24. Stage the Sledgehammer image.
+ 25. Create the Crowbar .ISO by merging the contents of the build and the image
+    directory.  Wherever there is a conflict in file names or contents, the
+    build directory has priority.  If we were asked to generate a shrunken ISO,
+    that happens here.
+ 26. If we were asked to test the ISO, invoke the test framework on our 
+    newly-created ISO.
+ 27. Clean up after ourselves.
+
+Barclamp Staging Walkthrough:
+
+build\_crowbar will try to stage each barclamp in dependency order (as inferred
+from each barclamp's crowbar.yml file).  Staging a barclamp properly for the
+OS we are staging on to requires the use of a chroot environment to ensure
+that we get all the packages we need and that we don't break the host OS
+in the process.  Each barclamp is staged in 6 phases:
+
+  1. Check to see if all the OS packages listed in the pkgs: and build\_pkgs: 
+   section of the crowbar.yml are present in this barclamps's OS build cache.
+   If they are not, fetch any missing ones and all their dependencies using
+   a chroot environment, and add any new or updated packages so fetched back
+   into the build cache.
+  2. Check to see that all the gems listed in the crowbar.yml are present in
+   the build cache.  If they are not, fetch them and all their dependencies in
+   the chroot environment, and add any new or updated gems to the build cache.
+  3. Download and cache any packages pointed to by raw\_pkg stanzas in the 
+   crowbar.yml that we are missing.
+  4. Download and cache any files required by extra\_files stanzas in the
+   crowbar.yml thatwe are missing.
+  5. If the crowbar.yml has a build\_cmd stanza, source that file and use it
+   to build an external package.  The script pointed to by build\_cmd should
+   have two functions declared:
+   
+   bc\_needs\_build -- This function should return 0 if the external
+   pacakge needs building, and 1 if it does not.
+   
+   bc\_build: This function will be invoked after setting up a chroot and
+   bind-mounting the build cache for this barclamp into it.  It is responsible
+   for using the chroot enviromnent to build the external package, and making
+   sure that the output of the build process winds up in the proper location
+   in the build cache so that the rest of the barclamp can properly use it.
+
+   bc-build has access to the following environment variables:
+   BC\_DIR = the full path to the root of the barclamp source repository.  
+   BC\_CACHE = The full path to the barclamp package cache.
+
+   Any actual building should happen in the chroot environment. 
+   To facilitate this, $BC\_CACHE is bind-mounted to /mnt in the chroot,
+   any build\_pkgs required by this barclamp will be installed in the chroot,
+   and /mnt/current\_os in the chroot will be a symlink to the OS package cache
+   that for the barclamp build cache that is bind mounted to /mnt in the chroot.
+
+   You can use the chroot\_install command to install any additional packages
+   you may need, and you can use the in\_chroot command to run commands
+   in hte chroot environment.
+
+   For some in-tree examples, refer to the ganglia, provisioner, and deployer
+   barclamps.  All of these have an additional script that is copied into the
+   chroot that handles most of the build tasks.
+
+  6. Tar up the source for the barclamp and the build cache into a deployable
+   barclamp tarball.
+
+The build\_crowbar.sh script is heavily commented, please refer to it for more 
+detailed information.

--- a/doc/devguide/development/README.barclamp-packaging
+++ b/doc/devguide/development/README.barclamp-packaging
@@ -1,0 +1,114 @@
+This file documents how barclamps are packaged for installation
+and distribution.
+
+All barclamps that the Crowbar build process creates are packaged into 
+tarballs with the following layout:
+
+  <barclamp name>/ is the name of the barclamp 
+    crowbar.yml contains required barclamp metadata.  More detailed information
+                on what this file contains can be found in:
+                /opt/dell/barclamp_model on a freshly installed admin node.
+    sha1sums contains SHA1 checksums of everything in the barclamp tarball.
+             barclamp_install.rb uses this information to ensure that
+             the tarball was not corrupted and that it will not overwrite local
+             changes when installing a different barclamp revision.
+    bin/ contains binaries for /opt/dell/bin.
+         These are installed by barclamp_install.rb.
+    chef/ contains chef cookbooks, roles, and data bags.
+          See the barclamp model for more information on these directories. 
+    smoketest/ contains scripts for the smoketest framework.
+               See crowbar/test_framework/README.testing for more info.
+    cache/ contains the files and packages required by this barclamp
+      files/ contains raw files that the barclamp needs.
+             Examples are things like .ami files, raw source packages, etc.
+             Files and paths under this directory will be merged into
+             /tftpboot/files, and will wind up being served from
+             http://<admin ip>:8091/files/
+	     As a special case, the install process will unpack the .rpm
+             files from anything that looks like an Oracle java install
+	     package and place them into
+	     /tftpboot/<os-token>/crowbar-extra/oracle-java
+      gems/ contains gems that the barclamp requires.
+            Any gems will be symlinked into /tftpboot/gemsite/gems.
+            The install process on the admin node arranges for 
+            /tftpboot/gemsite to be served as a Rubygems repository through
+	    http://<admin ip>:3001/, and all nodes are configured to use
+	    that URL as their primary Gem repository.
+      <os-token>/ is a name like ubuntu-10.10, centos-5.7, etc.
+                  Ideally, there will be one of these for each OS the barclamp
+		  supports.  
+        pkgs/ contains all the <os-token> packages that the barclamp needs.
+	      /tftpboot/<os-token>/crowbar-extra/<barclamp name> will be a 
+	      symlink to this directory, so this directory should follow the
+	      layout conventions appropriate for whatever package manager
+	      is used by <os-token>.  Any packages in this directory will be
+	      installable on all the nodes.
+
+Creating a barclamp tarball:
+
+   The crowbar repository has a package_barclamp.sh script to help automate
+the process of creating a barclamp tarball.  That script makes the following
+assumptions:
+  1: The barclamp you wish to create is checked out under the Crowbar git
+     repository at barclamps/<barclamp name>.
+  2: The packages, files, and gems that your barclamp needs are present in the
+     crowbar build cache and were fetched by the build process.
+
+The package_barclamp.sh script takes the following options:
+  * --destdir <directory>
+    If this option is present, package_barclamp will save the barclamp tarballs
+    it creates in <directory>.  If it is not present, it will save them in the 
+    current directory.
+  * --os <os-token>
+    If this option is present, package_barclamp will only stage OS specific
+    packages for <os-token> along with the OS-independent files and gems. If
+    it is not present, package_barclamps.sh will try to package all the OS
+    specific packages it finds in the build cache.
+  * <barclamp names>
+    The names of the barclamps you want to package.
+
+Installing a barclamp:
+
+   Once you have a Crowbar admin node up and running, you can install new
+or updated barclamps using barclamp_install.rb.
+
+barclamp_install.rb can install multiple barclamps from multiple different
+sources at the same time, and it always installs barclamps in priority
+order as defined in the crowbar.yml for each barclamp. barclamp_install.rb
+knows about 3 types of sources:
+  * A path to a barclamp tarball.
+    If you pass a path to a barclamp tarball, barclamp_install.rb will
+    extract the tarball into a temporary directory and verify that the
+    previous install (if any) is pristine before continuing.
+  * A path to a directory containing a valid crowbar.yml.
+    If you pass a directory outside of /opt/dell/barclamps, barclamp_install.rb
+    will check to see if the current install is pristine before allowing the
+    install to continue.
+  * The name of a barclamp already installed in /opt/dell/barclamps.
+    If this is the case, barclamp_install.rb will assume that you are
+    reuploading an already installed barclamp, and will not check for 
+    pristineness.
+
+You can override the pristineness check in any of the above install methods
+by passing the --force switch to barclamp_install.rb.  After the pristineness
+check passes (or is overridden), the installer will copy the updated barclamp
+contents into /opt/dell/barclamps/<barclamp name>, merge the newer crowbar
+framework bits, update the chef components, and add new files and symlinks
+(as appropriate) to the cache directories.
+
+Once the new barclamp is installed, you will have to manually update the
+metadata for the gem and OS package repositories -- barclamp_install.rb is
+not smart enough to do it for you.  The steps for that are:
+  * find -L /tftpboot -type l -print0 |xargs -0 rm
+    This will delete any dangling symlinks that may be laying around.
+  * cd /tftpboot/gemsite; gem generate_index
+    This will recreate the metadata that gem uses to install the gems.
+  * cd /tftpboot/<os-token>/crowbar-extra
+    <os-token> is the OS you want to regenerate the package metadata for.
+    On RPM based distros, run:
+    # createrepo -d -q .
+    # knife ssh 'node:*' yum clean expire-cache
+    On .deb based distros, run:
+    # dpkg-scanpackages . |gzip -9 >Packages.gz
+    # knife ssh 'node:*' apt-get update
+

--- a/doc/devguide/development/README.build_cache
+++ b/doc/devguide/development/README.build_cache
@@ -1,0 +1,18 @@
+# To turn an existing build-cache into a git repo:
+
+## First, setup a .gitignore file in the root of your cache.
+
+### .gitignore for the build cache in gitolite.
+
+iso/
+*/iso-packages
+*/build
+*/chroot
+*/image
+
+## Then, do the init, add, commit to import.
+
+git init .; git add .; git commit -m "Initial import"
+
+
+

--- a/doc/devguide/development/README.dev-and-code-review
+++ b/doc/devguide/development/README.dev-and-code-review
@@ -1,0 +1,345 @@
+Dev leverages the Github pull request mechanism to enable handling some
+aspects of code review and merging. We do not use pull requests
+directly because we are in the habit of making synchronized changes
+across barclamps to handle code refactors and updates, and Github does
+not have the concept of a pull request touching multiple repositories.
+
+Singleton pull requests and pull request bundles:
+
+ * A singleton pull request is what you get when you submit a pull
+   request using the usual Github pull request mechanism.
+
+ * A pull request bundle is what you get when you issue pull requests
+   using ./dev pull-requests gen.  Pull request bundles are implemented
+   using singleton pull requests + a unique ID for the bundle (currently
+   the SHA1 of that SHAs of the tips of all the branches involved), what
+   release the pull request bundle is against, and a count of all the 
+   pull requests in the bundle.  Each pull request has this information
+   added by ./dev pull-requests gen.
+
+Dev finds out what pull requests are available at Github by one of two
+ways:
+
+ * ./dev fetch will silently pull down information about open pull
+   requests from each repository it touches on Github.
+ * ./dev pull-requests fetch <remote> will download information about
+   open pull requests from all known Crowbar repositories at <remote>,
+   assuming that remote is hosted on Github.
+
+Either way, fetching new pull request metadata goes through the same
+set of steps:
+ 1: Delete all locally cached pull request metadata, including
+    tracking branches created to point at the contents of a pull
+    request.
+ 2: Pull down information about open pull requests for each repository
+    we are touching as part of the fetch process, creating new
+    tracking branches on the fly.
+ 3: Determine which pull requests are part of a bundle, and
+    sanity-check the bundle to ensure that all of the components of the
+    bundle are present and consistent with the other components.
+ 4: If the pull request is not part of a bundle, infer which release
+    it applies to based on the branch that it should be merged into.
+ 5: Sort each singleton and bundle by last modified date, and assign a
+    numeric ID to each pull request singleton or bundle.  This bundle
+    ID will not change until the next fetch operation.
+ 5: Print out a status line that says how many singletons and bundles
+    are open.
+
+Here is what this looks like:
+victor@system76:~/crowbar$ ./dev pull-requests fetch
+2012-11-21 10:23:13 -0600: Fetching open pull requests for barclamp ApacheHadoop
+2012-11-21 10:23:13 -0600: Fetching open pull requests for barclamp chef
+2012-11-21 10:23:13 -0600: Fetching open pull requests for barclamp cinder
+2012-11-21 10:23:15 -0600: Fetching open pull requests for barclamp clouderamanager
+2012-11-21 10:23:15 -0600: Fetching open pull requests for barclamp crowbar
+2012-11-21 10:23:16 -0600: Fetching open pull requests for barclamp database
+2012-11-21 10:23:16 -0600: Fetching open pull requests for barclamp dell_bios
+2012-11-21 10:23:16 -0600: Fetching open pull requests for barclamp dell_branding
+2012-11-21 10:23:17 -0600: Fetching open pull requests for barclamp dell_raid
+2012-11-21 10:23:17 -0600: Fetching open pull requests for barclamp deployer
+2012-11-21 10:23:17 -0600: Fetching open pull requests for barclamp dns
+2012-11-21 10:23:18 -0600: Fetching open pull requests for barclamp ganglia
+2012-11-21 10:23:18 -0600: Fetching open pull requests for barclamp git
+2012-11-21 10:23:23 -0600: Fetching open pull requests for barclamp glance
+2012-11-21 10:23:24 -0600: Fetching open pull requests for barclamp hadoop
+2012-11-21 10:23:25 -0600: Fetching open pull requests for barclamp hive
+2012-11-21 10:23:25 -0600: Fetching open pull requests for barclamp indigo
+2012-11-21 10:23:25 -0600: Fetching open pull requests for barclamp ipmi
+2012-11-21 10:23:26 -0600: Fetching open pull requests for barclamp keystone
+2012-11-21 10:23:30 -0600: Fetching open pull requests for barclamp kong
+2012-11-21 10:23:32 -0600: Fetching open pull requests for barclamp logging
+2012-11-21 10:23:33 -0600: Fetching open pull requests for barclamp mysql
+2012-11-21 10:23:34 -0600: Fetching open pull requests for barclamp nagios
+2012-11-21 10:23:35 -0600: Fetching open pull requests for barclamp network
+2012-11-21 10:23:36 -0600: Fetching open pull requests for barclamp nova
+2012-11-21 10:23:41 -0600: Fetching open pull requests for barclamp nova_dashboard
+2012-11-21 10:23:41 -0600: Fetching open pull requests for barclamp ntp
+2012-11-21 10:23:41 -0600: Fetching open pull requests for barclamp openstack
+2012-11-21 10:23:41 -0600: Fetching open pull requests for barclamp overview
+2012-11-21 10:23:42 -0600: Fetching open pull requests for barclamp pig
+2012-11-21 10:23:42 -0600: Fetching open pull requests for barclamp postgresql
+2012-11-21 10:23:42 -0600: Fetching open pull requests for barclamp provisioner
+2012-11-21 10:23:45 -0600: Fetching open pull requests for barclamp quantum
+2012-11-21 10:23:45 -0600: Fetching open pull requests for barclamp redhat-install
+2012-11-21 10:23:47 -0600: Fetching open pull requests for barclamp sqoop
+2012-11-21 10:23:48 -0600: Fetching open pull requests for barclamp swift
+2012-11-21 10:23:48 -0600: Fetching open pull requests for barclamp tempest
+2012-11-21 10:23:50 -0600: Fetching open pull requests for barclamp test
+2012-11-21 10:23:50 -0600: Fetching open pull requests for barclamp ubuntu-install
+2012-11-21 10:23:51 -0600: Fetching open pull requests for barclamp zookeeper
+2012-11-21 10:23:53 -0600: Fetching open pull requests for Crowbar
+2012-11-21 10:23:55 -0600: 1 open pull request bundles and 13 open singleton pull requests
+victor@system76:~/crowbar$
+
+Once pull request data has been cached locally, you can list open pull
+requests and bundles:
+
+victor@system76:~/crowbar$ ./dev pull-requests list
+1: (development) RHEL OS / MBR install onto first smallest drive
+2: (fred) Optimize load time of update nodes recipe
+3: (fred) Nova changes for bigger network
+4: (development) make it more portable
+5: (fred) nagios optimizations
+6: (feature/pfs-folsom) updating feature/pfs-folsom/master
+7: (feature/pfs-folsom) updating feature/pfs-folsom/master with the latest code
+8: (development) Improving definitions documentation; adding minor fix for the Swift PFS support
+9: (development) Don't merge me, testing dev tool changes.
+10: (betty) Fixing tempest failures when running on Betty release
+11: (fred) Fixing tempest failures when running on Fred release
+12: (fred) Fixing tempest failures when running on Fred release
+13: (development) Adding ability to install Cinder from packages
+14: (feature/pfs-folsom) updating feature/pfs-folsom/master
+victor@system76:~/crowbar$
+
+Each line consists of the local ID of the pull request, the release
+the pull request applies to, and the title of the pull request.
+
+You can also get more specific information on a pull request:
+
+victor@system76:~/crowbar$ ./dev pull-requests show 1
+Title:               RHEL OS / MBR install onto first smallest drive
+Release:             development
+Last Updated:        2012-02-02T20:02:03Z
+Type:                singleton
+Repo:                barclamp-provisioner
+Repo with Changes:   https://github.com/bpezan/barclamp-provisioner.git
+Branch with Changes: master
+Local Branch:        pull-req-6
+Target Branch:       master
+Pull Request URL:    https://github.com/crowbar/barclamp-provisioner/pull/6
+Builds:              master
+victor@system76:~/crowbar$ 
+
+From this, we can see that the oldest pull request (pull requests are
+ordered from oldest to newest) is a singleton pull request, was last
+touched on 2012-02-02, applies to the provisioner barclamp, and
+targets the master build of the development release.
+
+Let's try switching to it:
+
+victor@system76:~/crowbar$ ./dev pull-requests switch 1 master
+2012-11-21 10:35:31 -0600: Switched to development/master
+Auto-merging chef/cookbooks/provisioner/templates/default/compute.ks.erb
+CONFLICT (content): Merge conflict in chef/cookbooks/provisioner/templates/default/compute.ks.erb
+Automatic merge failed; fix conflicts and then commit the result.
+2012-11-21 10:35:31 -0600: Could not merge pull-req-6 into master in barclamp-provisioner
+2012-11-21 10:35:32 -0600: Switching provisioner to master
+2012-11-21 10:35:32 -0600: Switched to development/master
+2012-11-21 10:35:32 -0600: Pull request 1 does not merge cleanly.  It should be updated or closed.
+victor@system76:~/crowbar$ 
+
+OK, this pull request does not apply cleanly to the current set of
+trees.  In this case, that is because the provisioner barclamp has
+undergone some major reorganization since this pull request was
+created, and it is no longer applicable in its current form.  Dev went
+ahead and switched all the trees back to a known-good state, which
+automatically cleans up.
+
+Let's try a different pull request:
+
+victor@system76:~/crowbar$ ./dev pull-requests show 9
+Title:        Don'y merge me, testing dev tool changes. 
+Release:      development
+Last Updated: 2012-11-19T19:12:46Z
+Type:         bundle
+Bundle ID:    311c3511f0c9de379cb2b755503b5bc95953352d
+Repo: barclamp-keystone
+    Repo with Changes:   https://github.com/VictorLowther/barclamp-keystone.git
+    Branch with Changes: pull-req-master-311c3511f0c9de379cb2b755503b5bc95953352d
+    Local Branch:        pull-req-47
+    Target Branch:       master
+    Pull Request URL:    https://github.com/crowbar/barclamp-keystone/pull/47
+    Builds:              openstack-os-build
+Repo: barclamp-mysql
+    Repo with Changes:   https://github.com/VictorLowther/barclamp-mysql.git
+    Branch with Changes: pull-req-master-311c3511f0c9de379cb2b755503b5bc95953352d
+    Local Branch:        pull-req-25
+    Target Branch:       master
+    Pull Request URL:    https://github.com/crowbar/barclamp-mysql/pull/25
+    Builds:              openstack-os-build
+Repo: barclamp-network
+    Repo with Changes:   https://github.com/VictorLowther/barclamp-network.git
+    Branch with Changes: pull-req-master-311c3511f0c9de379cb2b755503b5bc95953352d
+    Local Branch:        pull-req-100
+    Target Branch:       master
+    Pull Request URL:    https://github.com/crowbar/barclamp-network/pull/100
+    Builds:              master
+Repo: barclamp-provisioner
+    Repo with Changes:   https://github.com/VictorLowther/barclamp-provisioner.git
+    Branch with Changes: pull-req-master-311c3511f0c9de379cb2b755503b5bc95953352d
+    Local Branch:        pull-req-84
+    Target Branch:       master
+    Pull Request URL:    https://github.com/crowbar/barclamp-provisioner/pull/84
+    Builds:              master
+victor@system76:~/crowbar$ 
+
+OK, this is actually a pull request bundle that consists of changes to
+4 separate barclamps in the development release.  Let's switch to it:
+
+victor@system76:~/crowbar$ ./dev pull-requests switch 9
+2012-11-21 10:55:06 -0600: You must pass a build to pull-requests switch, because there is no obvious default.
+2012-11-21 10:55:06 -0600: Run ./dev pull-requests builds 9 to see what is available.
+victor@system76:~/crowbar$ ./dev pull-requests builds 9
+master
+openstack-os-build
+victor@system76:~/crowbar$ 
+
+Let's try that again while specifying that we want openstack-os-build:
+
+victor@system76:~/crowbar$ ./dev pull-requests switch 9 openstack-os-build
+2012-11-21 10:56:47 -0600: Switching chef to master
+2012-11-21 10:56:47 -0600: Switching crowbar to master
+2012-11-21 10:56:47 -0600: Switching deployer to master
+2012-11-21 10:56:47 -0600: Switching dns to master
+2012-11-21 10:56:47 -0600: Switching ganglia to master
+2012-11-21 10:56:47 -0600: Switching glance to master
+2012-11-21 10:56:47 -0600: Switching ipmi to master
+2012-11-21 10:56:47 -0600: Switching keystone to master
+2012-11-21 10:56:47 -0600: Switching logging to master
+2012-11-21 10:56:47 -0600: Switching mysql to master
+2012-11-21 10:56:48 -0600: Switching nagios to master
+2012-11-21 10:56:48 -0600: Switching network to master
+2012-11-21 10:56:48 -0600: Switching nova to master
+2012-11-21 10:56:48 -0600: Switching nova_dashboard to master
+2012-11-21 10:56:48 -0600: Switching ntp to master
+2012-11-21 10:56:48 -0600: Switching openstack to master
+2012-11-21 10:56:48 -0600: Switching swift to master
+2012-11-21 10:56:48 -0600: Switching tempest to master
+2012-11-21 10:56:48 -0600: Switching test to master
+2012-11-21 10:56:48 -0600: Switched to development/openstack-os-build
+Updating fab5803..a736082
+Fast-forward
+ crowbar_framework/app/models/keystone_service.rb |   42 +++++++++-------------
+ 1 file changed, 16 insertions(+), 26 deletions(-)
+Updating 01694b9..3fdd8ef
+Fast-forward
+ crowbar_framework/app/models/mysql_service.rb |   52 ++++++++++---------------
+ 1 file changed, 20 insertions(+), 32 deletions(-)
+Updating 8928c1d..c37ade1
+Fast-forward
+ chef/cookbooks/network/recipes/default.rb |    3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+Updating 98fd84f..d04621f
+Fast-forward
+ build_curl.sh        |   16 ----------------
+ build_curl_chroot.sh |   16 ----------------
+ crowbar.yml          |    2 --
+ 3 files changed, 34 deletions(-)
+ delete mode 100755 build_curl.sh
+ delete mode 100755 build_curl_chroot.sh
+2012-11-21 10:56:48 -0600: You are now on build openstack-os-build in pull request 9.
+victor@system76:~/crowbar$ 
+
+That worked.  Let's check out the state of the provisioner barclamp,
+which is part of the pull request bundle:
+
+victor@system76:~/crowbar$ cd barclamps/provisioner/
+victor@system76:~/crowbar/barclamps/provisioner$ git status
+# Not currently on any branch.
+nothing to commit (working directory clean)
+victor@system76:~/crowbar/barclamps/provisioner$ 
+
+From here, we can see that the provisioner barclamp is not currently
+on a branch.  This is by design -- in order to preserve your current
+branches and make sure that doing reviews of pull requests is not
+destructive, all merges of code from a pull request happen on raw
+commits, not branches.  This makes restoring state after examining
+pull requests simpler, as well -- since we did not change the state of
+any branches, we don't have to worry about changing them back.
+
+From here, we can run unit tests:
+
+victor@system76:~/crowbar$ ./dev tests clear
+victor@system76:~/crowbar$ ./dev tests run
+... lots of output ...
+victor@system76:~/crowbar$
+
+spin up a build (using the --no-switch flag to leave the barclamps
+alone) and smoketest it:
+victor@system76:~/crowbar$ ./dev build --os ubuntu-12.04 --no-switch --test use-screen tempest
+... even more output snipped ...
+victor@system76:~/crowbar$
+
+Once you are finshed, dev switch will switch back to the proper
+branches for the release/build combo you were on:
+
+victor@system76:~/crowbar$ ./dev switch
+2012-11-21 11:17:00 -0600: Switching keystone to master
+2012-11-21 11:17:00 -0600: Switching mysql to master
+2012-11-21 11:17:00 -0600: Switching network to master
+2012-11-21 11:17:00 -0600: Switching provisioner to master
+2012-11-21 11:17:00 -0600: Switched to development/openstack-os-build
+victor@system76:~/crowbar$
+
+Assuming you liked what you saw and the code passed the test, you can
+merge the changes in dev:
+
+victor@system76:~/crowbar$ ./dev pull-requests merge 9
+2012-12-05 09:47:25 -0600: https://github.com/crowbar/barclamp-crowbar/pull/287 merged.
+2012-12-05 09:47:26 -0600: https://github.com/crowbar/barclamp-glance/pull/58 merged.
+2012-12-05 09:47:29 -0600: https://github.com/crowbar/barclamp-hive/pull/19 merged.
+2012-12-05 09:47:32 -0600: https://github.com/crowbar/barclamp-keystone/pull/48 merged.
+2012-12-05 09:47:34 -0600: https://github.com/crowbar/barclamp-nova/pull/100 merged.
+2012-12-05 09:47:38 -0600: https://github.com/crowbar/barclamp-nova_dashboard/pull/43 merged.
+2012-12-05 09:47:40 -0600: https://github.com/crowbar/barclamp-openstack/pull/19 merged.
+2012-12-05 09:47:41 -0600: https://github.com/crowbar/barclamp-pig/pull/19 merged.
+2012-12-05 09:47:46 -0600: https://github.com/crowbar/barclamp-sqoop/pull/20 merged.
+2012-12-05 09:47:48 -0600: https://github.com/crowbar/barclamp-swift/pull/40 merged.
+2012-12-05 09:47:50 -0600: https://github.com/crowbar/barclamp-tempest/pull/14 merged.
+2012-12-05 09:47:52 -0600: https://github.com/crowbar/barclamp-zookeeper/pull/11 merged.
+2012-12-05 09:47:52 -0600: Pull requests merged.
+2012-12-05 09:47:52 -0600: You can use ./dev fetch to pull in updated pull request information.
+victor@system76:~/crowbar$
+
+More stuff on the way, including integrating this with Jenkins and
+adding pull request commenting functionality to Dev.
+
+Sample workflow for pull request review:
+
+ 1: Reviewer runs ./dev fetch, and notices that there are open pull requests.
+ 2: Reviewer runs ./dev pull-requests list to see what all pull
+    requests are available to be reviewed.
+ 3: Reviewer runs ./dev pull-requests show <id> to see details on what
+    was included as part of the pull request.  This will include links
+    to the pull request on Github.
+ 4: Reviewer uses Github and standard Git tools to compare the pull
+    request with the current state of the trees.
+ 5: Reviewer runs ./dev pull-requests builds <id> to see what all
+    builds are applicable to the pull request.
+ 6: Reviewer tests to see if the build merges cleanly with their
+    current code by running ./dev pull-requests switch <id> <build>.
+    If there are any merge conflicts, dev will inform the reviewer and
+    reset the working trees to their previous state.  Otherwise, the
+    working trees will be left in a state that reflects the results of
+    merging the pull request into the appropriate release/build in the
+    reviewers repository.  Any repositories that have code merged in
+    from the pull request will be left in a detached HEAD state, and
+    neither the local tracking branches for the pull request nor the
+    reviewers branches will be changed.
+ 7: Reviewer runs unit tests against the merged code.
+ 8: Reviewer spins up a build and smoketests it.
+ 9: If the unit tests and functional tests pass, the code passes code
+    review, and the submitter has signed a CLA, otherwise the reviewer
+    leaves notes in the pull requests that reflect what the submitter
+    needs to do to make the pull request acceptable.
+10: Reviewer runs ./dev pull-requests merge <id> to merge the pull requests.

--- a/doc/devguide/development/README.dev-and-workflow
+++ b/doc/devguide/development/README.dev-and-workflow
@@ -1,0 +1,325 @@
+This file documents dev, the workflow helper tool for Crowbar
+development.
+
+dev is designed to help automate the workflow and infrastructure
+related tasks associated with development in general with the Crowbar
+git tree layout.  Dev is designed around the following assumptions:
+
+ * Everyone has their own forks on Github of the Crowbar repository
+   and all of the barclamps.
+ * Your development workflow will involve regular synchronization
+   against your upstream repositories.
+ * The only path for getting code into upstream repositories is via
+   pull request.
+
+Requirements:
+
+ * A checkout of Crowbar.
+ * Bash 4, ruby, rubygems, and the json gem.
+   If running under Windows, make sure that all these operate in your
+   cygwin or msysgw enviromnent.
+ * A github username and password.
+
+Releases, Builds, and Barclamps:
+
+A release is a collection of builds, which in turn are collections of
+barclamps and some associated build-specific metadata.
+
+Releases are intended to be long-running, primary units of maintenance
+and development for a collection of builds. By convention, every
+release has a master build that contains references to the core
+crowbar barclamps, along with other builds that may add other
+barclamps to add extra capabilities.
+
+Builds how a specific product in a release is built and what it
+includes.  It includes references to barclamps, and any build-specific
+metadata and infrastructure.
+
+Barclamps enable Crowbar to manage sets of services across a
+cluster. All of Crowbar's functionality is implemented in terms of
+barclamps. Barclamps consist of independent git repositories with a
+well-defined and dev-controlled branching structure.
+
+Crowbar expects release and build names in the following formats:
+
+release
+release/build
+
+Any exceptions for specific commands will be documented in the help
+for that command.
+
+Release Branching Structure:
+
+The dev tool has the notion of a release, which it manages in terms of
+a directory hierarchy rooted at the releases/ directory in the main
+Crowbar repository.  Currently implemented release types are:
+
+ * Development is where the day-to-day development on new features and
+   bugfixes happens.  All master branches in the barclamps are
+   considered to be in the development release.
+ * Releases, which consist of released versions of Crowbar.  All
+   releases but development are considered to be stable, and any code
+   added to a release is either a bugfix or a backwards-compatible
+   functionality enhancements. Releases are named with a unique name
+   (similar to Ubuntu or Debian release names).
+
+   All barclamps which are members of a release must have a branch named
+   release/<release name>/master.
+ * Feature bundles, which are designed to be relatively independent
+   development streams in the main development stream.  Features are
+   intended to be used to implement a specific bugfix, enhancement,
+   or new feature that is relatively independent of the rest of the
+   development stream, but that will be merged back into development
+   when it is code complete. Features must have unique names, and
+   should be descriptive of what the feature is doing.
+
+   All barclamps which are members of a feature must have a branch
+   named feature/<feature name>/master.
+
+How Releases are Tracked:
+
+All releases are tracked in the following directory structure:
+
+$CROWBAR_DIR/
+  releases/
+    <release name>/
+       <build name>/
+          barclamp-<barclamp name>
+          ...
+          crowbar.json
+          <other build-specific .json files>
+          extra/
+            <build-specific scripting and install bits>
+          change-image/
+            <build-specific ancillary commands>
+
+For a build to be considered valid by the dev tool, it must have a
+barclamp-crowbar entry that points at a valid branch in the crowbar
+barclamp.
+
+For a release to be considered valid by the dev tool, it must contain
+a valid master build.
+
+Remotes:
+
+Dev expects to manage the various remotes that you work with to pull
+changes from and issue pull requests against.  dev wraps the git add,
+rm, and set-remote commands to ensure that remotes are named
+identically across the main Crowbar repo and the barclamps.  dev also
+adds the concepts of the remotes having priorities, which are assigned
+in inverse numerical order -- a remote with priority 1 us higher
+priority than a remote with priority 50, and so on.  Remote priorities
+also determine where barclamps are initially cloned from, and how
+remote tracking branches are configured.
+
+By default, the remote you cloned dev from will be assigned priority
+5, the remote named personal will have priority 95, and everything
+else will get priority 50.  You can change the priority of a remote at
+any time with the dev remote priority command.
+
+When ./dev setup is run, dev will create consistently-named remotes
+across all the Crowbar repositories, add a personal remote based on
+your github ID, and delete any remotes named origin in any of the
+Crowbar repositories -- since we calculate what the upstream remote is
+on a branch-by-branch basis, we don't need a per-repository origin remote
+that can be inconsistent from repository to repository.
+
+If there is a remote named personal, it will be used as the default
+target for backing up local changes and for creating placeholder
+branches for pull requests. dev setup will create a personal remote by
+default -- if you delete it you will no longer be able to use the dev
+tool to back up local changes or issue pull requests.
+
+
+Day to Day Workflows:
+
+Initial Setup:
+
+ 1: Clone the Crowbar repository from you preferred upstream fork of
+    Crowbar.  If you are not sure where to clone from, use
+    https://github.com/crowbar/crowbar.git.
+ 2: Run crowbar/dev setup.
+    a: Provide your github login ID and password.  Dev will need it to
+       to handle talking to Github.
+    b: dev will set up a remote for the upstream account you forked
+       from and a personal remote.  Both of these remotes will point
+       at the appropriate urls from Github.
+    c: dev will clone any Crowbar repositories from your upstream
+       Crowbar repositories on to your local system.
+    d: dev will also create personal forks of all the upstream
+       repositories into your personal Github account
+ 3: Create your local build cache.  See README.build for more
+    information.
+
+Regular Development:
+
+ 1: Run dev fetch followed by dev sync to fetch and merge changes from
+    your upstream repositories.
+    a: Dev will fetch all changes from all upstream remotes for all
+       repositories.
+    b: Dev will attempt to synchronize all the local branches with
+       their corresponding remote branches.  If there are merge
+       conflicts, the sync process will stop at the branch that was
+       having problems.  From there, you can manually fix the
+       conflicts and rerun dev sync. If the result of merging a branch
+       and rebasing it are conflict-free and result in identical
+       working trees, dev will prefer the rebased version of the branch.
+ 2: Run dev new-feature <featurename> to start working on a new
+    feature.
+    a: This command should be run from the development release.
+    b: Dev will create branches in the feature/<featurename> namespace
+       in the main Crowbar repository and in all the barclamps.  The
+       initial starting point for these branches will be the tips of
+       the corresponding branches in the development namespace.
+ 3: Hack/build/test/commit.
+ 4: Run dev backup to back up your changes.  This force-pushes your
+    changes to your personal forks of the crowbar repositories on
+    Github.
+ 5: If you are not ready to create a pull request for your changes, go
+    to 1.
+
+Collaborating on a Feature:
+Make Feature available for fetch:
+
+ 1: Run dev push-release feature/<featurename>
+    a: dev will create branches for this release on github/crowbar
+ 2: Run git push crowbar master
+    a: dev will update the github/crowbar/Crowbar main repo with the
+       metadata necessary for others to manage this feature
+
+Grabbing a feature and starting to hack on it:
+
+ 1: Normal dev fetch and dev sync will make the feature available in your
+     local repo.
+ 2: dev releases will show you the available releases and features
+ 3: dev switch feature/<featurename> will checkout that feature in your working
+    copy
+
+Merging changes from parent into feature/<featurename>
+
+ 1: Commit your current work to your local repo. git commit -am 'cool message'
+ 2: Run ./dev find-parent returns the name of your working copy's parent.
+ 3: Run ./dev sync <parent>  (no branch name allowed)
+
+Merging changes from your now complete feature back into parent:
+
+ 1: ./dev switch <parent>
+ 2: ./dev sync feature/<featurename>
+
+Ready for pull request:
+
+ 1: Run dev pull-requests-prep
+    a: dev will verify that all the local Crowbar repositories are "clean".
+    b: dev will perform a fetch and a sync, and abort if there were any
+       merge conflicts.
+    c: dev will figure out what barclamps and what main Crowbar
+       branches are candidates for a pull request in the current release.
+    d: dev will print a command line with all the branches and
+       barclamps that are candidates for pull requests in the current release.
+ 2: Run dev pull-requests-gen
+    a: dev will ask for a title to be used for all the pull requests.
+    b: dev will open an editor for you to type in a body that will be
+       used for all the pull requests that will be generated.
+    c: dev will work out the proper order that a reviewer will need to
+       merge the pull requests in based on barclamp submodule and
+       branch dependencies.
+    d: dev will issue pull requests in the order worked out
+       earlier. Each individual pull request will have a sequence
+       number added to the title indicating the proper merge order.
+    e: Reviewers for your upstream repository will review the pull
+       requests and merge them as appropriate.
+
+Review pull request:
+
+  See README.dev-and-code-review
+
+Release Workflows:
+
+Getting a list of known releases:
+
+ 1: Run dev releases
+
+Getting the release you are currently on:
+
+ 1: Run dev release
+
+Switching to a different release:
+
+ 1: Run dev switch <release name>
+    a: dev will verify that the barclamp repositories are "clean", and
+       it will refuse to do anything if they are not.
+    b: dev will checkout the appropriate master branch for the release
+       in all the barclamps.
+
+Cutting a new release:
+
+  1: Ensure that all the crowbar repositories are in the exact state
+     you want the new release to start out in.
+  2: Run dev cut_release <new release name>.
+     a: dev will verify that the release name is not already in use in
+        the current repository.
+     b: dev will create the master branch for the new release in each
+-        of the barclamps.
+     c: dev will create a branch structure for the new release based
+        on the branch structure of the current release.
+
+Managing multiple remotes:
+
+  Key concepts:
+    * There is no such thing as an "origin" remote -- instead, the
+      "best" origin remote depends on what branch of a release you
+      happen to be working on at that time.
+    * Instead, remotes have priorities, and these priorities control
+      what the "best" upstream for any given branch is on a branch by
+      branch basis.
+    * dev owns and controls the tracking branches, and changes what
+      branches track what remotes based on the priority of the remotes
+      that the remote tracking branches are in.
+
+The dev script knows how to manage releases spread out across multiple
+remotes.  When dev initially set things up, it created 2 remotes:
+ * 1 named after the name of the repository Crowbar was forked from, and
+ * 1 named personal that pointed at your fork of Crowbar.
+
+The dev script knows how to keep all the remotes in sync across the
+barclamps -- it can add, remove, change source URLs, and synchronize
+barclamp remotes across all your local clones of the Crowbar
+repositories in a consistent fashion.
+
+Whenever you do anything that changes the total set of remote branches
+using dev, it will recalculate which local branch should track what
+remote branch based on the priorities of the remotes involved.
+
+If your working circumstances involve not always having access to all
+the remotes you have configured, you can set the DEV_AVAILABLE_REMOTES
+environment variable to a list of remotes that are available.  dev
+will only try to operate on remotes that it currently thinks are
+reachable, but things will probably not work too well if origin gets
+excluded.
+
+You can see what commands dev has by running dev with no arguments,
+and you can get detailed help on each command by running dev help with
+the command name.
+
+Commands that expect to talk remotely:
+
+backup: Force-pushes data to your personal remote.
+clone-barclamps: Clones remote barclamps on to your local system and
+  into your personal remote (if configured.)
+fetch: Fetches changes from remotes into your local Got repository.
+  Does not change working tree.
+pull-requests-gen: Pushes placeholder branches for Github pull
+  requests, issues pull requests using the Github API.
+pull-requests-prep: Calls fetch internally.
+push: Pushes branches to personal remote.
+push-release: Pushes a release to a remote.
+remote add: Probes for the existence of remotes, fetches changed from
+  newly-configured remote.
+remote set-url: Ditto
+remote sync: Ditto.
+scrub-merged-pulls: Erases placeholder branches for Github pull
+  requests that have been merged.  Fetch calls this internally as needed.
+setup: Clones barclamps, adds and syncs remotes, verifies Github ID
+  and passwords.
+
+All other commands operate just on your local repository.

--- a/doc/devguide/development/README.heterogenous-os-support
+++ b/doc/devguide/development/README.heterogenous-os-support
@@ -1,0 +1,34 @@
+This file documents how to deploy multiple different operating systems
+in Crowbar.
+
+Right now deploying a hetrogenous OS cluster in Crowbar relies on a
+few prerequisites:
+ * Online mode.
+   You need to have the provisioner configure to operate in online
+   mode to deploy multiple different operating systems.  This is
+   needed to allow the operating systems to pick up all the packages
+   they well need for a node installation. See README.package-updates
+   for more information about setting the provisioner to online-mode.
+ * online_mirror stanzas in the deployed provisioner proposal for all
+   operating systems you wish to deploy.
+   These are needed so that the provisioner find the proper location
+   to copy all the information needed to kick off a network-based
+   installation of an operating system.  The defaout proposal includes
+   stanzas for the Ubuntu and CentOS operating system releases Crowbar
+   supports.
+ * Proper recipe supoprt for the OS in the provisioner.
+   Right now we only include support for Ubuntu and CentOS.  Adding
+   Redhat support is trivial, and adding SuSE support is slightly less
+   so.
+
+Once the above prerequisites are met, you can use the crowbar
+provisioner command to query the list of available oses a node can
+install, and view and change the OS the provisioner will deploy on to
+a node.  The new commands are:
+ * crowbar provisioner oses
+ * crowbar provisioner current_os <nodename>
+ * crowbar provisioner set_os <nodename> <os>
+
+You can run these commands at any time, and the next time a node
+transitions through the installing or reinstall states it will have
+the appropriate operating system installed.

--- a/doc/devguide/development/README.knife-config.md
+++ b/doc/devguide/development/README.knife-config.md
@@ -1,0 +1,36 @@
+# Interact with Chef #
+
+First you must sync local date and time with that on the target system. Especially if you run in a development environment and did not do so on installation (chef protects agains replay attacks and needs a correct time setting) 
+
+Get your local time 
+
+    echo \'date -us \"`date -u "+%Y-%m-%d %H:%M"`\"\' 
+    'date -us "2012-10-10 18:07"'
+
+and set it on all nodes (from the crowbar admin machine as root)
+
+    knife ssh node:* -- 'date -us "2012-10-10 18:07"'
+
+Next copy your `/etc/chef/webui.pem` file from the admin machine to `.chef/webui.pem`
+
+Copy the template knife.rb file and set the server url to the correct value
+
+    cp .chef/knife.rb.example .chef/knife.rb 
+
+copy the template `.rvmrc` in place and trust it (or install the corresponding ruby)
+
+    cp dot-rvmrc .rvmrc
+    rvm rvmrc trust .
+    rvm rvmrc load
+
+install chef with the Gemfile 
+
+    bundle install
+
+finally you can work with knife from your local maschine:
+
+    $ knife status
+    6 minutes ago, admin.v1.cr0wbar.de, admin.v1.cr0wbar.de, 10.124.0.10, ubuntu 12.04.
+    4 minutes ago, dc0-ff-ee-00-00-02.v1.cr0wbar.de, dc0-ff-ee-00-00-02.v1.cr0wbar.de, 10.124.3.2, ubuntu 12.04.
+    4 minutes ago, dc0-ff-ee-00-00-01.v1.cr0wbar.de, dc0-ff-ee-00-00-01.v1.cr0wbar.de, 10.124.3.3, ubuntu 12.04.
+    3 minutes ago, dc0-ff-ee-00-00-03.v1.cr0wbar.de, dc0-ff-ee-00-00-03.v1.cr0wbar.de, 10.124.3.1, ubuntu 12.04. 

--- a/doc/devguide/development/README.online-install
+++ b/doc/devguide/development/README.online-install
@@ -1,0 +1,46 @@
+This file documents how to install Crowbar on a basic install of
+Ubuntu or CentOS without needing to create a crowbar ISO first.
+
+Caveats:
+ * Online install mode still has plenty of bugs to work out.
+ * Especially where the Crowbar web UI is concerned.  Doing an online
+   install as described by this README will result in a broken web
+   UI.  The Crowbar CLI still works, though.
+ * Online install mode is primarily intended as a development aid for
+   now.  If you want to deploy something more production oriented,
+   build the ISO using the usual build process.
+
+Assumptions:
+ * Your primary NIC has an IP address of 192.168.124.10/24
+ * You have at least 20 gigs of disk space and 4 gigs of ram.
+ * You are running either as root or as crowbar.
+
+Instructions:
+
+ 1: Install a basic install of Ubuntu Server or CentOS.
+ 2: Do whatever is needed to be able to install packages from the Internet.
+ 3: Install git, rubygems, the ruby development packages, rpm, sudo,
+    debootstrap, and the json gem. This may involve setting up sane http_proxy
+    and https_proxy environment variables.
+ 4: Clone the Crowbar repository from
+    http://github.com/crowbar/crowbar.git, and cd into the
+    newly-created crowbar directory.
+ 5: In the crowbar repository, run ./dev switch.  This will check out
+    the barclamps we need.
+ 6: Run ./install, and wait.
+ 7: Profit.
+
+Neato things:
+
+ * You don't need to have a direct connection to the Internet at all
+   to deploy Crowbar with this code.  The install process pulls
+   all the packages it needs entirely over http, so all you need
+   is access to an http proxy that does have access to the Internet.
+   If you export an appropriate http_proxy before starting the
+   install, the install process and any nodes you bring up will wind
+   up using that proxy for all package fetching.
+ * The current code deploys its own caching proxy before installing
+   anything.  This allows us to minimize the amout of data we have to
+   pull from the Internet.
+ * You don't need to have ISO images of the operating systems you want
+   to install as long as you have an active Internet connection.

--- a/doc/devguide/development/README.package-updates
+++ b/doc/devguide/development/README.package-updates
@@ -1,0 +1,36 @@
+This file documents how to enable basic support for handling package
+updates in Crowbar.
+
+Assumptions:
+
+ * You have installed a Crowbar admin mode by creating a Crowbar ISO
+   and installing the admin node from it.
+ * The provisioner either has access to the Internet or visibility to
+   an HTTP proxy that does. The usual way of doing this is by
+   allocating a host IP address from the public network to the admin
+   node.  See the Crowbar users guide for more information on how to
+   do this.
+ * If you are going the HTTP proxy route, that proxy does not require
+   any form of authentication.
+ * You built your Crowbar ISO from a Crowbar checkout that is recent
+   enough to have this file in it.
+
+
+Enabling Online Mode
+
+ 1: In the Crowbar web UI, click on Barclamps, click on Provisioner, and
+    then click on Edit.  This will open the editing pane for the default
+    provisioner proposal.
+ 2: Find the "online": value, and change it from false to true.
+ 3: If you need to use an upstream HTTP proxy, find the
+    "upstream_proxy": value and change it to contain the address and
+    port of the proxy in the following format: "address:port"
+ 4: Click Save, then click Apply.  Once the proposal is finished
+    applying, apt/yum/gem on all the nodes will be configured to allow
+    package updates from the Internet.
+
+Caveats:
+ * This is still a work in progress.  Crowbar does not have any
+ controls around what packages may or may not be updated, so it is
+ possible that updating certian packages may break your cluster or
+ whatever applications your barclamps are managing.

--- a/doc/devguide/development/README.sledgehammer
+++ b/doc/devguide/development/README.sledgehammer
@@ -1,0 +1,35 @@
+Sledgehammer is the component of Crowbar that we use as a bootstrapping 
+tool to perform initial node discovery and to register its discovered
+state within the Crowbar node provisioning framework. After it has been
+discovered Sledehammer can be controlled to prepare the hardward and to 
+lay down the operating system and to assure correct node configuration.
+It consists of a slightly modified Centos 6.2 live environment.  To build
+Sledgehammer you need:
+
+  * A CentOS 6.2 install DVD from bittorrent or your favorite CentOS
+    mirror. This install DVD will need to go in $ISO_LIBRARY
+    (usually $HOME/.crowbar-build-cache/iso).
+  * Ruby, rpm, and rpm2cpio.
+
+By default, the Crowbar build process will try and build Sledgehammer
+if it is not already present in the build cache, so you should not
+need to do anything special to build Sledgehammer.  If you need to
+update Sledgehammer, run the build_sledgehammer.sh script in the main
+Crowbar checkout.
+
+Execute;
+	#> sudo build_sledgehammer.sh
+Output:
+The build process creates an ISO image that will be emmbedded within an
+initrd file.  The initrd file and all controls needed to use it will be
+installed into the $ISO_LIBRARY/tftpboot directory (see ~/.build-crowbar.conf.
+
+Note:
+To debug build_sledgehammer.sh operation set in ~/.build-crowbar.conf
+or in the environment:
+	DEBUG=1
+	SLEDGEECHO="echo"
+This provides details logs and preserves intermediate files that are 
+otherwise removed during processing. These files can be helpful for
+diagnositc purposes BUT SLEDGEECHO should be null (empty) for prodction
+use.

--- a/doc/devguide/development/README.sledgehammer-hooks
+++ b/doc/devguide/development/README.sledgehammer-hooks
@@ -1,0 +1,81 @@
+This file documents the hooks available in the Sledgehammer image that
+can be used to customize how Sledgehammer transitions through states.
+
+The primary Sledgehammer control script (control.sh) will search for
+-pre and -post hooks for every Crowbar state transition it knows how
+to go through. The hooks can be general (all nodes transitioning
+through the state will run them) or specific to one machine. This
+functionality is intended to be used to facilitate automated testing
+that must happen outside of the chef-client runs.  Hooks will run in
+the following order:
+
+1: Machine-specific -pre hooks,
+2: General -pre hooks,
+3: chef-client,
+4: General -post hooks,
+5: Machine-specific -post hooks.
+
+All hooks will be run in alphabetic order, and non-executable hooks
+will be skipped.  All hooks to be run should be staged in the /updates
+NFS share on the admin node in the following directories:
+
+ * /updates/$nodename/$state-pre
+ * /updates/$state-pre
+ * /updates/$state-post
+ * /updates/$nodename/$state-post
+
+$state = the Crowbar state that Sledgehammer is transitioning through.
+         discovering, discovered, update, etc.
+
+$nodename = the name of the node according to Chef.
+
+To make writing hooks simpler, certian functions in the control.sh script
+have been split into /updates/control_lib.sh, and control.sh has been
+refactored to account for these changes.  If your hooks are written in
+bash, they can source /updates/control_lib.sh to pull in the following
+functions:
+
+* get_state <node>
+  get_state will pull some information about <node> from the
+  chef-server, and store it in the local environment.  Specifically,
+  it will set the following environment variables:
+  BMC_ROUTER = the gateway IP address of the BMC network, if any.
+  BMC_ADDRESS = the IP address of the BMC for <node>, if any.
+  BMC_NETMASK = the netmask in dotted quad format of the BMC network,
+                if any.
+  CROWBAR_STATE = the current Crowbar state that the node is in.
+  HOSTNAME = the hostname of the system according to the Chef server.
+  ALLOCATED = whether or not <node> has been allocated
+
+* post_state <node> <crowbar_state>
+  post_state will attempt to transition <node> to <state>.  If
+  successful, it will then update the same environment data that
+  get_state does.
+
+* reboot_system
+  This will cleanly reboot the node.  You should use it instead of
+  reboot to ensure that all the logs are flushed and that the NFS
+  shares get umounted.
+
+* wait_for_allocated <node>
+  This function will spin until <node> has been allocated by Crowbar.
+
+* wait_for_crowbar_state <node> <state>
+  If <state> is not passed, this function will wait until <node>
+  transitions to a state other than the one it is currently at.  If
+  <state> is passed, this function will wait until <node> transitions
+  into <state>
+
+* hook_has_run
+  If the current hook has already run for the current -pre or -post
+  state, hook_has_run will return 0.  Otherwise, return 1.  This
+  function works by creating state tracking files in /install-logs/.
+  To facilitate this function, control.sh exports the following
+  environment variables to the hooks:
+  * HOOKNAME = the name of the hook without any path components.
+  * HOOKSTATE = the -pre or -post state that the hook is running in.
+
+Hook Exit Status
+
+All hooks must exit successfully (with a 0 return status), otherwise
+the system will reboot into the debug state.

--- a/doc/devguide/development/README.smoketest
+++ b/doc/devguide/development/README.smoketest
@@ -1,0 +1,97 @@
+This file documents the Crowbar smoketest framework
+
+Note: The default admin node memory allocation is 4G.  It may be necessary to
+run smoke tests with more (6 or 8G) to get speedy or reliable results.  The
+default 4G memory override can be set by adding to the .build_crowbar.conf
+file the following:  ADMIN_MEM=6G, or ADMIN_MEM=8G  (do not quote the values)
+
+The smoketest framework lives on the admin node, and consists of:
+  * smoketest
+    This is the front-end to the in-cluster side of the smoketest framework.
+    It takes a single parameter, which is the name of a barclamp to smoketest.
+    smoketest must be run as root.
+  * check_ready
+    This checks to see if a node had transitioned to a given state.
+    smoketest uses it internally.
+  * run_on
+    This runs a command on a given node as root.
+  * knife_node_find
+    This is a very thin and stupid wrapper around knife search node.
+  * name_to_ip
+    This translates an hostname into an IP address.
+  * parse_yml_or_json
+    This is a cheesy little function that parses yml (or JSON), extracts
+    fields of interest, and prints them in a form suitable for bash's eval.
+
+The smoketest command works like this:
+  * Your admin node is in the ready state, and the rest of the nodes are
+    in discovered.
+  * You run /opt/dell/bin/smoketest nova (for example).
+  * smoketest allocates all the nodes, and waits for them to transition
+    to ready. If any node transitions to problem, the smoketest fails.
+  * Once all the nodes are in ready state, smoketest will examine the barclamp
+    metadata for all installed barclamps. It will then deploy and test all the
+    barclamps needed to meet the dependencies of the barclamp to test, including
+    itself.
+  * The output from all the tests along with the proposals that were created,
+    modified, and deployed will be saved in /var/log/smoketests.
+  * If any deploys or tests fail, the smoketest fails.
+  * You can test more than one barclamp at a time by passing multiple arguments
+    to the smoketest command:
+    /opt/dell/bin/smoketest nova_dashboard swift tempest
+    will run the smoketests for nova_dashboard, swift and tempest and all
+    the barclamps they depend on.
+  * It is a good idea to make sure that the admin node has IP addresses on
+    the public, storage, and nova_fixed networks.  The dev tool and
+    test_crowbar.sh do this automatically, otherwise you can run this script
+    on the admin node to add the networks:
+
+#!/bin/bash
+# Give the admin node IP addresses on the other networks we care about.
+# This will make the life of the smoketests easier.
+
+[[ -f /opt/dell/.all_nets ]] && exit 0
+touch /opt/dell/.all_nets
+for n in "public host" "storage host" "nova_fixed router"; do
+    crowbar network allocate_ip default $(hostname --fqdn) $n
+done
+
+/opt/dell/bin/blocking_chef_client.sh
+
+
+Writing Barclamp Smoketests
+
+  Barclamp smoketests consists of three parts:
+  * Smoketest Metadata.
+    This consists of metadata in the barclamp's crowbar.yml that declares any 
+    smoketest-specific barclamp dependencies and an overall timeout that the
+    smoketest for this barclamp cannot exceed.  The smoketests use the
+    following metadata:
+    * barclamp.requires and smoketest.requires
+      Any barclamps that are in these arrays will be deployed and smoketested
+      before the current smoketest.
+    * barclamp.member
+      This is used to satisfy group dependencies if a group is listed as 
+      a dependency in the barclamp.requires and smoketest.requires.
+    * smoketest.timeout
+      This is the number of seconds that a smoketest can run before the 
+      framework decides that it is never going to finish and returns failure. 
+  * smoketest/modify-json
+    This executable should accept the proposal JSON on stdin, make whatever
+    changes are needed to let it run in the framework (changing free space
+    requirements, replication factors, etc), and write the modified JSON to
+    stdout.
+  * smoketest/*.test
+    These executables should each perform a discrete test of the barclamp. The
+    smoketest framework will run them in ascending order, and the first test
+    that exits with a nonzero status will signal that the overall smoketest
+    for this barclamp failed, and the framework will stop processing further
+    tests. The framework does not care what language the tests are written in,
+    as long as the build/test system can run them.
+    The smoketest framework arranges for the crowbar CLI and the framework 
+    helper commands to be available during the run.  Any output from the test
+    hooks will be captured and logged.
+  
+Any other files will be ignored by the smoketest framework -- you can use them
+for shared libraries, templates, etc. as the needs of your smoketest require.
+

--- a/doc/devguide/development/README.uefi
+++ b/doc/devguide/development/README.uefi
@@ -1,0 +1,81 @@
+This file documents the current state of UEFI booting in Crowbar
+
+Right now, we have basic support for network booting systems running
+in UEFI mode. We are able to netboot Sledgehammer and the OS install
+kernel/initrd pairs, and get to the point where we have an installed
+operating system on the compute nodes.
+
+How To Use UEFI:
+ * Switch your system to operate in UEFI mode.  How this is done
+   varies from system to system.
+ * Once the system is in UEFI mode, configure it to network boot off
+   the first nic.
+ * The crowbar framework will handle things from there.
+
+What UEFI Gives You:
+ * Native support for drive sizes > 2TB.
+ * All new low-level system firmware.
+
+What Does Not Work:
+ * Booting Ubuntu 12.04 off the hard drive.
+
+   There is a bug in how the version of Grub 2 that comes with Ubuntu
+   handles memory mapping in the UEFI environment that causes the
+   system to crash the UEFI firmware when it tries to load the kernel
+   and initrd.  Upstream grub2 has been patched to resolve this issue,
+   but the updates have not been pulled into Ubuntu 12.04 yet.
+
+   Patch is at http://savannah.gnu.org/bugs/?36532.
+
+   Possible workarounds include:
+   * Look at using grub-legacy or elilo instead of grub2 when
+     installing in UEFI mode.
+   * Working on getting Canonical to pull in an updated version of
+     Grub2 that has the patch that fixes the issue.
+
+What Had to Be Changed:
+
+ * We now generate per-node OS installation scripts and UEFI/PXE
+   config files on the fly instead of having per-OS install scripts
+   and config files.  This was needed to support network installation
+   of Redhat and CentOS due to anaconda not being able to find out
+   what NIC it booted from when installing in UEFI mode.  For
+   consistency between the UEFI and PXE netboot codepaths, the
+   per-machine UEFI and PXE config files are now IP address specific
+   instead of MAC address specific.
+
+ * When systems operate in UEFI mode, we manage the boot order
+   directly instead of assuming that we will always netboot.
+
+   Each of the OSes we support uses a different bootloader for UEFI
+   (CentOS and Redhat use grub1, and Ubuntu uses grub2), and they do
+   not have the right intersection of being able to netboot, being
+   able to chainload, and operating reliably in a network environment
+   to be useful.  Instead we use elilo, and we grab the prcompiled EFI
+   apps from Sourceforge instead of trying to compile things ourselves,
+   playing packaging shennanigans to keep our admin node bootable
+   while juggling multiple bootloaders, or have the provisioner handle
+   messing with boot templates for multiple different bootloaders.
+
+   However, none of the UEFI capable bootloaders I have found have the
+   ability just hand control back to UEFI to try the next thing in the
+   boot sequence, which means that we can no longer assume that we
+   will always netboot. Instead, I have added efibootmgr to
+   Sledgehammer and the default package installs for the operating
+   systems, and added a piece of code to the crowbar-hacks recipe
+   in the deployer that knows how to change the boot order to either
+   be nics-first or nics-last, and we set that based on the PXE state
+   machine -- if it is in execute state, we will set things to
+   nics-last, otherwise it will set things to nics-first.
+
+   In order to make that work reliably, I had to modify the
+   provisioner state machine to run chef-client on every node that is
+   transitioning out of the execute state in order to ensure that the
+   boot sequence gets updated.  This failed when transitioning into
+   reset or delete, because those states deallocate all IP addresses
+   to the nodes.  To cope with that, the network barclamp recognizes
+   when the admin network is being removed and arranges for the system
+   to run dhclient on all the interfaces until it gets an IP address.
+   Since we run chef-client on the nodes before running it on the
+   admin node, this should result in the system getting the same IP
+   address it had before, which will let the chef-client run continue.

--- a/doc/devguide/development/dev-vm-Fedora.md
+++ b/doc/devguide/development/dev-vm-Fedora.md
@@ -1,0 +1,105 @@
+# Crowbar dev environment based on Fedora
+
+## Setting up the virtual machine (VM)
+
+1. Create a new virtual network 192.168.124.0/24 (using virt-manager or virsh).
+   Do not use DHCP for this network.
+
+1. Start with a fresh Fedora 18 VM (can be minimal install).
+
+1. Assign the previously created virtual network to the VM and configure the
+   VM's networking like this:
+
+   ````
+   IP address: 192.168.124.10
+   Netmask:    255.255.255.0
+   Gateway:    192.168.124.1
+   DNS:        192.168.124.1
+   ````
+
+   (You will need to edit `/etc/sysconfig/network-scripts/ifcfg-eth0` and
+   `/etc/resolv.conf` to achieve this on a VM that was configured differently
+   during installation.)
+
+1. Connect to the machine via SSH and try to ping some address to verify that
+   traffic gets routed correctly and DNS works.
+
+   ````
+   kvm-host> ssh root@192.168.124.10
+   ````
+
+1. [Optional] If you have problems with outbound connections from VM even after
+   editing network-scripts and resolv.conf, it might be that iptables
+   forwarding rules for the virtual network didn't get created on your host
+   machine. Check that with iptables:
+
+   ````
+   kvm-host> sudo iptables -L
+
+   Chain FORWARD
+   target     prot opt source               destination
+   ACCEPT     all  --  anywhere             192.168.124.0/24     state RELATED,ESTABLISHED
+   ACCEPT     all  --  192.168.124.0/24     anywhere
+
+   (The output is shortened to show the important part only.)
+   ````
+
+   If you don't see the above forwarding rules, shut down your VMs and restart
+   libvirtd:
+
+   ````
+   kvm-host> systemctl restart libvirtd.service
+   ````
+
+   Then check the iptables output again and the forwarding rules should be there.
+
+1. Create a user on the VM for Crowbar development.
+
+   ````
+   root@crowbar-dev> useradd -m crowbar
+   root@crowbar-dev> passwd crowbar
+   ````
+
+1. Install dependencies that will be required to run the app in dev mode, build
+   discovery image ("Sledgehammer") and run tests:
+
+   ````
+   root@crowbar-dev> yum install git ruby rubygem-rake rubygem-bundler mkisofs binutils markdown erlang debootstrap ruby-devel gcc gcc-c++ sqlite-devel libxml2-devel libxslt-devel
+   ````
+
+
+## Setting up the development environment
+
+You should now have a working VM that you can SSH into from the host.
+
+1. Copy your .gitconfig and other configuration files to the VM, e.g.:
+
+   ````
+   crowbar@crowbar-dev> scp -r <your-usual-dev-host>:.{gitconfig,vimrc,vim,profile,ssh} .
+   ````
+
+1. Check out the Crowbar git repo and run the dev tool:
+
+   ````
+   crowbar@crowbar-dev> git clone https://github.com/crowbar/crowbar.git
+   crowbar@crowbar-dev> cd ~/crowbar
+   crowbar@crowbar-dev> ./dev setup --no-github
+   ````
+
+   If you want the `./dev setup` script to automatically fork the crowbar and
+   barclamp repositories into your github account, leave out the `--no-github`
+   parameter.
+
+   See [dev-and-workflow]
+   (https://github.com/crowbar/crowbar/blob/master/README.dev-and-workflow)
+   and [dev-and-code-review]
+   (https://github.com/crowbar/crowbar/blob/master/README.dev-and-code-review)
+   for details about the development process.
+
+1. Now you can run the tests. See the [testing page](testing.md) for how to do
+   it.
+
+1. After you [generated the test setup](testing.md) into the
+   `/tmp/crowbar-dev-test/opt/dell/crowbar_framework` directory, you can also
+   [run the web UI](testing/web-ui.md) from there.
+

--- a/doc/devguide/development/dev-vm-SUSE.md
+++ b/doc/devguide/development/dev-vm-SUSE.md
@@ -1,0 +1,166 @@
+# Crowbar Dev based on SUSE
+
+Here we describe how to setup a Crowbar development environment in a virtual
+machine (VM) that is based on openSUSE or SUSE Linux Enterprise Server (SLES).
+It is currently focused on the core Rails application and required barclamps.
+
+## Setting up the VM
+
+We assume that you are using KVM and have read the [KVM setup
+instructions](dev-vm.md).  If not, setup the VM accordingly and
+continue on to the [next
+section](#setting-up-the-development-environment).
+
+We assume your KVM host is the desktop you are working from, so adapt them if
+necessary.
+
+### Download the VM
+
+Download the latest version of the Crowbar Dev VM from one of the following
+locations (KVM image in `qcow2` format recommended):
+
+* [openSUSE Crowbar Dev VM](http://susestudio.com/a/n0rKOx/crowbar-dev)
+* [SLES Crowbar Dev VM](http://susestudio.com/a/n0rKOx/crowbar-dev-sles)
+
+### Boot the VM
+
+This can be done *either* via `libvirt`, *or* directly via `qemu-kvm`:
+
+#### Booting via libvirt
+
+Give the VM a name; this can be whatever you want.
+
+        kvm-host# vm_name=crowbar-admin-sles
+
+Set which bridge device you want to route the VM's NAT traffic
+through:
+
+        kvm-host# bridge=virbr0
+
+Register and boot the VM:
+
+        kvm-host# vm-install \
+                      -n $vm_name -o sles11 -c4 -m2048 -M2048 \
+                      -d qcow2:$vm_disk,xvda,disk,w,0,cachemode=none \
+                      -e \
+                      --nic bridge=$bridge,model=virtio \
+                      --keymap en-gb
+
+(Note: the above applies for openSUSE 12.3.  Older distributions may
+need tweaks, e.g. `cache=none` instead of `cachemode=none`.)
+
+Of course you can tweak the number of virtual CPUs and amount of RAM
+in the above arguments if you want.  It is not recommended to allocate
+less than 2GB of RAM to the VM.
+
+Once the VM is registered with `libvirt`, you can later control it
+using `virt-manager` in the normal way.
+
+#### Booting via qemu-kvm
+
+1.  Place the image in the `dev-setup/qemu-kvm` directory of the [Crowbar
+    git](https://github.com/crowbar/crowbar/) checkout on your KVM host.
+
+1.  [Optional] Set which bridge device you want to route the VM's NAT
+    traffic through:
+
+            kvm-host# export BRIDGE=virbr0
+
+1.  Start the VM by running the following as root:
+
+            kvm-host# ./start-vm
+
+    Use the `--preallocate` option if you need to improve disk performance.
+
+### Post-boot
+
+1.  [SLES VM only] Connect to the VM's graphical console to accept the
+    end user license agreement (EULA).  If you used `qemu-kvm`,
+    connect via VNC, e.g.:
+
+            kvm-host> vncviewer :10
+
+    Otherwise you will already see the console, but you can also connect
+    via `virt-manager` or `vncviewer`.
+
+    Once connected, type `q`, `y`, and hit enter.
+
+1.  After the VM boots up (takes a bit longer for first boot), you
+    should be able to connect to the VM via SSH:
+
+            kvm-host> ssh root@192.168.124.10            # Password is 'linux'
+
+1.  [SLES only] If you're running the VM within the SUSE network, run
+    `add-suse-internal-repos` to add the internal SUSE
+    repositories. Otherwise, if you have a SLES subscription, register
+    with NCC to get updates.
+
+1.  Create a non-root user account and set the password. Use the same
+    username as you do on your regular workstation for
+    convenience. Then re-login to the dev VM as the newly created
+    user, e.g.:
+
+            root@crowbar-dev> useradd -m jamestyj
+            root@crowbar-dev> passwd jamestyj
+            root@crowbar-dev> logout
+            jamestyj@kvm-host> ssh 192.168.124.10
+            jamestyj@crowbar-dev>
+
+## Setting up the development environment
+
+You should now have a working VM that you can SSH into from the qemu-kvm host.
+
+1.  Copy your `.gitconfig` and other configuration files to the VM, e.g.:
+
+            crowbar-dev> scp -r <your-usual-dev-host>:.{gitconfig,vimrc,vim,profile,ssh} .
+
+1. Check out the Crowbar git repo and run the dev tool:
+
+            crowbar-dev> git clone git://github.com/crowbar/crowbar.git
+            crowbar-dev> cd crowbar
+            crowbar-dev> ./dev setup
+
+    The `./dev setup` script will ask for your Github username and
+    password. It will fork the Crowbar and corresponding barclamp
+    repositories to your account and clone them into
+    `crowbar/barclamps/`. See
+    [dev-and-workflow](https://github.com/crowbar/crowbar/blob/master/README.dev-and-workflow)
+    and [dev-and-code-review](https://github.com/crowbar/crowbar/blob/master/README.dev-and-code-review)
+    for details.
+
+1.  Now assemble the Crowbar application:
+
+            crowbar-dev> ./dev tests setup --no-gem-cache
+
+    This assembles a working and testable Crowbar Rails application in
+    `/tmp/crowbar-dev-test/opt/dell/crowbar_framework`.
+
+1.  Now you can run an instance of the web UI:
+
+            crowbar-dev> cd /tmp/crowbar-dev-test/opt/dell/crowbar_framework
+            crowbar-dev> bundle install
+            crowbar-dev> bundle exec rake db:migrate
+            crowbar-dev> bundle exec rails s puma
+
+1. And also to run the (unit + RSpec) tests:
+
+            crowbar-dev> bundle exec rake db:drop railties:install:migrations db:migrate db:fixtures:dump test:units spec
+
+See the [testing page](testing.md) for details.
+
+## Troubleshooting tips
+
+1.  Connect to the VM via VNC. This is useful for debugging the VM (e.g.
+    networking issues).
+
+            kvm-host> vncviewer :10
+
+    The VM is configured with the following settings:
+
+            IP address: 192.168.124.10
+            Netmask:    255.255.255.0
+            Gateway:    192.168.124.1
+            DNS:        10.120.2.88, 8.8.8.8
+
+    You may need to update the DNS setting to match your environment
+    by modifying `/etc/resolv.conf`.

--- a/doc/devguide/development/dev-vm-Ubuntu.md
+++ b/doc/devguide/development/dev-vm-Ubuntu.md
@@ -1,0 +1,120 @@
+# Crowbar Dev environment based on Ubuntu
+
+## Setting up the virtual machine (VM)
+
+Currently only Ubuntu 12.04 LTS is supported, though the instructions here
+should also work with other versions.
+
+The steps here describe how to setup the VM from the command line. You can use
+[virt-manager](http://virt-manager.org) if you prefer a graphical user
+interface. Do submit your relevant virt-manager configs if you have some!
+
+The steps here assume that your KVM host is also the desktop that you are
+working from. If not, adapt the commands accordingly.
+
+Installation steps:
+
+1. Download Ubuntu 12.04 LTS 64 bit (`ubuntu-12.04.1-server-amd64.iso`) from
+   http://www.ubuntu.com/download/server. For example, run the following
+   commands within the Crowbar git checkout on the qemu-kvm host:
+
+   ````
+   cd dev-setup/qemu-kvm
+   aria2c http://releases.ubuntu.com/precise/ubuntu-12.04.1-server-amd64.iso.torrent
+   ````
+
+1. Create a blank disk image that is at least 20 GB, eg:
+
+   ````
+   qemu-img create -f qcow2 -o preallocation=metadata ubuntu-12.04.qcow2 20G
+   ````
+
+1. Start a VM with the desired network (private network with NAT), with the ISO
+   and disk attached. For example:
+
+   ````
+   sudo qemu-kvm -m 2G -daemonize -vnc :10 -cdrom ubuntu-12.04.1-server-amd64.iso \
+                 -net nic,model=virtio,macaddr=DE:AD:BE:EF:30:22 \
+                 -net tap,script=qemu-ifup \
+                 -drive file=ubuntu-12.04.qcow2,cache=none,if=virtio
+   ````
+
+   Note that `script=qemu-ifup` points to the script at `qemu-kvm/qemu-ifup`,
+   so make sure you are running the above command in the same directory, or
+   modify it accordingly.
+
+1. Connect to the VM via VNC and install the system:
+
+   ````
+   vncviewer :10
+   ````
+
+   The installer will attempt to auto-configure the network with DHCP, which
+   you can cancel and jump to manual configuration instead with the following
+   settings:
+
+   ````
+   IP address: 192.168.124.10
+   Netmask:    255.255.255.0
+   Gateway:    192.168.124.1
+   ````
+
+   Use the same name server (DNS) address as your host, which you can find out
+   on Linux systems by running `grep nameserver /etc/resolv.conf` on the host.
+   For example, within the SUSE intranet it is `10.120.2.88`. If the host is not
+   running in any internal or corporate network, you can use `8.8.8.8`.
+
+   The hostname and domain names can be left at the defaults. The apt-get proxy
+   can also be left blank.
+
+1. Once installation is complete, you can shutdown the VM (`sudo poweroff`) and
+   subsequently start it in the same way, minus the `-cdrom ...` option. Or
+   use the [qemu-kvm/start-vm](https://github.com/crowbar/crowbar/blob/master/dev-setup/qemu-kvm/start-vm))
+   helper script.
+
+## Setting up the development environment
+
+You should now have a working VM that you can SSH into from the qemu-kvm host.
+For example:
+
+    ssh 192.168.124.10
+
+The VM should also be able to access the external network. We can now start
+with setting up the Crowbar development environment.
+
+1. Install the basic Crowbar dev tool dependencies:
+
+   ````
+   sudo apt-get install git rubygems
+   sudo gem install json --no-ri --no-rdoc
+   ````
+
+1. Copy your .gitconfig and other configuration files to the VM, eg:
+
+   ````
+   scp -r <your-usual-dev-host>:.{gitconfig,vimrc,vim,profile,ssh} .
+   ````
+
+1. Check out the Crowbar git repo and run the dev tool:
+
+   ````
+   git clone git://github.com/crowbar/crowbar.git
+   cd crowbar
+   ./dev setup
+   ````
+
+   The `./dev setup` script will ask for your Github username and password. It
+   will fork the Crowbar and corresponding barclamp repositories to your
+   account and clone them into `crowbar/barclamps/`. See [dev-and-workflow]
+   (https://github.com/crowbar/crowbar/blob/master/README.dev-and-workflow)
+   and [dev-and-code-review]
+   (https://github.com/crowbar/crowbar/blob/master/README.dev-and-code-review)
+   for details. This will take a while so get some coffee.
+
+1. Install dependencies required by the test suite:
+
+   ````
+   sudo apt-get install ruby-dev ruby-bundler libsqlite3-dev g++ erlang-base erlang-inets
+   ````
+
+Now see the [testing page](testing.md) for how to run the tests.

--- a/doc/devguide/development/dev-vm.md
+++ b/doc/devguide/development/dev-vm.md
@@ -1,0 +1,49 @@
+# Getting started with Crowbar development
+
+Setting up a full Crowbar development environment is complex due to its many
+dependencies - we are simplifying and automating this process as much as
+possible. This document provides detailed instructions on how to setup a
+_minimal Crowbar development instance_: access to the web interface and the
+ability to run the unit, RSpec, and BDD tests.
+
+We assume you are setting up the Crowbar development environment in a qemu-kvm
+virtual machine (VM). It is not a hard requirement - just adapt the steps and
+commands accordingly.
+
+If you prefer other hypervisors, check out the corresponding [VirtualBox]
+(https://github.com/crowbar/crowbar/wiki/Running-Crowbar-in-VirtualBox-VMs) and
+[VMWare]
+(https://github.com/crowbar/crowbar/wiki/Running-Crowbar-in-VMWare-VMs) docs.
+Then skip to the "Setting up the development environment" section of your
+preferred distro.
+
+If you are using Fedora 18, [these scripts]
+(https://github.com/cwolferh/crowbar-virt-for-f18) may save you a bit of time
+setting up a qemu-kvm/virsh environment for Crowbar.
+
+## Setting up the qemu-kvm host
+
+### Installing KVM
+
+First you need to install KVM. On SUSE based systems, run:
+
+    sudo zypper in kvm
+
+### Enabling CPU virtualization acceleration
+
+[Intel VT-x]
+(http://en.wikipedia.org/w/index.php?title=X86_virtualization#Intel_virtualization_.28VT-x.29)
+or [AMD-V]
+(http://en.wikipedia.org/wiki/X86_virtualization#AMD_virtualization_.28AMD-V.29)
+capable CPUs are required for hardware acceleration. This is usually disabled
+by default in the BIOS, so you may need to enable it manually.
+
+Run the [qemu-kvm/setup-kvm]
+(https://github.com/crowbar/crowbar/blob/master/dev-setup/qemu-kvm/setup-kvm)
+script to set it up. It checks for CPU support and loads the appropriate kernel
+modules.
+
+## Setting up the virtual machine
+
+Refer to the following distro specific docs: [openSUSE / SLES](dev-vm-SUSE.md),
+[Ubuntu](dev-vm-Ubuntu.md), and [Fedora](dev-vm-Fedora.md).

--- a/doc/devguide/development/openSUSE-images.md
+++ b/doc/devguide/development/openSUSE-images.md
@@ -1,0 +1,24 @@
+# openSUSE images
+
+There are a number of openSUSE images available for different use cases:
+
+1. [Crowbar Dev VM](http://susestudio.com/a/n0rKOx/crowbar-dev). This is a
+   ready to go Crowbar development image, based on openSUSE. Tailored for those
+   who want to work on the Crowbar Rails application directly from Git sources.
+   Follow the [step-by-step instructions]
+   (https://github.com/crowbar/crowbar/blob/master/doc/devguide/dev-vm-openSUSE.md)
+   and start hacking.
+
+1. [Crowbar test image](http://susestudio.com/a/E5zfDp/crowbar-2-0). This
+   image uses the packages from [systemsmanagement:crowbar:2.0]
+   (https://build.opensuse.org/project/monitor?project=systemsmanagement:crowbar:2.0)
+   and is intended only for developer testing.
+
+1. [Crowbar staging test image]
+   (http://download.opensuse.org/repositories/systemsmanagement:/crowbar:/2.0:/staging/images/).
+   This image is similar to the one above, but uses the packages from
+   [systemsmanagement:crowbar:2.0:staging]
+   (https://build.opensuse.org/project/monitor?project=systemsmanagement%3Acrowbar%3A2.0%3Astaging).
+   The image is automatically rebuilt by [OBS](https://build.opensuse.org/)
+   whenever there are new packages/RPMs in the staging repository. Also
+   intended only for developer testing.

--- a/doc/devguide/devtool.md
+++ b/doc/devguide/devtool.md
@@ -1,0 +1,25 @@
+### Coding and Building Crowbar - DevTool
+
+The DevTool has significant inline documentation.  It is strongly recommended to review the code for help with DevTool!
+
+#### Building
+
+`./dev build --os ubuntu-12.04`
+
+#### Submitting Pull Requests
+
+1. `./dev pull-requests-prep`
+1. follow the instructions from the previous step
+
+#### Running Tests
+
+Prerequs
+1. Ubuntu 12.04.01 as the OS for DevTool
+1. `sudo gem install i18n active_support builder rails`
+
+To run the tests with DevTool, you must first setup the tests using `./dev tests setup`.  DevTool will prompt you to install any missing components.
+
+
+After you have completed setup, use `./dev tests run` to run the tests.
+
+If you want to troubleshoot the tests, all the files are in `/tmp/crowbar-dev-test/opt/dell/crowbar_framework/`.  You can manually run the DevTool rails application by running `bundle exec rails s` from the dev test directory.

--- a/doc/misc_docs/CLA.md
+++ b/doc/misc_docs/CLA.md
@@ -1,0 +1,10 @@
+#### Contributors
+
+Contributor licenses protect you and the project!  They are designed to ensure that contributions to the project are open and not encumbered by licenses or other obligation.  They are not designed to limit you (the Apache license is very open) - they are for your protection.
+
+We will accept small pushes and bug fixes without a CLA; however, we ask that you sign a Contributor License Agreement (CLA) if you plan to make regular or substantial code contributions.  The CLA is based upon the Apache 2 CLA.
+
+CLAs:
+
+* [Individual CLA](https://github.com/crowbar/crowbar/blob/master/license/Corporate%20Contributor%20License%20Agreement.pdf)
+* [Corporate CLA](https://github.com/crowbar/crowbar/blob/master/license/Individual%20License%20Agreement.pdf)

--- a/doc/misc_docs/README.md
+++ b/doc/misc_docs/README.md
@@ -1,0 +1,5 @@
+
+This is miscellaneous documentation carried over as part of the docs merge from the
+top level Crowbar repository.  It is temporary, and is being merged into the rest of the documentation.
+
+

--- a/doc/misc_docs/analysis.md
+++ b/doc/misc_docs/analysis.md
@@ -1,0 +1,7 @@
+## Automated code analysis [![Code Climate](https://codeclimate.com/github/crowbar/travis-ci-crowbar.png)](https://codeclimate.com/github/crowbar/travis-ci-crowbar)
+
+In addition to [automated testing and code coverage
+reports](testing.md), we make use of the awesome service at
+[codeclimate.com](https://codeclimate.com) to give us
+[metrics on code complexity, smells, duplication etc.](https://codeclimate.com/github/crowbar/travis-ci-crowbar) across the whole Ruby codebase.  The badge above indicates
+the current overall metric.

--- a/doc/misc_docs/api/README.md
+++ b/doc/misc_docs/api/README.md
@@ -1,0 +1,94 @@
+# Crowbar REST API
+
+## Overview
+
+The Crowbar API "contract" consists of URIs, resources, the structure and
+content of resource representations, their formats, and the HTTP methods for
+each resource.
+
+Crowbar URIs have one of two forms:
+
+1. `http(s)://<HOSTNAME>/api/<VERSION>`. These URIs provide access to Crowbar
+   framework resources, such as attribs, attrib_types, barclamps, deployments,
+   groups, jigs, nodes, roles, role_types, and snapshots.
+2. `http(s)://<HOSTNAME>/<BARCLAMP>/<VERSION>`. These provide access to
+   barclamp specific resources.
+
+The content returned to the client has a media type of
+`application/vnd.crowbar+json; version=X.Y` unless otherwise noted. (*a little
+googling turned up: http://tools.ietf.org/html/draft-kelly-json-hal-05 "a
+generic media type with with Web APIs can be developed and exposed as a series
+of links", perhaps we should use it rather than defining our own. Regardless,
+we should steal their link syntax.*)
+
+## Client Errors
+
+There are three possible types of client errors on API calls that receive
+request bodies:
+
+1. Sending invalid JSON will result in a `400 Bad Request` response.
+2. Sending the wrong type of JSON values will result in a `400 Bad Request`
+   response.
+3. Sending invalid fields will result in a `422 Unprocessable Entity` response.
+
+## HTTP Verbs
+
+Where possible the Crowbar API strives to use the appropriate HTTP verbs for
+each action, eg:
+
+| Verb   | Description |
+|--------|-------------|
+| HEAD   | Used against any resource to get just the HTTP header information. |
+| GET    | Used for retrieving resources. |
+| POST   | Used for creating resources, or performing custom actions. |
+| PATCH  | Used for updating resources with partial JSON data. |
+| PUT    | Used for replacing resources or collection. Requests should always set `Content-Length` header to zero. |
+| DELETE | Used for deleting resources. |
+
+## Hypermedia Controls
+
+Crowbar API clients should be able to navigate with a bare minimum of a priori
+knowledge. `Links` are included in the content returned to clients that allow
+the client to progress through the application. The `hal+json` media type
+specifies links in the following format:
+
+```json
+{
+  "_links": {
+    "self": {
+      "href": "/api/v2/nodes/42"
+    },
+    ...
+  },
+  "id":     "xyzzy",
+  "status": "outstanding!"
+  ...
+}
+```
+
+The reserved property `_links` contains links to other resources of the form:
+`reltype` : `href`. Where `reltype` is the relation type and `href` is a
+relative or absolute URI. The `self` link should always be provided, further
+links are included depending on the type of the content.
+
+## Pagination
+
+Requests that return multiple items are paginated by 128 items by default. You
+can specify further pages with the `?page` parameter.
+
+The pagination info is included in the `Link` header. It is important to follow
+these `Link` header values instead of constructing your own URIs. A `Link`
+header has the form:
+
+```
+Link: <http://your.crowbar.host/api/v2/attribs?page=3&per_page=128>; rel="next", <http://your.crowbar.host/api/v2/attribs?page=12&per_page=128>; rel="last"
+```
+
+The possible values for the `rel` attribute are:
+
+| Value | Description |
+|-------|-------------|
+| next  | URI of the immediate next page of results. |
+| last  | URI of the last page of results. |
+| first | URI of the first page of results. |
+| prev  | URI of the immediate previous page of results. |

--- a/doc/misc_docs/api/attrib.md
+++ b/doc/misc_docs/api/attrib.md
@@ -1,0 +1,134 @@
+# Attribs
+
+This resource provides access to all the Crowbar *attribs*. It can be used to:
+
++ List attribs
++ Retrieve a specific attrib
+
+## List attribs
+
+### Request
+
+```
+GET /api/v2/attribs
+```
+
+### Parameters
+
++ filter -- specifies one or more properties that selected attribs must match
++ created -- selects attribs created after specified datetime
++ updated -- selects attribs updated after specified datetime
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Cache-Control: max-age=0, private, must-revalidate
+X-Runtime: 0.139598
+X-Request-Id: 4957a1203d60a953350f0401d90f32c0
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+ETag: "d494b9ec2f2b084386a940e95e71b22a"
+Transfer-Encoding: chunked
+Link: <http://localhost/api/v2/attribs?page=2&per_page=128>; rel="next"
+```
+
+Body:
+
+```json
+[
+  {
+    "name": "status",
+    "state": 999,
+    "node_id": 1,
+    "attrib_type_id": 40,
+    "description": "This is an Attrib",
+    "value": "empty",
+    "updated_at": "2013-03-11T15:43:38Z",
+    "order": 999999,
+    "id": 47
+    "created_at": "2013-03-11T15:43:38Z",
+    "_links": {
+      "self": { "href": "/api/v2/attribs/47" },
+      "attrib_type": { "href": "/api/v2/attrib_types/42" }
+    }
+  },
+  {
+    "name": "status",
+    "state": 999,
+    "node_id": 1,
+    "attrib_type_id": 40,
+    "description": "This is another Attrib",
+    "value": "empty",
+    "updated_at": "2013-03-11T15:04:44Z",
+    "order": 999999,
+    "id": 46,
+    "created_at": "2013-03-11T15:04:44Z"
+    "_links": {
+      "self": { "href": "/api/v2/attribs/46" },
+      "attrib_type": { "href": "/api/v2/attrib_types/28" }
+    }
+  },
+  ...
+  {
+    "name": "forwarders",
+    "state": "empty",
+    "node_id": null,
+    "attrib_type_id": 36,
+    " escription": "dns Created Attribute",
+    "value": null,
+    "updated_at": "2013-03-11T14:59:33Z",
+    "order": 10000,
+    "id": 42,
+    "created_at": "2013-03-11T14:59:33Z",
+    "_links": {
+      "self": { "href": "/api/v2/atttribs/42" },
+      "attrib_type": { "href": "/api/v2/attrib_types/36" }
+    }
+  }
+]
+```
+
+## Retrieve a specific attrib
+
+### Request
+
+```
+GET /api/v2/attribs/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: ce79f8c672719a693891f537bd747d8a
+X-Runtime: 0.012809
+ETag: "5a1469c57221b78c1df21f0a6b67e431"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "name": "forwarders",
+  "attrib_type_id": 36,
+  "node_id": null,
+  "updated_at": "2013-03-11T14:59:33Z",
+  "value": null,
+  "description": "dns Created Attribute",
+  "state": "empty",
+  "order": 10000,
+  "created_at": "2013-03-11T14:59:33Z",
+  "id": 42,
+  "_links": {
+    "self": { "href": "/api/v2/attribs/42" },
+    "attrib_type": { "href": "/api/v2/attrib_types/36" }
+  }
+}
+```

--- a/doc/misc_docs/api/attrib_types.md
+++ b/doc/misc_docs/api/attrib_types.md
@@ -1,0 +1,123 @@
+# Attrib Types
+
+This resource provides access to all the Crowbar *attrib_types*, eg:
+
+1. List attrib_types
+1. Retrieve a specific attrib_type
+
+## List attrib_types
+
+### Request
+
+```
+GET /api/v2/attrib_types
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 8786e1c250445b852872288fcdda1afb
+X-Runtime: 0.021875
+ETag: "ab3d4dfa3accd5d6918c9783327e9541"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+    "name": "web_port",
+    "updated_at": "2013-03-11T14:59:23Z",
+    "description": "crowbar Created Attribute",
+    "created_at": "2013-03-11T14:59:23Z",
+    "order": 10000,
+    "id": 1,
+    "_links": {
+      "self": { "href": "/api/v2/attrib_types/1" },
+      "attribs": [
+        { "href": "/api/v2/attribs/42" },
+        { "href": "/api/v2/attribs/36" }
+      ]
+    }
+  },
+  {
+    "name": "instances",
+    "updated_at": "2013-03-11T14:59:23Z",
+    "description": "crowbar Created Attribute",
+    "created_at": "2013-03-11T14:59:23Z",
+    "order": 10000,
+    "id": 2,
+    "_links": {
+      "self": { "href": "/api/v2/attrib_types/2" },
+      "attribs": [
+        { "href": "/api/v2/attribs/22" }
+      ]
+    }
+  },
+  ...
+  {
+    "name": "status",
+    "updated_at": "2013-03-11T15:04:44Z",
+    "description": "System Assigned Attrib for Role-Node membership",
+    "created_at": "2013-03-11T15:04:44Z",
+    "order": 999999,
+    "id": 40,
+    "_links": {
+      "self": { "href": "/api/v2/attrib_types/40" },
+      "attribs": [
+        { "href": "/api/v2/attribs/99" },
+        { "href": "/api/v2/attribs/33" },
+        { "href": "/api/v2/attribs/11" }
+      ]
+    }
+  }
+]
+```
+
+## Retrieve a specific attrib_type
+
+### Request
+
+```
+GET /api/v2/attrib_types/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 8786e1c250445b852872288fcdda1afb
+X-Runtime: 0.021875
+ETag: "ab3d4dfa3accd5d6918c9783327e9541"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "name": "web_port",
+  "updated_at": "2013-03-11T14:59:23Z",
+  "description": "crowbar Created Attribute",
+  "created_at": "2013-03-11T14:59:23Z",
+  "order": 10000,
+  "id": 1,
+  "_links": {
+    "self": { "href": "/api/v2/attrib_types/1" },
+    "attribs": [
+      { "href": "/api/v2/attribs/42" },
+      { "href": "/api/v2/attribs/36" }
+    ]
+  }
+}
+```

--- a/doc/misc_docs/api/barclamp.md
+++ b/doc/misc_docs/api/barclamp.md
@@ -1,0 +1,185 @@
+# Barclamp API
+
+This resource provides access to all the Crowbar *barclamps*
+
++ List barclamps
++ Retrieve a specific barclamp
+
+## List barclamps
+
+### Request
+
+```
+GET /api/v2/barclamps
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 5f7a7e9a28bcc3dfab26b522a17016d9
+X-Runtime: 0.021580
+ETag: "7f7e86fb0b2538e200852a3af7f55c81"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+    "description": "Self-referential barclamp enabling other barclamps",
+    "order": 0,
+    "api_version": "v2",
+    "transition_list": "all",
+    "proposal_schema_version": 2,
+    "commit": "unknown",
+    "online_help": "https://crowbar.github.com/",
+    "run_order": 0,
+    "allow_multiple_deployments": false,
+    "transitions": false,
+    "display": "Crowbar",
+    "user_managed": true,
+    "layout": 2,
+    "build_on": null,
+    "mode": "full",
+    "name": "crowbar",
+    "source_path": "../barclamps/crowbar",
+    "license": "apache2",
+    "version": 0,
+    "api_version_accepts": "v2",
+    "template_id": 1,
+    "jig_order": 0,
+    "copyright": "Dell, Inc 2013",
+    "created_at": "2013-03-11T14:59:23Z",
+    "updated_at": "2013-03-11T14:59:23Z",
+    "id": 1,
+    "_links": {
+      "self": { "href": "/api/v2/barclamps/1"}
+    }
+  },
+  {
+    "description": "Ganglia",
+    "order": 100,
+    "api_version": "v2",
+    "transition_list": "all",
+    "proposal_schema_version": 2,
+    "run_order": 70,
+    "allow_multiple_deployments": false,
+    "transitions": false,
+    "display": "Ganglia",
+    "user_managed": true,
+    "layout": 1,
+    "build_on": null,
+    "mode": "full",
+    "name": "ganglia",
+    "source_path": "../barclamps/ganglia",
+    "license": "apache2",
+    "version": 0,
+    "api_version_accepts": "v2",
+    "template_id": 2,
+    "jig_order": 1040,
+    "copyright": "Dell, Inc 2013",
+    "created_at": "2013-03-11T14:59:24Z",
+    "updated_at": "2013-03-11T14:59:24Z",
+    "id": 2
+    "_links": {
+      "self": { "href": "/api/v2/barclamps/2"}
+    }
+  },
+  ...
+  {
+    "description": "Dns",
+    "order": 30,
+    "api_version": "v2",
+    "transition_list": "all",
+    "proposal_schema_version": 2,
+    "commit": "unknown",
+    "online_help": null,
+    "run_order": 30,
+    "allow_multiple_deployments": false,
+    "transitions": false,
+    "display": "DNS",
+    "user_managed": true,
+    "layout": 1,
+    "build_on": null,
+    "mode": "full",
+    "name": "dns",
+    "source_path": "../barclamps/dns",
+    "license": "apache2",
+    "version": 0,
+    "api_version_accepts": "v2",
+    "template_id": 13,
+    "jig_order": 30,
+    "copyright": "Dell, Inc 2013",
+    "created_at": "2013-03-11T14:59:32Z",
+    "updated_at": "2013-03-11T14:59:33Z",
+    "id": 12
+    "_links": {
+      "self": { "href": "/api/v2/barclamps/12"}
+    }
+  }
+]
+```
+
+## Retrieve a specific barclamp
+
+### Request
+
+```
+GET /api/v2/barclamps/:id
+```
+
+#### Response
+
+Headers:
+
+```http 
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 5f7a7e9a28bcc3dfab26b522a17016d9
+X-Runtime: 0.021580
+ETag: "7f7e86fb0b2538e200852a3af7f55c81"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Response:
+
+```json
+{
+  "description": "Dns",
+  "order": 30,
+  "api_version": "v2",
+  "transition_list": "all",
+  "proposal_schema_version": 2,
+  "commit": "unknown",
+  "online_help": null,
+  "run_order": 30,
+  "allow_multiple_deployments": false,
+  "transitions": false,
+  "display": "DNS",
+  "user_managed": true,
+  "layout": 1,
+  "build_on": null,
+  "mode": "full",
+  "name": "dns",
+  "source_path": "../barclamps/dns",
+  "license": "apache2",
+  "version": 0,
+  "api_version_accepts": "v2",
+  "template_id": 13,
+  "jig_order": 30,
+  "copyright": "Dell, Inc 2013",
+  "created_at": "2013-03-11T14:59:32Z",
+  "updated_at": "2013-03-11T14:59:33Z",
+  "id": 12,
+  "_links": {
+    "self": { "href": "/api/v2/barclamps/12"}
+  }
+}
+```

--- a/doc/misc_docs/api/group.md
+++ b/doc/misc_docs/api/group.md
@@ -1,0 +1,111 @@
+# Groups
+
+This resource provides access to all the Crowbar *groups*. It can be used to:
+
++ List groups
++ Retrieve a specific group
+
+## List groups
+
+### Request
+
+```
+GET /api/v2/groups
+```
+
+### Response
+
+Headers:
+
+```http`
+HTTP/1.1 200 OK
+X-Request-Id: 6f0404a4f974ebf889086b2e77acb396
+X-Runtime: 0.006447
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+ETag: "0582b058b9b234b6f995b5e18417a8b0"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+    "name": "not_set",
+    "created_at": "2013-03-12T16:09:50Z",
+    "description": "Not set",
+    "updated_at": "2013-03-12T16:09:50Z",
+    "category": "ui",
+    "id": 1,
+    "order": 10000,
+    "_links": {
+      "self": { "href": "/api/v2/groups/1" }
+    }
+  },
+  {
+    "name": "bddthings",
+    "created_at": "2013-03-12T16:11:15Z",
+    "description": "BDD Testing Only - should be automatically removed",
+    "updated_at": "2013-03-12T16:11:15Z",
+    "category": "ui",
+    "id": 2,
+    "order": 100,
+    "_links": {
+      "self": { "href": "/api/v2/groups/2" }
+    }
+  },
+  {
+    "name": "bdddelete",
+    "created_at": "2013-03-12T16:11:16Z",
+    "description": "BDD Testing Only - should be automatically removed",
+    "updated_at": "2013-03-12T16:11:16Z",
+    "category": "ui",
+    "id": 3,
+    "order": 200,
+    "_links": {
+      "self": { "href": "/api/v2/groups/3" }
+    }
+  }
+]
+```
+
+## Retrieve a specific group
+
+### Request
+
+```
+GET /api/v2/groups/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+X-Request-Id: 46401724f8afc9c12e23a74530e2fae3
+X-Runtime: 0.010442
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+ETag: "b2a9513490c67f2058271daf7bc74922"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "name": "bdddelete",
+  "created_at": "2013-03-12T16:11:16Z",
+  "description": "BDD Testing Only - should be automatically removed",
+  "updated_at": "2013-03-12T16:11:16Z",
+  "category": "ui",
+  "id": 3,
+  "order": 200,
+  "_links": {
+    "self": { "href": "/api/v2/groups/3" }
+  }
+}
+```
+

--- a/doc/misc_docs/api/jig.md
+++ b/doc/misc_docs/api/jig.md
@@ -1,0 +1,122 @@
+# Jigs
+
+This resource provides access to Crowbar *jigs*. It can be used to:
+
++ List jigs
++ Retrieve a specific jig
+
+## List jigs
+
+### Request
+
+```
+GET /api/v2/jigs
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+X-Request-Id: 1380a1dbde1767805afcd0ed9b7d85e2
+X-Runtime: 0.011635
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+ETag: "59bd92a16eb7f1055ff940db8318db68"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+    "id": 1,
+    "type": "BarclampCrowbar::Jig",
+    "name": "test",
+    "created_at": "2013-03-12T16:04:34Z",
+    "description": null,
+    "updated_at": "2013-03-12T16:04:34Z",
+    "order": 9999,
+    "_links": {
+      "self": { "href": "/api/v2/jigs/1" }
+    }
+  },
+  {
+    "id": 2,
+    "type": "BarclampChef::Jig",
+    "name": "admin_chef",
+    "created_at": "2013-03-12T16:04:41Z",
+    "description": null,
+    "updated_at": "2013-03-12T16:04:41Z",
+    "order": 100,
+    "_links": {
+      "self": { "href": "/api/v2/jigs/2" }
+    }
+  },
+  {
+    "id": 3,
+    "type": "BarclampChef::Jig",
+    "name": "chef",
+    "created_at": "2013-03-12T16:04:41Z",
+    "description": null,
+    "updated_at": "2013-03-12T16:04:41Z",
+    "order": 200,
+    "_links": {
+      "self": { "href": "/api/v2/jigs/3" }
+    }
+  },
+  {
+    "id": 4,
+    "type": "BarclampCrowbar::Jig",
+    "name": "bddjig",
+    "created_at": "2013-03-12T16:11:23Z",
+    "description": "BDD Testing Only - should be automatically removed",
+    "updated_at": "2013-03-12T16:11:23Z",
+    "order": 100,
+    "_links": {
+      "self": { "href": "/api/v2/jigs/4" }
+    }
+  }
+]
+```
+
+## Retrieve a specific jig
+
+### Request
+
+```
+GET /api/v2/jigs/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+X-Request-Id: a0589084434f31b3bb6e343b4007638b
+X-Runtime: 0.011998
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+ETag: "0acc1bf46308b8011437b5b3dd3e1084"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "id": 4,
+  "type": "BarclampCrowbar::Jig",
+  "name": "bddjig",
+  "created_at": "2013-03-12T16:11:23Z",
+  "description": "BDD Testing Only - should be automatically removed",
+  "updated_at": "2013-03-12T16:11:23Z",
+  "order": 100,
+  "_links": {
+    "self": { "href": "/api/v2/jigs/4" }
+  }
+}
+```

--- a/doc/misc_docs/api/nodes.md
+++ b/doc/misc_docs/api/nodes.md
@@ -1,0 +1,144 @@
+# Nodes
+
+This resoure provides access to Crowbar *nodes*. It can be used to:
+
++ List nodes
++ Retrieve a specific node
+
+## List nodes
+
+### Request
+
+```
+GET /api/v2/nodes
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 221938bcbba8cda724aa727bc1a43c55
+X-Runtime: 0.019898
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "fc52a8eafec72c878f29bcfdb14574a9"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+   "created_at": "2013-03-18T15:10:05Z",
+   "name": "global-node.testing.com",
+   "alias": "global-node",
+   "updated_at": "2013-03-18T15:10:05Z",
+   "description": "GlobalBDD Testing Only - should be automatically removed",
+   "order": 100,
+   "state": "empty",
+   "id": 1,
+   "allocated": false,
+   "os_id": null,
+   "admin": false,
+   "_links": {
+     "self": { "href": "/api/v2/nodes/1" }
+   }
+  },
+  {
+   "created_at": "2013-03-18T15:10:33Z",
+   "name": "dashboard1.example.com",
+   "alias": "dashboard1",
+   "updated_at": "2013-03-18T15:10:33Z",
+   "description": "BDD Testing Only - should be automatically removed",
+   "order": 100,
+   "state": "empty",
+   "id": 2,
+   "allocated": false,
+   "os_id": null,
+   "admin": false,
+   "_links": {
+     "self": { "href": "/api/v2/nodes/2" }
+   }
+  },
+  {
+   "created_at": "2013-03-18T15:11:22Z",
+   "name": "group1.node.test",
+   "alias": "group1",
+   "updated_at": "2013-03-18T15:11:22Z",
+   "description": "BDD Testing Only - should be automatically removed",
+   "order": 100,
+   "state": "empty",
+   "id": 4,
+   "allocated": false,
+   "os_id": null,
+   "admin": false,
+   "_links": {
+     "self": { "href": "/api/v2/nodes/4" }
+   }
+  },
+  {
+   "created_at": "2013-03-18T15:11:53Z",
+   "name": "bdd1.example.com",
+   "alias": "bdd1",
+   "updated_at": "2013-03-18T15:11:53Z",
+   "description": "BDD Testing Only - should be automatically removed",
+   "order": 100,
+   "state": "empty",
+   "id": 6,
+   "allocated": false,
+   "os_id": null,
+   "admin": false,
+   "_links": {
+     "self": { "href": "/api/v2/nodes/6" }
+   }
+  }
+]
+```
+
+## Retrieve a specific node
+
+### Request
+
+```
+GET /api/v2/nodes/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 9b3f0ea191adbdd0a31357bd64df76ad
+X-Runtime: 0.015017
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "4b2a8f03178a28da428123cfc46da865"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "created_at": "2013-03-18T15:11:53Z",
+  "name": "bdd1.example.com",
+  "alias": "bdd1",
+  "updated_at": "2013-03-18T15:11:53Z",
+  "description": "BDD Testing Only - should be automatically removed",
+  "order": 100,
+  "state": "empty",
+  "id": 6,
+  "allocated": false,
+  "os_id": null,
+  "admin": false,
+   "_links": {
+     "self": { "href": "/api/v2/nodes/6" }
+   }
+}
+```

--- a/doc/misc_docs/api/role_types.md
+++ b/doc/misc_docs/api/role_types.md
@@ -1,0 +1,110 @@
+# Role Types
+
+This resource provides access to Crowbar *role_types*. It can be used to:
+
++ List role types
++ Retrieve a specific node
+
+## List role types
+
+### Request
+
+```
+GET /api/v2/role_types
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: 2fc91b765c045887d729e68f9e71af48
+X-Runtime: 0.013939
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "ef8436a949e33358b7f6a2bee8119c13"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+   "created_at": "2013-03-18T15:07:04Z",
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": "Private Role for Internal Data",
+   "name": "private",
+   "id": 1,
+   "order": 1,
+   "_links": {
+     "self": { "href": "/api/v2/role_types/1" }
+   }
+  },
+  {
+   "created_at": "2013-03-18T15:07:04Z",
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": "Crowbar template Created Role",
+   "name": "crowbar",
+   "id": 2,
+   "order": 9999,
+   "_links": {
+     "self": { "href": "/api/v2/role_types/2" }
+   }
+  },
+  ...
+  {
+   "created_at": "2013-03-18T15:10:32Z",
+   "updated_at": "2013-03-18T15:10:32Z",
+   "description": "User Defined Attributes",
+   "name": "user_defined",
+   "id": 35,
+   "order": 999990,
+   "_links": {
+     "self": { "href": "/api/v2/role_types/35" }
+   }
+  }
+]
+```
+
+## Retrieve a specific role type
+
+### Request
+
+```
+GET /api/v2/role_types/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: abe15e55f14b941b61c301a06e073dc2
+X-Runtime: 0.011858
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "e618177c7f419eba322e8d0caa1f86bb"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "created_at": "2013-03-18T15:07:04Z",
+  "updated_at": "2013-03-18T15:07:04Z",
+  "description": "Ganglia template Created Role",
+  "name": "ganglia-client",
+  "id": 3,
+  "order": 9999,
+  "_links": {
+    "self": { "href": "/api/v2/role_types/3" }
+  }
+ }
+```
+

--- a/doc/misc_docs/api/roles.md
+++ b/doc/misc_docs/api/roles.md
@@ -1,0 +1,141 @@
+# Roles
+
+This resource provides access to Crowbar *roles*. It can be used to:
+
++ List roles
++ Retrieve a specific role
+
+## List nodes
+
+### Request
+
+```
+GET /api/v2/roles
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: c94d84f01c79ab2e90590d9d51b34369
+X-Runtime: 0.171903
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "5cbe8547a13a83b530027f49423b3e38"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+   "id": 1,
+   "states": "all",
+   "created_at": "2013-03-18T15:07:04Z",
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": null,
+   "snapshot_id": 1,
+   "name": "private",
+   "order": 1,
+   "role_type_id": 1,
+   "run_order": -1,
+   "_links": {
+     "self": { "href": "/api/v2/roles/1" }
+   }
+  },
+  {
+   "id": 2,
+   "states": "all",
+   "created_at": "2013-03-18T15:07:04Z",
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": "Imported from /tmp/crowbar-dev-test/opt/dell/barclamps/crowbar/bc-template-crowbar.json",
+   "snapshot_id": 1,
+   "name": "crowbar",
+   "order": 100,
+   "role_type_id": 2,
+   "run_order": 0,
+   "_links": {
+     "self": { "href": "/api/v2/roles/2" }
+   }
+  },
+  {
+   "id": 3,
+   "states": "all",
+   "created_at": "2013-03-18T15:07:04Z",
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": null,
+   "snapshot_id": 2,
+   "name": "private",
+   "order": 1,
+   "role_type_id": 1,
+   "run_order": -1,
+   "_links": {
+     "self": { "href": "/api/v2/roles/3" }
+   }
+  },
+  ...
+  {
+   "id": 75,
+   "states": "all",
+   "created_at": "2013-03-18T15:10:38Z",
+   "updated_at": "2013-03-18T15:10:38Z",
+   "description": null,
+   "snapshot_id": 19,
+   "name": "logging",
+   "order": 9999,
+   "role_type_id": 28,
+   "run_order": 9999,
+   "_links": {
+     "self": { "href": "/api/v2/roles/75" }
+   }
+  }
+]
+```
+
+## Retrieve a specific role
+
+### Request
+
+```
+GET /api/v2/roles/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: d119a0a3be6bc3b7beabb77a1779b45a
+X-Runtime: 0.006579
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "506a9998adf549acde2c2abfaa07acac"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "id": 75,
+  "states": "all",
+  "created_at": "2013-03-18T15:10:38Z",
+  "updated_at": "2013-03-18T15:10:38Z",
+  "description": null,
+  "snapshot_id": 19,
+  "name": "logging",
+  "order": 9999,
+  "role_type_id": 28,
+  "run_order": 9999,
+  "_links": {
+    "self": { "href": "/api/v2/roles/75" }
+  }
+ }
+```
+

--- a/doc/misc_docs/api/snapshots.md
+++ b/doc/misc_docs/api/snapshots.md
@@ -1,0 +1,129 @@
+# Snapshots
+
+This resource provides access to Crowbar *snapshots*. It can be used to:
+
++ List snapshots
++ Retrieve a specific snapshot
+
+## List snapshots
+
+### Request
+
+```
+GET /api/v2/snaphsots
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: f284a8393fa8c98110fbc1cc2de9d3b0
+X-Runtime: 0.023323
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "99bc4a55f90359bde684be4e1aac8032"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+[
+  {
+   "created_at": "2013-03-18T15:07:04Z",
+   "deployment_id": null,
+   "name": "Crowbar template",
+   "barclamp_id": 1,
+   "status": 1,
+   "order": 10000,
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": "Imported from /tmp/crowbar-dev-test/opt/dell/barclamps/crowbar/crowbar.yml",
+   "failed_reason": null,
+   "element_order": "[[\"crowbar\"]]",
+   "id": 1,
+   "_links": {
+     "self": { "href": "/api/v2/snapshots/1" }
+   }
+  },
+  {
+   "created_at": "2013-03-18T15:07:04Z",
+   "deployment_id": null,
+   "name": "Ganglia template",
+   "barclamp_id": 2,
+   "status": 1,
+   "order": 10000,
+   "updated_at": "2013-03-18T15:07:04Z",
+   "description": "Imported from /tmp/crowbar-dev-test/opt/dell/barclamps/ganglia/crowbar.yml",
+   "failed_reason": null,
+   "element_order": "[[\"ganglia-server\",\"ganglia-client\"]]",
+   "id": 2,
+   "_links": {
+     "self": { "href": "/api/v2/snapshots/2" }
+   }
+  },
+  ...
+  {
+   "created_at": "2013-03-18T15:10:38Z",
+   "deployment_id": 7,
+   "name": "solid",
+   "barclamp_id": 11,
+   "status": 1,
+   "order": 10000,
+   "updated_at": "2013-03-18T15:10:38Z",
+   "description": "Imported from /tmp/crowbar-dev-test/opt/dell/barclamps/logging/crowbar.yml",
+   "failed_reason": null,
+   "element_order": "[[\"logging-server\",\"logging-client\"]]",
+   "id": 19,
+   "_links": {
+     "self": { "href": "/api/v2/snapshots/19" }
+   }
+  }
+]
+```
+
+## Retrieve a specific snapshot
+
+### Request
+
+```
+GET /api/v2/snapshots/:id
+```
+
+### Response
+
+Headers:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.crowbar+json; version=1.9; charset=utf-8
+X-Request-Id: fab7f475170330b7552662c54c8d0115
+X-Runtime: 0.011233
+X-UA-Compatible: IE=Edge,chrome=1
+ETag: "de3db0b378e972b97c43cf7b99943e48"
+Cache-Control: max-age=0, private, must-revalidate
+Transfer-Encoding: chunked
+```
+
+Body:
+
+```json
+{
+  "created_at": "2013-03-18T15:07:04Z",
+  "deployment_id": null,
+  "name": "Crowbar template",
+  "barclamp_id": 1,
+  "status": 1,
+  "order": 10000,
+  "updated_at": "2013-03-18T15:07:04Z",
+  "description": "Imported from /tmp/crowbar-dev-test/opt/dell/barclamps/crowbar/crowbar.yml",
+  "failed_reason": null,
+  "element_order": "[[\"crowbar\"]]",
+  "id": 1,
+  "_links": {
+     "self": { "href": "/api/v2/snapshots/1" }
+  }
+}
+```

--- a/doc/misc_docs/barclamps.md
+++ b/doc/misc_docs/barclamps.md
@@ -1,0 +1,122 @@
+## Crowbar Barclamps
+
+> NOTE: This is from the wiki and needs to be reviewed, RAH 11/9/2012
+
+The Crowbar barclamp provides the roles and recipes to set up the barclamp framework.
+It initializes the system, creates initial instances of other barclamps defined in its configuration, and creates the users to access the crowbar API and UI. Any number of barclamp instances can be started. By default, the system starts a network, ganglia, nagios, ntp, dns, provisioner, deployer, ipmi, raid, and BIOS barclamp based upon their default configurations. The initialization function of the crowbar barclamp works exactly like the other barclamps. A proposal is created and can be committed during installation.
+
+The main post-installation function is to provide the main transition entry point for the system. All barclamps' transition functions can be called directly, but the crowbar barclamp calls these in an order specified each barclamps' crowbar.yml file. The default unspecified priority is 1000. 
+
+### Roles
+
+The following node roles are defined:
+
+   * Crowbar 
+      * Configures the system to run the barclamp framework (web app and other services).
+      * Depends upon the apache2, rails, passenger, and utils cookbooks.
+
+### Scripts
+
+The shared barclamp command line library is all the is provided to interact with the barclamp.
+
+The following scripts are also provided.
+
+<table border=1>
+  <tr><th>Script</th><th>Description</td></tr>
+  <tr>
+    <td>crowbar</td>
+    <td>Master control script for the command line interface</td></tr>
+  <tr>
+    <td>crowbar_crowbar</td>
+    <td>The actual control script for the crowbar barclamp</td></tr>
+  <tr>
+    <td>crowbar_watch_status</td>
+    <td>Wrapper for script that watches the node state and node status</td></tr>
+  <tr>
+    <td>crowbar_node_state</td>
+    <td>Displays the current provisioner state of the nodes</td></tr>
+  <tr>
+    <td>crowbar_node_status</td>
+    <td>Displays the current nagios state of the nodes</td></tr>
+  <tr>
+    <td>transition.sh</td>
+    <td>A helper script that can be used to transition nodes.</td></tr>
+</table>
+
+### Parameters
+
+The Crowbar Barclamp has a couple of list parameters.
+
+<table border=1>
+  <tr><th>Name</th><th>Default</th><th>Description</th></tr>
+  <tr><td>instances</td><td>The starting barclamps using their default configurations</td><td>A map of barclamp names that reference a list of json files (default is special to mean to take the defaults) that represent starting barclamp instances to create</td></tr>
+  <tr><td>users</td><td>A map of users - containing crowbar</td><td>This map defines the users allowed to access crowbar's UI and REST API.</td></tr>
+</table>
+
+The users map contains a map. The key is the user name and the rest of the required fields are:
+
+<table border=1>
+  <tr><th>Name</th><th>Description</th></tr>
+  <tr><td>password</td><td>Clear text password of the user</td></tr>
+  <tr><td>description</td><td>A description of the user.</td></tr>
+</table>
+
+**Operations**
+
+When the barclamp is committed, it uses a custom apply_roles function to ensure that the barclamps listed in the instances variable are created and committed.
+
+Once running, the barclamp provides the global transition function that calls other barclamps as nodes transition. The barclamp is also responsible for creating new nodes, assigning them a temporary name. The deployer will change these things if needed later in the node's life cycle. The transition function will also add the crowbar config to the admin node as it transitions through the =discovered= state.
+
+When starting a barclamp, use the following steps.
+
+Example (using Swift):
+
+**Proposals:**
+
+   1. crowbar swift proposal list 
+      - Output: Nothing or the name of the current proposals ie... default, Default, etc...
+   2. crowbar swift proposal show Default &gt; swift_default.txt 
+      - Output: creates the file swift_default.txt with the settings that are currently ready for deployment
+      - Other things you can do with the file: 
+         + Edit the file and change parameters. Once done you will need to import or edit the proposal.
+   3. crowbar swift proposal --file=swift_default.txt edit Default 
+      - Output: "Edited Default"
+   4. Command: crowbar swift commit Default 
+      - Output: "Committed Default"
+
+**Working with the Running Config**
+
+   1. crowbar swift list 
+      - List Current running configs
+   2. crowbar swift show "Name" 
+      - Shows the config in question in stdout, you can use standard unix commands to send it to a file
+   3. crowbar swift --file=file.txt edit "Name" 
+      - Edit and commits the current running config
+   4. crowbar swift create default2 
+      - creates and commits a config using defaults
+
+**Usage: crowbar swift [options] <subcommands>**
+
+* --help or -h - help
+* --hostname <name or ip> or -n <name or ip> - specifies the destination server
+* --port <port> or -p <port> - specifies the destination server port
+* --debug or -d - turns on debugging information
+* --data <data> - used by create or edit as data (must be in json format)
+* --file <file> - used by create or edit as data when read from a file (must be in json format)
+* --timeout <seconds> - timeout in seconds for read http reads
+* transition <name> <mac> <state> - Transition a mac to state
+* edit <name> - edit a new config
+* list - show a list of current configs
+* help - this page
+* delete <name> - delete a config
+* element_node <name> - List nodes that could be that element
+* elements - List elements of a deploy
+* show <name> - show a specific config
+* create <name> - create a specific config
+* proposal - Proposal sub-commands
+* commit <name> - Commit a proposal to active
+* edit <name> - edit a new proposal
+* list - show a list of current proposals
+* delete <name> - delete a proposal
+* show <name> - show a specific proposal
+* create <name> - create a proposal 

--- a/doc/misc_docs/barclamps/create-stub.md
+++ b/doc/misc_docs/barclamps/create-stub.md
@@ -1,0 +1,71 @@
+### Create Barclamp Stub
+**Version 2.x update**: This is current changing with [[Crowbar 2.0]] refactoring.  Documentation may move the the new book-developersguide (link pending)
+
+#### Version 1.x
+
+**15 minute how to video: http://www.youtube.com/watch?v=vSazhFcXd4k**
+
+A barclamp is a deployment module that is imported from its own code repository into the Crowbar framework. A barclamp cannot operate without Crowbar, but you do not have to create a unique build of Crowbar in order to create a barclamp.
+
+The first thing to know about barclamps is that most of the work (80%!) is building your Chef cookbooks. If you don’t have a cookbook that deploys your application then stop here and work on that first.
+
+The second thing to know about barclamps is that there are a lot of them that you can study for examples. Check out the Glance barclamp if you have a single server deployment, Nagios if you have a service that needs to be integrated into every node, Nova if you have a complex multi-component system and Provisioner if you want to impact core Crowbar functionality.
+
+We’ve done a lot of work to make it easy to create and install a stub barclamp. Our experience is that building a barclamp is a highly iterative exercise with a lot of testing. Luckily, Crowbar’s primary mission is to help you brush, rinse and repeat. From there, you can customize and extend your barclamp to deploy your application’s full untamed glory.
+
+Before you try to create a new barclamp, you must install Crowbar.
+
+#### Creating a barclamp
+
+The following steps use the barclamp_model that included under /dell/opt and is described below.
+
+1.     Figure out the name of your barclamp. I’m naming our example “foo barclamp”
+   1.         Barclamps must have unique names.
+   1.         Do not use spaces or hyphens.
+1.     From the Crowbar server, become the super admin: sudo -i
+1.     Create a directory for your barclamp: mkdir /barclamps
+1.     Run the barclamp create script: /opt/dell/bin/barclamp_create.rb foo “Zehicle” /barclamps
+   1.         “foo” is our barclamp name [required]
+   1.         “Zehicle” is my company name for the copyright information [default is Dell]
+   1.         “/barclamps” is the path where we are putting the barclamp [default is /opt/dell/barclamps]
+1.         Result will be a populated barclamp. In this example: /barclamps/foo
+
+That’s it! If you want to plan ahead then you could use an initialized git repo as the target.
+
+Reminder: In building your barclamp, you’ll need to learn about Chef, how Crowbar extends cookbooks and how barclamps interact. That’s beyond the scope of this post.
+
+#### Barclamp layout
+
+A barclamp has the following core components:
+
+>     crowbar.yml configuration file (documented below)
+>     README.txt file (optional, recommended)
+>     chef directory containing
+>         Cookbooks directory with Chef cookbooks
+>         Data_bags directory with Crowbar configuration files
+>         Roles directory with Chef roles used by the cookbooks and data_bags
+>     crowbar_framework directory
+>         app directory with Crowbar model, controller, and view code
+>         other optional directories to add components needed by the UI such as images
+
+The barclamp_model has a functional layout that covers most configuration requirements. The string ==BC-MODEL== indicates places where the name of the barclamp must be substituted. It is critical to understand that the name of the barclamp is embedded into the barclamp path and file names! This is needed to avoid file collisions when the barclamp is imported.
+Crowbar.yml
+
+The crowbar.yml file is a required configuration file that gives direction to the installer. The file has many components and documented on the [[Barclamp crowbar.yml]] page.
+
+The minimum components are:
+> barclamp:
+>   name: name of your barclamp (required, do not use space or hyphens) 
+>
+> crowbar:
+>
+>   layout: 1 (use the # one. This is required because it tells the installer what to expect inside your barclamp)
+>
+
+#### Barclamp Proposal
+
+To provide configuration information for your barclamp when handling node transitions or cookbook attributes, a proposal and its validation schema needs to be defined.  The crowbar framework defines a basic schema for all proposals.  This is required to meet basic crowbar functions.  This is versioned and controlled by the installation process to make sure the schema is up to date or updated to the latest.  The base crowbar sections are controlled by the crowbar/proposal_schema_version in the crowbar.yml file.  [[Barclamp Proposal Schema]] description and versions.
+
+The attributes section of the proposal defines the barclamp's unique configuration space.  This is versioned and controlled by the barclamp/proposal_schema_version.  The installer doesn't do anything with this currently.
+
+

--- a/doc/misc_docs/barclamps/makingbarclamps.md
+++ b/doc/misc_docs/barclamps/makingbarclamps.md
@@ -1,0 +1,119 @@
+## Making a Barclamps work with Crowbar
+
+This section shows you how to make barclamps.
+
+### Customization Locations
+
+To create a barclamp, you must update many places with the name of your barclamp.  While this seems redundant inside the barclamp, it is essential when your barclamp gets merged into the larger Crowbar framework.  This often means that your barclamp tree will have one or two files inside a [barclamp] subdirectory.  That's normal and you'll be glad of it when you have to troubleshoot your barclamp later.
+
+Locations of Crowbar Components in a typical barclamp
+
+* `/bin` 
+* `/chef` 
+   * `/`
+* `/crowbar_framework` 
+   * `/app` - contains the code for the barclamp.  Crowbar does not require much code for basic operations, but stubs are required
+      * `/controllers`
+      * `/models`
+      * `/views`
+        * `/barclamp/[barclamp]/*.haml` - attribute & deployment view pages
+      * `/asset`
+   * `/BDD` - integrated testing framework (see DevGuide Testing)
+   * `/doc` - integrated documentation frameowkr (see DevGuide documentation) 
+      * `[barclamp].yml` - index of your barclamps additions to the documentation
+      * `/default/[topic].md` - documentation files (can be in subdirectories)
+   * `/db`   
+      * `migrate` - required to create the barclamp record so Crowbar can find your barclamp in the database
+        * `YYYYMMDDHHMMSS_barclamp_import_[barclamp].rb` - does the migration (see DevGuide barclamp meta data)
+      
+> Note: The good news is that that barclamp_model will start you off with all of these files populated!
+
+#### Requested Sections
+The following items are desired but not yet created in the documenation.
+
+* Creating UI screens
+* Adding Chef cookbooks
+* ...
+
+#### Create the WebApp Pieces
+
+As a Rails app, you will need to following Rails naming conventions.  Say you name a barclamp, fred_rocks.  This means that the camelized name would be FredRocks.  
+
+#### Create the WebApp Controller
+
+The controller file lives in crowbar_framework/app/controllers.  It should be named bcname_controller.rb.  bcname is the lower case name of with the barclamp.  The class name should be the camelized name of the barclamp with Controller and it should inherit from BarclampController.
+
+It should look like this:
+class FredRocksController < BarclampController
+end
+
+For normal operation and to provide the default APIs, nothing else need to be provided.
+
+#### Create the WebApp Service Object
+
+The service object lives in the crowbar_framework/app/models directory.  It is usually named bcname_service.rb.  bcname is the lowercase version of the name.  The class name should be the camelized version of the barclamp name with Service and it should inherit from ServiceObject.
+
+It should look like this:
+class FredRocksService < ServiceObject
+end
+
+For normal operation and to provide the default APIs, nothing else need to be provided.
+
+Within this class, the following routines can be overridden:
+* create_proposal(name)
+* transition(name, inst, state)
+* apply_role_pre_chef_call(old_config, new_config, all_nodes)
+* proposal_dependencies(proposal_config)
+* validate_proposal_elements(proposal_elements)
+* validate_proposal(proposal)
+
+These can be overriden, but usually aren't.  They represent the basic API calls that have complex actions within the barclamp.
+* apply_role(new_proposal_config, in_queue)
+* destroy_active(prop_name)
+* dequeue_proposal(prop_name)
+* proposal_create(params)
+* proposal_edit(params)
+* proposal_delete(prop_name)
+* proposal_commit(prop_name, in_queue)
+
+#### Creating Barclamp Views
+
+Crowbar has pre-wired routes that allow barclamps to create custom view pages without changing the routes file.  These views must conform to the following pattern in the Barclamp Controller object.
+
+<table>
+  <tr><th>Method</th><th>Route</th><th>Path</th></tr>
+  <tr>
+    <td>node</td>
+    <td>barclamp_node_path(:controller=>_)</td>
+    <td>/barclamp/[:controller]/node/[:id]</td></tr>
+  <tr>
+    <td>network</td>
+    <td>barclamp_network_path(:controller=>_)</td>
+    <td>/barclamp/[:controller]/network/[:id]</td></tr>
+  <tr>
+    <td>util</td>
+    <td>barclamp_util_path(:controller=>_)</td>
+    <td>/barclamp/[:controller]/util/[:id]</td></tr>
+</table>
+
+> All these methods can optionally take :id as long as :id is limited to valid ID/Names
+
+> Please review the 'adding-navigation` DevGuide topic for information about including the view in the menu.
+
+#### Importing a barclamp
+
+_this is the manual process, there is a Utility for this in the UI_
+
+Once you created a barclamp, you can import the barclamp into Crowbar & Chef.
+
+Assuming that you already created the foo barclamp in /barclamps, here are the steps:
+
+1.     From the Crowbar server, become the super admin: sudo –i
+1.     Run the barclamp install script: /opt/dell/bin/barclamp_install /barclamps/foo
+   1.         “/barclamps/foo” is the path to your barclamp. If could be anything!
+   1.         The core barclamps are in /opt/dell/barclamps.
+   1.         In a vm, you could mount a shared folder to access the barclamp (e.g.: /mnt/hgfs/barclamps)
+
+Your barclamp should now show up in the Crowbar UI! You can also see it in Chef under the Crowbar databag.
+
+While barclamps are generally safe to install multiple times, you can uninstall a barclamp using “barclamp_uninstall.rb /path/to/barclamp”

--- a/doc/misc_docs/barclamps/metadata.md
+++ b/doc/misc_docs/barclamps/metadata.md
@@ -1,0 +1,26 @@
+### Barclamp Meta Data
+
+Every barclamps has meta data that tells Crowbar how to display and manage the barclamp within the Crowbar framework.
+
+In Crowbar 1.x, this meta data was tracked in the Crowbar.yml file.  This file still exists, but has a much more limited function.
+
+In Crowbar 2.x, barclamp meta data is injected into Crowbar in the barclamps `YYYYMMDDHHMMSSnn_barclamp_import_[barclamp].rb` migration file stored in the barclamp's `crowbar_framework/db/migrate` directory.
+
+This migration is used to populate (or update) the barclamp information used by Crowbar.  
+
+> _Note:_ For legacy barclamps, you can use `Barclamp.import_1x 'barclamp'` to simply import the information from the 1.x barclamp.yml into the new schema.  This is not recommended for new barclamps.
+
+* name (must be unique)
+* description
+* display
+* version - (default 2)
+* online_help - not required, URL to online help
+* proposal_schema_version (default 2)
+* layout - version of layout (default 2)
+* order - display order in UI (default 0)
+* run_order
+* jig_order
+* commit - automatically generated flag
+* build_on - automatically generated flag
+  
+  

--- a/doc/misc_docs/barclamps_intro.md
+++ b/doc/misc_docs/barclamps_intro.md
@@ -1,0 +1,20 @@
+# Barclamp Catalog
+
+This book is a composite of information from the barclamps installed in the Crowbar Framework.
+
+Each barclamp is expected to populate information into this book; consequently, the contents are variable depending on which barclamps have been installed.
+
+## Introduction and Background
+
+Barclamps are modules that plug into the Crowbar framework to deploy an application layer.  
+
+A barclamp is a module in Crowbar that provides specific functionality for the system.  Barclamps cannot operate without the framework, but they represensent self contained capabilities that are exposed by the Crowbar Framework.
+
+### Adding barclamps to an existing system
+
+...
+
+### What are barclamp suites?
+
+Barclamps can be grouped into suites for easier management.  Typical suites include Crowbar Core, Hadoop and OpenStack.
+

--- a/doc/misc_docs/browser-support.md
+++ b/doc/misc_docs/browser-support.md
@@ -1,0 +1,119 @@
+# Graded browser support
+
+We are committed to making Crowbar as accessible and consistent as we can.
+However, it is not practical for us to support every available operating system
+and web browser combination. Thus we have adopted the following graded browser
+and operating system support policy, inspired by [Yahoo's GBS]
+(http://yuilibrary.com/yui/docs/tutorials/gbs/).
+
+Browser support grades:
+
+| Grade | QA  | Bug priority         | Browser and version combinations |
+|-------|-----|----------------------|----------------------------------|
+| A     | Yes | Normal               | Current and previous major releases of Firefox, Firefox ESR (used in SLES/D), Chrome and Internet Explorer. |
+| B     | No  | Low, likely WONT_FIX | Current major release of Safari. |
+| C     | No  | WONT_FIX             | All browser and version combinations that are not in grades A or B. This includes old versions of A grade browsers and A grade browsers on unsupported operating systems. |
+
+This does not mean that Crowbar will only work on A-grade browsers - we expect
+it to work in all modern browsers and do make an effort to provide graceful
+degradation and progressive enhancements. It simply means that A-grade browsers
+are what we focus our development and QA efforts on, so those are what we
+recommend for the optimal user experience.
+
+Mobile browsers running on current versions of Android and iOS should generally
+work as well, although certain features like mouse-over pop-ups will not work
+on touch devices.
+
+The following table provides an example of the major browser and version
+combinations, the corresponding graded support, and their respective release
+cycles.
+
+> Note: All dates are in the yyyy-mm-dd format.
+
+<table>
+  <tr>
+    <th rowspan='2'>Browser</th>
+    <th rowspan='2'>Release cycle</th>
+    <th colspan='3'>Current major release</th>
+    <th colspan='3'>Previous major release</th>
+  </tr>
+  <tr>
+    <th>Grade</th>
+    <th>Version</th>
+    <th>Date</th>
+    <th>Grade</th>
+    <th>Version</th>
+    <th>Date</th>
+  </tr>
+  <tr>
+    <td>Mozilla Firefox</td>
+    <td><a href="https://wiki.mozilla.org/Releases#Previous_Releases">~1 month</a></td>
+    <td>A</td>
+    <td>17.0</td>
+    <td>2012-11-20</td>
+    <td>A</td>
+    <td>16.0</td>
+    <td>2012-10-09</td>
+  </tr>
+  <tr>
+    <td>Mozilla Firefox ESR</td>
+    <td><a href="http://www.mozilla.org/en-US/firefox/organizations/faq/">1 year</a></td>
+    <td>A</td>
+    <td>17.0 ESR</td>
+    <td>2012-11-20</td>
+    <td>A</td>
+    <td>10.0 ESR</td>
+    <td>2012-01-31</td>
+  </tr>
+  <tr>
+    <td>Google Chrome</td>
+    <td><a href="http://en.wikipedia.org/wiki/Google_Chrome">1-2 months</a></td>
+    <td>A</td>
+    <td>23.0.1271</td>
+    <td>2012-11-06</td>
+    <td>A</td>
+    <td>22.0.1229</td>
+    <td>2012-09-25</td>
+  </tr>
+  <tr>
+    <td>Microsoft Internet Explorer</td>
+    <td><a href="http://en.wikipedia.org/wiki/Internet_Explorer">Not time based</a></td>
+    <td>A</td>
+    <td>10</td>
+    <td>2012-10-26</td>
+    <td>A</td>
+    <td>9</td>
+    <td>2011-03-14</td>
+  </tr>
+  <tr>
+    <td>Apple Safari</td>
+    <td><a href="http://en.wikipedia.org/wiki/Safari_(web_browser)">Not time based</a></td>
+    <td>B</td>
+    <td>6</td>
+    <td>2012-07-25</td>
+    <td>C</td>
+    <td>5</td>
+    <td>2010-06-07</td>
+  </tr>
+</table>
+
+The operating systems that the browsers run on is also a factor. We use the
+same grade system as the browsers.
+
+A-grade operating systems:
+* Linux (latest supported SUSE desktop versions) - openSUSE 12.2, SLED11 SP2
+* Microsoft Windows (latest two versions) - Windows 7, Windows 8
+
+B-grade operating systems:
+* Apple Mac OS X (latest two versions) - Lion (10.7), Mountain Lion (10.8)
+
+C-grade operating systems:
+* Everything not in A or B grade
+
+Both [cookies](http://en.wikipedia.org/wiki/HTTP_cookie) and
+[JavaScript](en.wikipedia.org/wiki/JavaScript) must be enabled for the site
+to function properly.
+
+Reference browser support policies in other projects:
+[noVNC](https://github.com/kanaka/noVNC/wiki/Browser-support),
+[Twitter Bootstrap](https://github.com/twitter/bootstrap/wiki/Browser-Compatibility).

--- a/doc/misc_docs/building.md
+++ b/doc/misc_docs/building.md
@@ -1,0 +1,4 @@
+### Build Instructions for Crowbar
+
+This section should include building and updating the ISO and other packaging forms.
+

--- a/doc/misc_docs/contributing.md
+++ b/doc/misc_docs/contributing.md
@@ -1,0 +1,124 @@
+## Contributing to Crowbar
+
+Before [submitting pull requests]
+(https://help.github.com/articles/using-pull-requests), please ensure you are
+covered by a [CLA](CLA.md).
+
+#### Guidelines for Pull Requests
+
+   * Must be Apache 2 license
+   * For bugs & minor items (20ish lines), we can accept the request at our
+     discretion
+   * UI strings are localized (only EN file needs to be updated)
+   * Does not inject vendor information (Name or Product) into Crowbar expect
+     where relevant to explain utility of push (e.g.: help documentation &
+     descriptions).
+   * Passes code review by Dell Crowbar team reviewer
+   * Does not degrade the security model of the product
+   * Items requiring more scrutiny, including signing CLA
+      * Major changes
+      * New barclamps
+      * New technology
+
+#### Timing
+
+   * Accept no non-bug fix push requests within 2 weeks of a release fork
+   * No SLA - code accepted at Dell's discretion. No commitment to accept
+     changes.
+
+#### Coding Expectations [PRELIMINARY / PROPOSED 8/31]
+
+   * Copyright & License header will be included in files that can tolerate
+     headers
+   * At least 1 line comments as header for all methods
+   * Unit tests for all models concurrent with pull request
+   * BDD tests for all API calls and web pages concurrent with pull request
+   * Documentation for API calls concurrent with pull request
+   * Adhere to the community [Ruby style guide]
+     (https://github.com/bbatsov/ruby-style-guide)
+   * Adhere to the community [Rails style guide]
+     (https://github.com/bbatsov/rails-style-guide/)
+
+#### Testing/ Validation
+
+   * For core functions, push will be validated to NOT break build or deploy or
+     our commercial products
+   * For product suites (OpenStack, Hadoop, etc), push will be validated to NOT
+     break build or deploy our commercial products
+   * For operating systems that are non-core, we will _not_ validate on the
+     target OS for the push (e.g.: not testing SUSE install at this point)
+   * For non-DellCloudEdge barclamps &ndash; no rules!
+   * Eventually, we would expect that a pull request would be built and tested
+     in our CI system before the push can be accepted
+
+#### Feature Progression
+
+The following table shows the progression of new feature additions to Crowbar.
+The purpose of this list is to help articulate how new features appear in
+Crowbar and when they are considered core.
+
+<table border=1>
+  <thead>
+    <tr>
+      <th align="center"><em>Phase   </em></th>
+      <th align="center"><em>Comments</em></th>
+      <th align="center"><em>Roadmap </em></th>
+      <th align="center"><em>Support </em></th>
+      <th align="center"><em>On Trunk</em></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td align="center">Proposed</td>
+      <td align="center">Conceptual ideas and suggestions for Crowbar
+        functionality that have not been implemented as code</td>
+      <td align="center">May be shown</td>
+      <td align="center">None</td>
+      <td align="center">N/A</td>
+    </tr>
+    <tr>
+      <td align="center">Proof of Concept</td>
+      <td align="center">Initial code showing partial functionality for
+        feature</td>
+      <td align="center">Optionally Identified</td>
+      <td align="center">Negative Test (Does not impact core)</td>
+      <td align="center">No (on branch)</td>
+    </tr>
+    <tr>
+      <td align="center">Incubated</td>
+      <td align="center">Base functional code allowing use of feature to
+        demonstrate value</td>
+      <td align="center">Identified</td>
+      <td align="center">Negative Test (Does not impact core)</td>
+      <td align="center">No (on branch)</td>
+    </tr>
+    <tr>
+      <td align="center">Stable</td>
+      <td align="center">Base functional code is available for use in select
+        builds</td>
+      <td align="center">Included</td>
+      <td align="center">Validated by QA, No Support</td>
+      <td align="center">Yes</td>
+    </tr>
+    <tr>
+      <td align="center">Core</td>
+      <td align="center">Feature code integrated into operations of Crowbar in
+        fundamental way</td>
+      <td align="center">Central</td>
+      <td align="center">Validated by QA, Current Version Support</td>
+      <td align="center">Yes</td>
+    </tr>
+    <tr>
+      <td align="center">Supported</td>
+      <td align="center">Same as core, but available with commercial
+        support</td>
+      <td align="center">Central</td>
+      <td align="center">Backwards Support via Patches</td>
+      <td align="center">Yes &amp; Maintained on Branches</td>
+    </tr>
+  </tbody>
+</table>
+
+Note: Features are NOT required to progress through all these phases!
+Architectural changes may skip ahead based on their level of impact and
+disruption.

--- a/doc/misc_docs/deployguide.md
+++ b/doc/misc_docs/deployguide.md
@@ -1,0 +1,21 @@
+# Crowbar Deployment Guide
+
+_THIS GUIDE HAS NOT BEEN FORMATED!!_
+
+This guide is based on the **Dell OpenStack™ Powered Cloud Solution Deployment Guide** please update as needed.  OpenStack specific items should be moved to the OpenStack deployment guide.
+
+### Notes, Cautions, and Warnings
+
+> NOTE: A NOTE indicates important information that helps you make better use of your system.
+> CAUTION: A CAUTION indicates potential damage to hardware or loss of data if 
+instructions are not followed.
+> WARNING: A WARNING indicates a potential for property damage, personal 
+injury, or death.
+
+### Information in this document is subject to change without notice.
+
+© 2012 Dell Inc. 
+
+Reproduction of these materials is allowed under the Apache 2 license.
+Trademarks used in this text: Dell™, the DELL logo, OpenStack ™, Nagios™, Ganglia™, Opscode Chef™, Canonical Ubuntu™ , VMWare™
+Other trademarks and trade names may be used in this publication to refer to either the entities claiming the marks and names or their products. Dell Inc. disclaims any proprietary interest in trademarks and trade names other than its own.

--- a/doc/misc_docs/deployguide/introduction.md
+++ b/doc/misc_docs/deployguide/introduction.md
@@ -1,0 +1,766 @@
+## OpenStack Deployment Procedure
+This guide provides the information necessary to deploy the Dell OpenStack Powered Cloud Solution.  It is intended to be used in conjunction with the Dell OpenStack Powered Cloud Solution Reference Architecture Guide, the Dell OpenStack Powered Cloud Solution Barclamps User Guide, and the Dell Crowbar Users Guide.
+Deployment consists of the following steps:
+1. Site preparation and hardware installation
+2. Administration node setup, including network configuration and Crowbar installation.
+3. OpenStack deployment using Crowbar.
+When the deployment is complete, the complete Dell OpenStack Powered Cloud Solution will be installed, as shown in Figure 1.
+
+Figure 1 OpenStack Solution Taxonomy
+2 Site Preparation and Hardware Installation
+2.1 Hardware Setup
+All systems should be installed and cabled according the physical configurations detailed in the Dell OpenStack Powered Cloud Solution Reference Architecture Guide.
+Estimate the electrical power and cooling usage using the Dell Energy Smart Solution Advisor: http://www.dell.com/content/topics/topic.aspx/global/products/pedge/topics/en/config_calculator?c=us&cs=555&l=en&s=biz
+You can use this tool to plan the appropriate PDU and ensure the cooling is adequate.
+2.2 Bootstrap Node
+The initial setup of the administration node will require a temporary bootstrap node, such as a laptop.  The administration node will also need a keyboard, and monitor (or KVM connection) during initial installation.
+The bootstrap node will be used to perform the initial PXE boot of the administration node.  It must have VMWare player installed to start the bootstrap process, and will be connected to the administration node via a crossover network cable.
+2.3 Administration Node
+The hardware on the admin node should be configured as follows:
+* Boot sequence: BIOS is set to boot from local disk. Note that this is the “normal” operating setting, but for its initial setup boot, the admin node will need to boot from network in order to bootstrap the installation from the VMPlayer image running on the bootstrap node.
+* RAID controller: All disks should be in a RAID 10 configuration.
+BMC and networking settings for the nodes are configured using Crowbar, and manual steps are not required.
+2.4 Switch Configuration
+The network switches should be configured appropriately before beginning the installation.  The installation process does not configure the switches.  A typical configuration using Dell PowerConnect 6248 switches is included in Appendix A:  Default Switch Configuration.  If the network configuration differs from the standard one described in the Reference Architecture, this configuration must be updated.
+2.5 Additional Site Preparation 
+Solution deployment may need additional preparation.
+The Reference Architecture does not specify any firewalls or load-balancers – if these are required, they should be configured at this time.
+Also, a bastion host, installed behind appropriate site-specific security systems, can be used to access the administration node and cloud remotely. Direct access to the admin, internal, and external networks should not be configured without appropriate security procedures.
+3 Administration Node Setup
+The admin node must be configured first.  Installing the admin node involves installing the base operating system, optionally customizing the Crowbar configuration (primarily the networking configuration,) and installing Crowbar itself.
+Once configured, Crowbar running on the admin node is used to configure and deploy the rest of the solution, and to provide ongoing operations management.  The admin node manages all the cluster compute and storage nodes. It assigns the other nodes IP addresses; PXE boots them, configures them, and provides them the necessary software for their roles. To provide these services, the admin node runs the services listed in Table 1. The admin node must be the only DHCP server visible to the compute and storage nodes. 
+Crowbar Server
+Manages all nodes, supplying configuration of hardware and software. 
+Chef Server
+Manages many of the software packages and allows the easy changing of nodes. 
+DHCP server
+Assigns and manages IPs for the compute and storage nodes. The admin node must be the only DHCP server visible to the compute and storage nodes. 
+NTP server 
+Synchronizes all nodes are to the same time reference.
+TFTP server
+PXE boots compute and storage nodes with a Linux kernel. The TFTP server services any PXE boot request it receives with its default options. 
+DNS server
+Manages the name resolution for the nodes and can be configured to provide external name forwarding.
+Table 1 Management Services on Admin Node
+3.1 Installing the Admin Node Operating System and Software	
+The initial admin node installation is performed by PXE booting the admin node from a bootstrap node, typically a laptop.  The steps are:
+1. Power on the admin node, and ensure that:
+a. It is set up to boot from the hard disk for subsequent boots.
+b. This first boot (and only this first boot) is a network boot.
+2. Power off the admin node.
+3. Make sure you have VMWare Player1 installed on the laptop.
+4. Make sure you have the Crowbar ISO image loaded on the laptop.
+5. Turn off or disable wireless networking on the laptop.
+6. Open the VMware machine configuration distributed with Crowbar (this will be a .vmx file).
+7. Edit the machine settings within Player and ensure that the network adapter is configured to use Bridged Networking (see Figure 3), connected to the physical network adapter.
+8. Configure VMWare player to mount the Crowbar ISO image a DVD in the VM (see Figure 2.)
+9. Connect the network crossover cable between eth0 of the admin node the network port of the laptop.
+10. Power on the VM – it should boot and present a login prompt in under a minute.
+11. Power on the admin node.  It should PXE boot, obtaining its image from the VM.
+12. The admin node will automatically install its operating system and deployment software.
+13. Once the installation is complete, power down the installer VM, and disconnect the laptop
+14. Reconnect eth0 of the admin node to the appropriate switch port.
+When this process has completed, the operating system and deployment software has been installed on the admin node.  The Crowbar software has been copied to the admin node, but final installation has not been completed.
+Figure 2 VMWare Player configuration for ISO boot
+Figure 3 VMWare Player configuration for network bridging
+
+3.2 Network Configuration
+3.2.1 Logical Network Configuration
+Crowbar manages the network settings for the deployment using the network Barclamp. The base networking configuration has been architected to maintain a logical segregation of traffic, with minimal configuration. There are several logical networks defined, segmented into separate vLANs as shown in Table 2.
+The Crowbar network configuration can be customized to support site specific networking needs and conventions.  These changes include adding additional vLANs, changing vLAN mappings, changing IP address range assignments, and teaming NICs.  
+If changes are required, they must be done at this point, before the final Crowbar installation.
+Name 
+Usage 
+Notes 
+admin 
+Private network for node to node communication 
+A router, if wanted, is external to the system. This network must be owned by the crowbar system to run DHCP on. 
+bmc 
+Private network for bmc communication 
+This can be the same as the admin network by using the ranges to limit what IP goes where. A router, if wanted, is external to the system. 
+bmc_vlan 
+Private network for admin nodes on the bmc network 
+This must be the same as the bmc network and have the same vlan. This will be used to generate a vlan tagged interface on the admin nodes that can access the bmc lan. 
+storage 
+Private network for storage traffic 
+A router, if wanted, is external to the system 
+public 
+Public network for crowbar and other components 
+A router, if wanted, is external to the system. 
+nova_fixed 
+Public network for nova Virtual Machines 
+The nova-network node acts as a router. This must be completely owned by the nova system. 
+nova_floating
+Used for external access to nova virtual machines
+
+Table 2 Logical Network Definitions
+3.2.2 Changing the network configuration
+The network configuration is defined by the Crowbar network Barclamp.  The details are specified in a text file in JSON2 format.  This file can be edited to change many parameters in the network configuration.  After making the changes, the final Crowbar installation can be completed (see section 3.3, Installing Crowbar.)
+The configuration file is on the admin node, with the pathname:
+ /opt/dell/chef/data_bags/crowbar/bc-template-network.json
+When editing the file, be careful with the syntax, particularly with commas.  A common mistake is to add trailing commas at the end of sections.  The file is validated at Crowbar installation time.  If there are errors, the Crowbar installation will fail, a nd the log files will contain a reference to the error.
+3.2.3 Network configuration options
+The JSON configuration file is divided into several sections.  This document contains a summary of the options for convenience.  For more details, refer to the network Barclamp section in the Dell Crowbar Users Guide.
+Refer to the sample JSON file in Appendix  B: Sample Network Configuration JSON or the file on disk to see the actual file syntax.
+3.2.3.1 Attributes 
+This section contains global settings for the network configuration.
+Name 
+Default 
+Description 
+start_up_delay 
+30 
+Used to provide a delay in seconds, so the spanning tree in the switch can settle when new interfaces are brought up. 
+mode 
+single 
+This controls whether single or teamed (bonded) NICS are used (it actually defines which conduit map is used)
+teaming 
+6 
+Determines the Linux teaming mode used 
+
+3.2.3.2 Interface Maps
+This section specifies the hardware bus order used to define eth0, eth1, etc., on particular hardware systems.  This rarely needs to be changed, unless a particular system is not correctly enumerating network controllers in the correct order. 
+3.2.3.3 Conduit Maps and Lists
+The Crowbar network Barclamp uses an abstraction, called a conduit, to map hardware network interfaces into logical interfaces.  This section defines the logical conduit names (intf0, intf2, etc.,) and the interfaces in the conduit.  The interfaces are defined by the type of network interface card (NIC.)  1g refers to a 1 GBit network interfaces, 10g refers to a 10 GBit network interface. 
+3.2.3.4 Networks
+The network section defines the individual networks.  Each subsection specifies the network name, its VLAN assignments, and the IP parameters.
+The networks section is the one which is most commonly edited to change vlan assignments and IP address parameters. Each network has the following parameters: 
+Name 
+Default 
+Description 
+vlan 
+Integer 
+The VLAN ID to use on the switch and interfaces for this network 
+use_vlan 
+true 
+A value of true enables VLAN tagging.  A value of false assumes that the node will receive untagged traffic for this network. 
+add_bridge 
+false 
+indicates if the network should have a bridge built on top of it. The bridge will be brnnn. This is used for Nova compute nodes. 
+subnet 
+IP Address 
+The subnet for this network 
+netmask 
+Netmask 
+The netmask for this network 
+router 
+IP Address 
+The default router for this network 
+broadcast 
+IP Address 
+The default broadcast address for this network 
+ranges 
+map 
+This contains a map of strings to start and stop values for network. This allows for sub-ranges with the network for specific uses. e.g. dhcp, admin, bmc, hosts. 
+The range map has a string key that is the name and map defining the range. 
+Name 
+Type 
+Description 
+start 
+IP Address 
+First address in the range, inclusive 
+end 
+IP Address 
+Last address in the range, inclusive 
+3.2.3.5 Example network definition 
+This is a sample network definition stanza, for an admin network.
+1 "admin": {
+2    "vlan": 100,
+3    "use_vlan": false,
+4    "add_bridge": false,
+5    "subnet": "192.168.124.0",
+6    "netmask": "255.255.255.0",
+7    "broadcast": "192.168.124.255",
+8    "ranges": {
+9             "admin"
+10                 { "start": "192.168.124.10", "end": "192.168.124.11" },
+11             "dhcp"
+12                 { "start": "192.168.124.21", "end": "192.168.124.80" },
+13             "host"
+14                 { "start": "192.168.124.81", "end": "192.168.124.160" },
+15             "switch"
+16                 { "start": "192.168.124.241", "end": "192.168.124.250" }
+17    }
+18  }
+3.2.4 Adding External Access to the Admin Node
+A common requirement is to add incoming access to the admin node through a bastion host or network.  This requires an additional definition for the external network, a change to the conduit maps to specify the interface, and a one-time IP address allocation. These changes need to be made before Crowbar is installed, and the IP needs to be allocated after Crowbar installation.
+3.2.4.1 Defining the External Network
+Add a new network stanza that defines the external network.  For this example, we will assume that you have one address that you want to assign to the admin node and you are going to run this as a native (non-tagged) interface. 
+The logical name of the network will be “bastion”. Set use_vlan and add_bridge to false, and specify any vlan number (since it’s unused in this case.)  Also ensure the rest of the parameters are correct for your network. The admin range will be used to assign the address to the admin node from this pool. Place the assigned address in the start and end fields. The conduit field will be "bastion1".
+The results should look like this example:
+1  "bastion": {
+2    "conduit": "bastion1",
+3    "vlan": 50,
+4    "use_vlan": false,
+5    "add_bridge": false,
+6    "subnet": "192.168.235.0",
+7    "netmask": "255.255.255.0",
+8    "broadcast": "192.168.235.255",
+9    "ranges": {
+10             "admin": { "start": "192.168.235.10", "end": "192.168.235.10" }           
+11    }
+12  }
+3.2.4.2 Defining the Interface in the Conduit Map
+Update the conduit map to include the conduit defined in the new network. For this example, we will assume that you are in single mode and have a second 1Gbit interface to use.  
+Add an entry for conduit “bastion1” to the conduit list in the “single” section of the conduit maps, and specify the interface is 1g2.  Here is an example, where lines 4-6 were added:
+1         {
+2           "pattern": "single/.*/.*",
+3           "conduit_list": {
+4             "bastion1": {
+5               "if_list": [ "1g2" ]
+6             },
+7             "intf0": {
+8               "if_list": [ "1g1" ]
+9             },
+10             "intf1": {
+11               "if_list": [ "1g1" ]
+12             },
+13             "intf2": {
+14               "if_list": [ "1g1" ]
+15             }
+16           }
+17         },
+
+
+3.2.4.3 Allocating the IP Address
+After the Crowbar installation is complete, the last steps are to actually allocate the IP address and assign it to the interface:
+# crowbar network allocate_ip default <admin name> bastion admin
+# chef-client
+
+Once the chef-client has finished, you should have access to the admin node through the new interface.
+3.2.5 Configuring the Network for Outbound Connectivity 
+The default configuration assumes the admin node is isolated, and does not depend on external connectivity.  In some cases, it may be desirable to allow outbound access from the admin node, possibly to access external NTP or DNS servers.  This requires updates to the public network definition. These changes need to be made before Crowbar is installed, and the IP needs to be allocated after Crowbar installation.
+3.2.5.1 Updating the public network definition
+Change the definition of the public network to match the external LAN before installing Crowbar.   For example, in the following definition of the public network, lines 6-9, 12, and 13 would need to be updated to match the existing LAN.  The entries that must be updated are the subnet, netmask, broadcast address, router, and ranges.  You might also need to change the conduit entry, depending on which network interface is connected to the external network.
+1         "public": {
+2           "conduit": "intf1",
+3           "vlan": 300,
+4           "use_vlan": true,
+5           "add_bridge": false,
+6           "subnet": "192.168.122.0",
+7           "netmask": "255.255.255.0",
+8           "broadcast": "192.168.122.255",
+9           "router": "192.168.122.1",
+10 	  "router_pref":  5,
+11           "ranges": {
+12             "host": { "start": "192.168.122.2", "end": "192.168.122.49" },
+13             "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }
+14           }
+15         },
+After saving the changes, finish the Crowbar installation.
+3.2.5.2 Allocating the IP Address
+After the Crowbar installation is complete, the last steps are to actually allocate the IP address and assign it to the interface.  On the admin node, execute the commands:
+# crowbar network allocate_ip default <admin name> public host
+# chef-client
+# /etc/init.d/chef-server-webui restart
+
+Once the chef-client has finished, you should have access to the admin node through the new interface, and can outbound access to dns or ntp servers.   
+If external access was being configured to support external DNS and/or NTP servers, then edit any new or existing Barclamp proposals to include the external server entries, and apply the proposals.
+To verify NTP access, you can use the ntpq utility. The ‘*’ before the node IP indicates the local ntp client has synchronized to the external server.  You should wait for the admin node to initially sync to the external time server before deploying the remaining nodes.
+[root@admin config]# ntpq –p
+remote refid st t when poll reach delay offset jitter 
+=============================================================== 
+*172.26.1.50 132.163.4.103 2 u 40 64 377 0.287 -0.433 0.169 
+3.3 Installing Crowbar	
+The initial admin node installation does not complete the Crowbar installation, to allow the network configuration to be customized.  After any customizations have been made, the final Crowbar installation can be completed. 
+   The networks cannot be reconfigured after Crowbar is installed. 
+To complete the Crowbar installation, the steps are:
+1. Log onto the admin node. The default username is crowbar, password: crowbar.
+2. Verify or edit the network configuration file: /opt/dell/chef/data_bags/crowbar/ bc-template-network.json 
+3. sudo –i
+4. cd /tftpboot/ubuntu_dvd/extra
+5. ./install  systemname.yourdomain.com
+The Crowbar installation will be started in a screen session.  You can attach to this session to follow the install process.  The install logs are wtitten to /var/log, and can be checked if there are any errors during the install process.  The process will take several minutes to complete.
+The main cause of errors at this point is usually syntax errors caused while modifying the network configuration.  If an error occurs, check the log files, fix any syntax errors and then restart the Crowbar install process.
+3.3.1 Verifying Admin Node Status
+When the Crowbar installation completes, the admin node will remain at a shell prompt. At this point, all Crowbar and operations services have started. Consult the table below to access these services from a web browser on the administration network.
+Service
+URL
+Credentials 
+SSH
+crowbar@192.168.124.10
+crowbar
+Crowbar UI
+http://192.168.124.10:3000/
+crowbar / crowbar
+Nagios
+http://192.168.124.10/nagios3
+nagiosadmin / password
+Ganglia
+http://192.168.124.10/ganglia
+nagiosadmin / password
+Chef UI
+http://192.168.124.10:4040/
+admin / password
+
+Logging into the Crowbar interface requires acceptance of the License agreement.  It can be found on the Dashboard under EULA, in Appendix C:  End User License Agreement of this document, or at this web page:  http://www.dell.com/content/topics/global.aspx/policy/en/policy?c=us&l=en&s=gen&~section=015#dsla
+3.4 Discovering and Allocating Additional Nodes
+After crowbar has been installed, all additional deployment is performed through Crowbar.
+When additional nodes are powered on, they will PXE boot from the admin server.  The initial boot will use a special ‘discovery’ image, which will probe the node and report its configuration and status to Crowbar.  When this process completes for each node, it will appear in Crowbar as discovered.   
+At this point, no changes have been made to the node.  The node must explicitly be allocated in Crowbar to continue the process.  (This step allows verification of the node identity before continuing.)  After the node has been allocated, it will reboot, and go through a process of installing a base operating system plus operational infrastructure such as NTP, DNS, Nagios, Ganglia, and Chef.
+At the end of the allocation phase, the nodes are ready to have specific OpenStack components deployed to them.
+4 Installing OpenStack Components
+The general workflow to use Crowbar to deploy OpenStack components is:
+a. Obtain a default proposal that includes the parameters for the 
+b. Edit or verify the proposal to assign the correct nodes for component, or to customize the configuration.
+c. Save the proposal to Crowbar
+d. Commit the proposal
+This may be done through the use of the Crowbar command line tool, or the web interface. The sections that follow use the command line tool: /opt/dell/bin/crowbar (for details on using the UI, see the Dell Crowbar Users Guide).
+When using the crowbar tool on the admin node, the user may first have to set the following environment variable:
+export CROWBAR_KEY=`cat /etc/crowbar.install.key`
+If on a non-admin node, one may also use:
+export CROWBAR_KEY=crowbar:crowbar    (the default username/password)
+
+The OpenStack components should be installed in the same order as they appear in the Crowbar interface.  Generally, the OpenStack Compute components are installed on one set of nodes, and the OpenStack Swift components are installed on a different set of nodes. 
+4.1 Example: Implementing a Proposal via Cmd. Line	
+
+You must be root in order to run the crowbar command
+4.1.1 Obtain a Proposal		
+Crowbar will inspect the current known nodes and provide a proposal that it believes will best utilize available systems for the component being installed. To obtain and inspect this proposed configuration:
+/opt/dell/bin/crowbar <component> proposal create <name>
+/opt/dell/bin/crowbar <component> proposal show <name> > <local_file_name>
+Where:
+* <component> - is the component for which the proposal is made; e.g. swift, nova, glance
+* <name> - is the name assigned to this proposal. This name should be unique for the component; i.e. if 2 swift clusters are being installed, the proposals for each should have unique names. They need not be unique between components of different types
+* <local_file_name> - is a file into which the proposal will be written
+4.1.2 Update a Proposal		
+The local file created above can be inspected and modified. Common changes include:
+* Changing default passwords and other Barclamp parameters (e.g. Swift replica count)
+* Changing the assignment of machines to roles
+Once edits are completed, crowbar must be updated. To update Crowbar with a modified proposal:
+/opt/dell/bin/crowbar <component> proposal –-file=<local_file_name> edit <name>
+where the parameters in this command are the same as mentioned above. Crowbar will validate the proposal for syntax and perform basic sanity checks as part of this process.
+4.1.3 Committing a Proposal
+Once the proposal content is satisfactory, the Barclamp instance can be activated:
+/opt/dell/bin/crowbar <component> proposal commit <name>
+This might take a few moments, as Crowbar is deploying the required software to the machines mentioned in the proposal.
+4.1.4 Modifying an Active Configuration	
+When committing a proposal which was previously committed, Crowbar compares the new configuration to the currently active state and applies the deltas.
+To force crowbar to reapply a proposal, the active state needs to be deleted via:
+/opt/dell/bin/crowbar <component> delete <name>
+Then commit the proposal again as described above.
+
+
+5 Appendix A:  Default Switch Configuration
+When deploying the switches the following configuration should be used to appropriately setup the VLANs.  The following commands are to be used with a Dell PowerConnect 6248 switch.  Modifications will be required depending on the network configuration of the environment.  Items in red are optional.
+1 #
+2 #
+3 vlan database
+4 vlan 2,100,200,300,400,500 
+5 interface vlan 2 
+6 name mgmt
+7 exit
+8 swith 1 priority 10
+9 switch 2 priority 9
+10 interface vlan 100
+11 name Admin_Net
+12 ip address 192.168.124.1 255.255.255.0
+13 routing
+14 exit
+15 interface vlan 200
+16 name Storage_Net
+17 exit
+18 interface vlan 300
+19 name External_Net
+20 exit
+21 interface vlan 400
+22 name Nova_Floating
+23 exit
+24 interface vlan 500
+25 name Nova_Fixed
+26 exit
+27 #
+28 #
+29 interface range ethernet 1/g1-1/g48,2/g1-2/g48
+30 shutdown
+31 spanning-tree portfast 
+32 switchport mode general 
+33 switchport general pvid 100 
+34 switchport general allowed vlan add 100 
+35 switchport general allowed vlan add 200,300,400,500 tagged 
+36 switchport general allowed vlan remove 1 
+37 no switchport general acceptable-frame-type tagged-only
+38 lldp transmit-tlv port-desc sys-name sys-desc sys-cap
+39 lldp transmit-mgmt
+40 lldp notification
+41 no shutdown
+42 exit
+43 #
+44 #
+45 ip address 192.168.254.250 255.255.255.0
+46 ip address vlan 2
+47 ip ssh server
+48 #
+49 #
+50 UPLINK Port
+51 interface ethernet 1/gxxx
+52 shutdown
+53 switchport general pvid 300
+54 no switchport general acceptable-frame-type tagged-only
+55 switchport general allowed vlan add 300
+56 switchport general allowed vlan remove 1,2
+57 lldp transmit-tlv port-desc sys-name sys-desc sys-cap
+58 lldp transmit-mgmt
+59 lldp notification
+60 no shutdown
+61 exit
+62 switchport general allowed vlan add xxxx
+63 switchport general allowed vlan add 300 tagged
+64 switchport general allowed vlan remove 1
+65 lldp transmit-tlv port-desc sys-name sys-desc sys-cap
+66 lldp transmit-mgmt
+67 lldp notification
+68 exit
+69 
+
+6 Appendix  B: Sample Network Configuration JSON
+This is a sample of the default network configuration included in the Dell OpenStack Powered Cloud Solution. This is provided for reference – the actual file included on the installation media is the latest version, and may differ slightly from this example.
+
+70 {
+71   "id": "bc-template-network",
+72   "description": "Instantiates network interfaces on the crowbar managed systems. Also manages the address pool",
+73   "attributes": {
+74     "network": {
+75       "start_up_delay": 30,
+76       "mode": "single",
+77       "teaming": {
+78         "mode": 6
+79       },
+80       "interface_map": [
+81         {
+82           "pattern": "PowerEdge R610",
+83           "bus_order": [
+84             "0000:00/0000:00:01",
+85             "0000:00/0000:00:03"
+86           ]
+87         },
+88         {
+89           "pattern": "PowerEdge R710",
+90           "bus_order": [
+91             "0000:00/0000:00:01",
+92             "0000:00/0000:00:03"
+93           ]
+94         },
+95         {
+96           "pattern": "PowerEdge C6145",
+97           "bus_order": [
+98             "0000:00/0000:00:04",
+99             "0000:00/0000:00:02"
+100           ]
+101         },
+102         {
+103           "pattern": "PowerEdge C2100",
+104           "bus_order": [
+105             "0000:00/0000:00:1c",
+106             "0000:00/0000:00:07",
+107             "0000:00/0000:00:09",
+108             "0000:00/0000:00:01"
+109           ]
+110         },
+111         {
+112           "pattern": "C6100",
+113           "bus_order": [
+114             "0000:00/0000:00:01",
+115             "0000:00/0000:00:03",
+116             "0000:00/0000:00:07"
+117           ]
+118         },
+119         {
+120           "pattern": "product",
+121           "bus_order": [
+122             "0000:00/0000:00:01",
+123             "0000:00/0000:00:02"
+124           ]
+125         }
+126       ],
+127       "conduit_map": [
+128         {
+129           "pattern": "team/.*/.*",
+130           "conduit_list": { 
+131             "intf0": {
+132               "if_list": [ "1g1", "1g2" ],
+133               "team_mode": 6
+134             },
+135             "intf1": {
+136               "if_list": [ "1g1", "1g2" ],
+137               "team_mode": 6
+138             },
+139             "intf2": {
+140               "if_list": [ "1g1", "1g2" ],
+141               "team_mode": 6
+142             }
+143           }
+144         },
+145         {
+146           "pattern": "dual/.*/.*",
+147           "conduit_list": { 
+148             "intf0": {
+149               "if_list": [ "?1g1" ]
+150             },
+151             "intf1": {
+152               "if_list": [ "?1g2" ]
+153             },
+154             "intf2": {
+155               "if_list": [ "?1g1" ]
+156             }
+157           }
+158         },
+159         {
+160           "pattern": "single/.*/.*",
+161           "conduit_list": { 
+162             "intf0": {
+163               "if_list": [ "?1g1" ]
+164             },
+165             "intf1": {
+166               "if_list": [ "?1g1" ]
+167             },
+168             "intf2": {
+169               "if_list": [ "?1g1" ]
+170             }
+171           }
+172         },
+173         {
+174           "pattern": ".*/.*/.*",
+175           "conduit_list": { 
+176             "intf0": {
+177               "if_list": [ "?1g1" ]
+178             },
+179             "intf1": {
+180               "if_list": [ "1g1" ]
+181             },
+182             "intf2": {
+183               "if_list": [ "1g1" ]
+184             }
+185           }
+186         },
+187         {
+188           "pattern": "mode/1g_adpt_count/role",
+189           "conduit_list": { 
+190             "intf0": {
+191               "if_list": [ "1g1" ]
+192             },
+193             "intf1": {
+194               "if_list": [ "?1g1" ]
+195             },
+196             "intf2": {
+197               "if_list": [ "?1g1" ]
+198             }
+199           }
+200         }
+201       ],
+202       "networks": {
+203         "storage": {
+204           "conduit": "intf1",
+205           "vlan": 200,
+206           "use_vlan": true,
+207           "add_bridge": false,
+208           "subnet": "192.168.125.0",
+209           "netmask": "255.255.255.0",
+210           "broadcast": "192.168.125.255",
+211           "ranges": {
+212             "host": { "start": "192.168.125.10", "end": "192.168.125.239" }
+213           }
+214         },
+215         "public": {
+216           "conduit": "intf1",
+217           "vlan": 300,
+218           "use_vlan": true,
+219           "add_bridge": false,
+220           "subnet": "192.168.122.0",
+221           "netmask": "255.255.255.0",
+222           "broadcast": "192.168.122.255",
+223           "router": "192.168.122.1",
+224 	  "router_pref":  5,
+225           "ranges": {
+226             "host": { "start": "192.168.122.2", "end": "192.168.122.49" },
+227             "dhcp": { "start": "192.168.122.50", "end": "192.168.122.127" }
+228           }
+229         },
+230         "nova_fixed": {
+231           "conduit": "intf1",
+232           "vlan": 500,
+233           "use_vlan": true,
+234           "add_bridge": true,
+235           "subnet": "192.168.123.0",
+236           "netmask": "255.255.255.0",
+237           "broadcast": "192.168.123.255",
+238           "router": "192.168.123.1",
+239 	  "router_pref": 20,
+240           "ranges": {
+241             "router": { "start": "192.168.123.1", "end": "192.168.123.49" },
+242             "dhcp": { "start": "192.168.123.50", "end": "192.168.123.254" }
+243           }
+244         },
+245         "nova_floating": {
+246           "conduit": "intf1",
+247           "vlan": 300,
+248           "use_vlan": true,
+249           "add_bridge": false,
+250           "subnet": "192.168.122.128",
+251           "netmask": "255.255.255.192",
+252           "broadcast": "192.168.122.191",
+253           "ranges": {
+254             "host": { "start": "192.168.122.129", "end": "192.168.122.191" }
+255           }
+256         },
+257         "bmc": {
+258           "conduit": "bmc",
+259           "vlan": 100,
+260           "use_vlan": false,
+261           "add_bridge": false,
+262           "subnet": "192.168.124.0",
+263           "netmask": "255.255.255.0",
+264           "broadcast": "192.168.124.255",
+265           "ranges": {
+266             "host": { "start": "192.168.124.162", "end": "192.168.124.240" }
+267           }
+268         },
+269         "bmc_vlan": {
+270           "conduit": "intf2",
+271           "vlan": 100,
+272           "use_vlan": true,
+273           "add_bridge": false,
+274           "subnet": "192.168.124.0",
+275           "netmask": "255.255.255.0",
+276           "broadcast": "192.168.124.255",
+277           "ranges": {
+278             "host": { "start": "192.168.124.161", "end": "192.168.124.161" }
+279           }
+280         },
+281         "admin": {
+282           "conduit": "intf0",
+283           "vlan": 100,
+284           "use_vlan": false,
+285           "add_bridge": false,
+286           "subnet": "192.168.124.0",
+287           "netmask": "255.255.255.0",
+288           "broadcast": "192.168.124.255",
+289           "router": "192.168.124.1",
+290 	  "router_pref": 10, 
+291           "ranges": {
+292             "admin": { "start": "192.168.124.10", "end": "192.168.124.11" },
+293             "dhcp": { "start": "192.168.124.21", "end": "192.168.124.80" },
+294             "host": { "start": "192.168.124.81", "end": "192.168.124.160" },
+295             "switch": { "start": "192.168.124.241", "end": "192.168.124.250" }
+296           }
+297         }
+298       }
+299     }
+300   },
+301   "deployment": {
+302     "network": {
+303       "crowbar-revision": 0,
+304       "element_states": {
+305         "network": [ "readying", "ready", "applying" ]
+306       },
+307       "elements": {},
+308       "element_order": [
+309         [ "network" ]
+310       ],
+311       "config": {
+312         "environment": "network-base-config",
+313         "mode": "full",
+314         "transitions": true,
+315         "transition_list": [ "discovered", "reset", "delete" ]
+316       }
+317     }
+318   }
+319 }
+320 
+
+7 Appendix C:  End User License Agreement
+
+DELL END USER LICENSE AGREEMENT Ver. 1.3
+TYPE-A SOFTWARE 
+
+THIS IS A LEGAL AGREEMENT BETWEEN YOU (EITHER AN INDIVIDUAL OR AN ENTITY) AND DELL PRODUCTS L.P. OR DELL GLOBAL B.V. (SINGAPORE BRANCH), ON BEHALF OF DELL INC. AND ITS WORLDWIDE SUBSIDIARIES AND AFFILIATES (COLLECTIVELY, "Dell" OR “DELL”), WHICH GOVERNS YOUR USE OF THE SOFTWARE. THE SOFTWARE SHALL MEAN COLLECTIVELY THE SOFTWARE PROGRAM, THE ASSOCIATED MEDIA, PRINTED MATERIALS, ONLINE OR ELECTRONIC DOCUMENTATION, AND ANY COPIES THEREOF, TO WHICH THIS AGREEMENT IS ATTACHED OR OTHERWISE ASSOCIATED (the “Software” or “SOFTWARE”).  PLEASE READ THE TERMS AND CONDITIONS OF THIS AGREEMENT CAREFULLY, INCLUDING, WITHOUT LIMITATION, ANY SUPPLEMENTAL TERMS AND CONDITIONS APPEARING OR REFERENCED BELOW, WHICH ARE HEREBY MADE PART OF THIS END USER LICENSE AGREEMENT (COLLECTIVELY, “EULA”), BEFORE DOWNLOADING, INSTALLING, ACTIVIATING AND/OR OTHERWISE USING THE SOFTWARE. BY EXPRESSLY ACCEPTING THESE TERMS OR DOWNLOADING, INSTALLING, ACTIVATING AND/OR OTHERWISE USING THE SOFTWARE, YOU ARE AGREEING THAT YOU HAVE READ, AND THAT YOU AGREE TO COMPLY WITH AND TO BE BOUND BY THE TERMS AND CONDITIONS OF THIS EULA AND ALL APPLICABLE LAWS AND REGULATIONS IN THEIR ENTIRETY WITHOUT LIMITATION OR QUALIFICATION. IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS AND CONDITIONS OF THIS EULA, THEN YOU MAY NOT DOWNLOAD, INSTALL, ACTIVATE OR OTHERWISE USE ANY OF THE SOFTWARE AND YOU MUST PROMPTLY RETURN THE SOFTWARE AND ANY HARDWARE TO WHICH IT IS ATTACHED, AS DIRECTED BY DELL OR ITS RESELLER (IF APPLICABLE) FOR A FULL REFUND.  IF YOU ARE AN INDIVIDUAL REPRESENTING AN ENTITY, YOU ACKNOWLEDGE THAT YOU HAVE THE APPROPRIATE AUTHORITY TO ACCEPT THESE TERMS AND CONDITIONS ON BEHALF OF SUCH ENTITY.
+
+1. License. Subject to the terms, conditions and limitations of this EULA and timely payment by you, Dell hereby grants you a limited, nonexclusive, nontransferable, non-assignable license, without rights to sublicense, to install or have installed, display and use the Software (in object code only) only on as many computers, devices and/or in such configurations as you are expressly entitled (e.g., as set forth in the applicable Dell sales quote).  The terms and conditions of this EULA will govern use of the Software and any upgrades, updates, patches, hotfixes, modules, routines and/or additional versions of the Software provided by Dell, at Dell’s sole discretion, that replace and/or supplement the original Software (collectively, “Update”), unless such Update is accompanied by or references a separate license agreement in which case the terms and conditions of that agreement will govern.  If this EULA governs your use of an Update, such Update shall be considered Software for purposes of this EULA. Unless earlier terminated as provided herein, the term of each individual license granted under this EULA begins on the date of acceptance of this EULA, and continues only for such period as you have purchased, in the case of a term license, and is perpetual if no term is specified.  Customer may use only portions of Software for which it has paid the applicable license fee. 
+
+2. License Limitations. You may not copy the Software except for a reasonable number of copies solely as needed for backup or archival purposes or as otherwise expressly permitted in Section 1 “License” above.  You may not modify or remove any titles, trademarks or trade names, copyright notices, legends, or other proprietary notices or markings on or in the Software. The rights granted herein are limited to Dell's and its licensors' and suppliers’ intellectual property rights in the Software and do not include any other third party’s intellectual property rights. If the Software was provided to you on removable media (e.g., CD, DVD, or USB drive), you may own the media on which the Software is recorded but Dell, Dell's licensor(s) and/or supplier(s) retain ownership of the Software itself and all related intellectual property rights. You are not granted any rights to any trademarks or service marks of Dell. This EULA does not apply to any third party software that is not included as part of the Software.    The use of any other software, including any software package or file, whether licensed to you separately by Dell or by a third party, is subject to the terms and conditions that come with or are associated with such software. 
+
+3. Rights Reserved. THE SOFTWARE IS LICENSED, NOT SOLD.  Except for the license expressly granted in this EULA, Dell, on behalf of itself and its licensors and suppliers, retains all right, title, and interest in and to the Software and in all related content, materials, copyrights, trade secrets, patents, trademarks, derivative works and any other intellectual and industrial property and proprietary rights, including registrations, applications, renewals, and extensions of such rights (the "Works"). The rights in these Works are valid and protected in all forms, media and technologies existing now or hereafter developed and any use other than as contemplated herein, including the reproduction, modification, distribution, transmission, adaptations, translation, display, republication or performance of the Works, except as specifically permitted herein, is strictly prohibited.  Dell, on behalf of itself and its licensors and suppliers, retains all rights not expressly granted herein. 
+
+4. Restrictions. Except as otherwise provided herein or expressly agreed by Dell, you may not, and will not allow a third party to (A) sell, lease, license, sublicense, assign, distribute or otherwise transfer or encumber in whole or in part the Software; (B) provide, make available to, or permit use of the Software in whole or in part by, any third party, including contractors, without Dell's prior written consent, unless such use by the third party is solely on Customer’s behalf, is strictly in compliance with the terms and conditions of this EULA, and you are liable for any breach of this EULA by such third party (a “Permitted Third Party”); (C) copy, reproduce, republish, upload, post or transmit the Software in any way (D) decompile, disassemble, reverse engineer, or otherwise attempt to derive source code (or underlying ideas, algorithms, structure or organization) from the Software program, in whole or in part; (E) modify or create derivative works based upon the Software (except as set forth in Section 13 – Development Tools); (F) use the Software on a service bureau, rental or managed services basis or permit other individuals or entities to create Internet "links" to the Software or "frame" or "mirror" the Software on any other server or wireless or Internet-based device; (G) use Software that was loaded by Dell onto specific hardware (an “Appliance”) separately from such Appliance; or (H) use the Software to create a competitive offering.  You may not, and will not allow a Permitted Third Party to, use the Software in excess of the number of licenses expressly authorized by Dell.  In addition, you may not share the results of any benchmarking of the Software without Dell’s prior written consent.  
+
+5. Compliance.  You will certify in writing, upon reasonable request by Dell, that all use of Software is in compliance with the terms of this EULA, indicating the number of Software licenses deployed at that time.  You grant Dell, or an agent selected by Dell, the right to perform a reasonable audit of your compliance with this EULA during normal business hours.  You agree to cooperate and provide Dell with all records reasonably related to your compliance with this EULA. If, as a result of the audit, a deficiency of greater than five percent (5%) is found in the licensee fees paid, then you shall bear the total cost of the audit, in addition to any other liabilities you may have.
+
+6. Support and Subscription Services Not Included. Dell does not provide any maintenance or support services under this EULA. Maintenance and support services, if any, are provided under a separate agreement, which may be located at www.Dell.com/servicecontracts. Additionally, this EULA, in and of itself, does not entitle you to any Updates at any time in the future. 
+
+7. Termination. Dell may terminate this EULA immediately and without prior notice if you fail to comply with any term or condition of this EULA or if Dell does not receive timely payment for the licenses to the Software or for the hardware to which it is attached, if any. In addition, Dell may terminate any license to Software distributed for free at any time in its sole discretion.  Either party may terminate this EULA at any time by providing at least ninety (90) days prior written notice to the other party.  In the event of termination of this EULA, all licenses granted hereunder shall automatically terminate and you must immediately cease use of the Software and return or destroy all copies of the Software. The parties recognize and agree that their obligations under Sections 3, 4, 7, 10, 11, 12, 17, 18, 19, 20, 22 and 23 of this EULA, as well as obligations for payment, survive the cancellation, termination, and/or expiration of this EULA, and/or the licenses granted hereunder.
+
+8. Export, Import and Government Restrictions. You are advised that the Software is subject to U.S. export laws as well as the laws of the country where it is delivered or used.  You agree to abide by these laws.  Under these laws, the Software may not be sold, leased, or transferred to restricted countries (currently Cuba, Iran, North Korea, Sudan and Syria), restricted end-users, or for restricted end-uses.  You specifically agree that the Software will not be used for activities related to weapons of mass destruction, including but not limited to, activities related to the design, development, production or use of nuclear materials, nuclear facilities, or nuclear weapons, missiles or support of missile projects, or chemical or biological weapons. You understand that certain functionality of the Software, such as encryption or authentication, may be subject to import restrictions in the event you transport the Software from the country of delivery and you are responsible for complying with applicable restrictions.  
+
+The Software and documentation are "commercial items" as that term is defined at 48 C.F.R. 2.101, consisting of "commercial computer software" and "commercial computer software documentation" as such terms are used in 48 C.F.R. 12.212. Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through 227.7202-4, all U.S. Government end users acquire the Software and documentation with only those rights set forth herein. Contractor/manufacturer is Dell Products L.P., One Dell Way, Round Rock, Texas 78682.  
+
+9. Limited Warranty. Unless otherwise provided in the limited warranties for the Software found at http://www.Dell.com/Warranty, Dell solely warrants that it has the right to grant the licenses to the Software, and except as set forth in Sections 14 and 16 below, that such Software will substantially conform in material respects to the functional specifications and current documentation provided by Dell with the Software.  This limited warranty is not transferable and extends only for thirty (30) days from the date of delivery of the Software, unless otherwise stated at www.Dell.com/Warranty. This limited warranty does not cover damages, defects, malfunctions or failures caused by any unauthorized modification by you, or your agents, of the Software; any abuse, misuse or negligent acts of you; modification by you of any interfaces or any software or hardware interfacing with the Software; or any failure by you to follow Dell’s installation, operation or maintenance instructions. EXCEPT FOR THE PRECEDING EXPRESS LIMITED WARRANTY, DELL MAKES, AND YOU RECEIVE, NO OTHER WARRANTIES RELATED TO THE SOFTWARE WHETHER EXPRESS, IMPLIED OR STATUTORY, AND DELL SPECIFICALLY DISCLAIMS ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. DELL DOES NOT WARRANT THAT THE FUNCTIONS OF THE SOFTWARE WILL MEET YOUR REQUIREMENTS OR THAT OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED OR ERROR FREE.  YOU ASSUME RESPONSIBILITY FOR SELECTING THE SOFTWARE AND THE RESULTS ACHIEVED.  YOUR SOLE AND EXCLUSIVE REMEDY, AND DELL’S ENTIRE LIABILITY,  FOR BREACH OF THE WARRANTIES PROVIDED HEREIN, IS FOR DELL, AT ITS SOLE DISCRETION, TO EITHER USE COMMERCIALLY REASONABLE EFFORTS TO REMEDY ANY NON-CONFORMANCE OR TO PROVIDE A REFUND OF THE LICENSE FEES PAID BY YOU TO DELL FOR THE SOFTWARE. THIS DISCLAIMER OF WARRANTY MAY NOT BE VALID IN SOME JURISDICTIONS AND YOU MAY HAVE WARRANTY RIGHTS UNDER LAW WHICH MAY NOT BE WAIVED OR DISCLAIMED -- ANY SUCH WARRANTY EXTENDS ONLY FOR THIRTY (30) DAYS FROM THE DATE OF DELIVERY OF THE SOFTWARE.
+
+10. Limitation of Liability.  DELL WILL NOT BE LIABLE FOR ANY INCIDENTAL, INDIRECT, PUNITIVE, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF OR IN CONNECTION WITH THIS EULA AND/OR THE SOFTWARE. DELL SHALL HAVE NO LIABILITY FOR THE FOLLOWING:  (A) LOSS OF REVENUE, INCOME, PROFIT, OR SAVINGS, (B) LOST OR CORRUPTED DATA OR SOFTWARE, LOSS OF USE OF SYSTEM(S) OR NETWORK(S), OR THE RECOVERY OF SUCH, (C) LOSS OF BUSINESS OPPORTUNITY, (D) BUSINESS INTERRUPTION OR DOWNTIME, (E) LOSS OF GOODWILL OR REPUTATION, OR (F) SOFTWARE NOT BEING AVAILABLE FOR USE OR THE PROCUREMENT OF SUBSTITUTE SOFTWARE OR GOODS. 
+
+NOTWITHSTANDING ANYTHING TO THE CONTRARY SET FORTH IN THIS EULA, DELL’S TOTAL LIABILITY FOR ANY AND ALL CLAIMS ARISING OUT OF OR IN CONNECTION WITH THIS EULA AND/OR THE SOFTWARE SHALL NOT EXCEED THE TOTAL AMOUNT RECEIVED BY DELL FOR THE PARTICULAR SOFTWARE GIVING RISE TO SUCH CLAIM(S).  
+
+The foregoing limitations, exclusions and disclaimers shall apply to any and all claims, regardless of whether the claim(s) for such damages is based in contract, warranty, strict liability, negligence, tort or otherwise. Insofar as applicable law prohibits any limitation on liability herein, the parties agree that such limitation will be automatically modified, but only to the extent so as to make the limitation compliant with applicable law.  The parties agree that the limitations on liabilities set forth herein are agreed allocations of risk and such limitations will apply notwithstanding the failure of essential purpose of any limited remedy and even if a party has been advised of the possibility of any such liability.  
+
+DELL SHALL NOT BE LIABLE TO YOU FOR ANY CLAIM BROUGHT MORE THAN TWO YEARS AFTER THE CAUSE OF ACTION FOR SUCH CLAIM FIRST AROSE.    
+
+11. Indemnification.  Except where prohibited by applicable law, Dell shall defend and indemnify you against any third-party claim or action that the Software (specifically excluding open source software) infringes or misappropriates that third party’s patent, copyright, trade secret, or other intellectual property rights (“Indemnified Claims”).  In addition, if Dell receives prompt notice of an Indemnified Claim that, in Dell’s reasonable opinion, is likely to result in an adverse ruling, then Dell shall at its sole discretion, (A) obtain a right for you to continue using such Software; (B) modify such Software to be non-infringing; (C) replace such Software with a non-infringing substitute; or (D) provide a reasonable depreciated refund for the allegedly infringing Software.  Notwithstanding the foregoing, Dell shall have no obligation under this Section for Indemnified Claims resulting or arising from: (i) modifications of the Software that were not performed by or on behalf of Dell; (ii) your unauthorized use of the Software, or the combination or operation of the Software in connection with a third-party product, software, or service (the combination of which causes the claimed infringement); (iii) your failure to incorporate free Software updates or upgrades that would have avoided the alleged infringement; or (iv) Dell’s compliance with your written specifications or directions, including the incorporation of any software or other materials or processes provided by or requested by you (collectively, “Excluded Indemnified Claims”).  Dell’s duty to indemnify and defend is contingent upon:  (a) your providing Dell with prompt written notice of the third-party claim or action, (b) Dell having the right to solely control the defense and settlement of such claim or action, and (c) your cooperation with Dell in defending and resolving such claim or action.  This Section states your exclusive remedies for any third-party claim or action, and nothing in this EULA or elsewhere will obligate Dell to provide any greater indemnity to you.  You, at your expense, shall defend and indemnify Dell against any claim, action or proceeding brought against Dell which arises from or is in any manner connected with the Excluded Indemnified Claims.
+
+12. Confidentiality.  You agree to: (A) not use Confidential Information except as necessary to exercise the rights herein and (B) use best efforts to preserve and protect the confidentiality of the Confidential Information. "Confidential Information" means any oral, written, graphic or machine-readable information disclosed by Dell that is (i) identified as confidential; (ii) designated in writing to be confidential or proprietary; or (iii) should be reasonably understood to be confidential.  Confidential Information includes the Software and its trade secrets, including but not limited to source code, the development status of the Software, the appearance, content and flow of the user interface of the Software, and the content and documentation of the Software.  Confidential Information does not include information that is (a) publicly available other than through a breach of this EULA; (b) known to you prior to such disclosure; or (c) subsequently lawfully obtained by you from a third party that has no obligations of confidentiality. You agree that, without Dell’s prior written consent, you will not grant access to any Dell Confidential Information to any persons or entities except for your employees and agents who have a business need to have such access and who are obligated to maintain the confidentiality thereof as set forth herein. These obligations do not expire.   In some, limited circumstances, Dell may need to engage a third party to fulfill its obligations to you under this EULA.  By using this Software you agree that Dell may provide your information to such third party for that purpose. Dell may obtain information related to your use of the Software and you agree that we may use such information in aggregate form in an anonymous manner in support of our marketing activities related to the Software. Any feedback, value added changes or suggestions made by you or other information that is provided to Dell relating to the Software shall be owned by Dell and considered Dell Confidential Information.  
+
+13. Development Tools.  If the Software includes development tools, such as scripting tools, APIs, or sample scripts (collectively “Development Tools”), you may use such Development Tools to create new scripts and code for the purpose of customizing your use of the Software (within the parameters set forth in this EULA and within the parameters set forth in the Development Tools themselves) and for no other purpose.    Notwithstanding anything to the contrary set forth in this EULA, no warranty or technical support is provided for sample scripts contained in such Development Tools or scripts or other code written by you or any third party.
+
+14. Evaluation Licenses.  If you have received Software for evaluation purposes (“Evaluation Software”), you may use the Evaluation Software solely for such limited evaluation period and for internal evaluation purposes only. You acknowledge that Dell may terminate your right to evaluate the Evaluation Software, for any or no reason, effective immediately upon notice to you. IN ADDITION, THE EVALUATION SOFTWARE IS PROVIDED TO YOU "AS IS" WITHOUT INDEMNITY OR WARRANTY OF ANY KIND, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE. NOTWITHSTANDING ANYTHING TO THE CONTRARY IN THIS EULA, DELL BEARS NO LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, PUNITIVE, SPECIAL OR CONSEQUENTIAL DAMAGES RESULTING FROM USE (OR ATTEMPTED USE) OF THE EVALUATION SOFTWARE THROUGH AND AFTER THE EVALUATION PERIOD AND HAS NO DUTY TO PROVIDE SUPPORT TO YOU.
+
+15. Hosted and Internet-Accessible Software.  Some or all of the Software may be remotely hosted or accessible to you through the Internet (“Hosted Software”). In such case, Dell may suspend, terminate, withdraw, or discontinue all or part of the Hosted Software or your access to the Hosted Software upon receipt of a subpoena or law-enforcement request, or when Dell believes, in its sole discretion, that you have breached any term of this EULA or are involved in any fraudulent, misleading, or illegal activities. Dell may modify the Hosted Software at any time with or without prior notice to you. Dell may perform scheduled or unscheduled repairs or maintenance, or remotely patch or upgrade the Hosted Software installed on its and your system(s), which may temporarily degrade the quality of the Hosted Software or result in a partial or complete outage of the Hosted Software. Updates, patches or alerts may be delivered from Dell servers, which may be located outside of your country. Dell provides no assurance that you will receive advance notification of such activities or that your use of the Hosted Software will be uninterrupted or error-free.
+
+16. Open Source Software.  The Software may come bundled or otherwise be distributed with open source software, which is subject to the terms and conditions of the specific license under which the open source software is distributed.  THIS OPEN SOURCE SOFTWARE IS PROVIDED BY DELL "AS IS" WITHOUT ANY WARRANTY, EXPRESS, IMPLIED, OR OTHERWISE, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.  NOTWITHSTANDING ANYTHING TO THE CONTRARY IN THIS EULA, AS IT RELATES TO ANY AND ALL CLAIMS ARISING OUT OF OR IN CONNECTION WITH OPEN SOURCE SOFTWARE, DELL SHALL HAVE NO LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, PUNITIVE, SPECIAL OR CONSEQUENTIAL DAMAGES. Under certain open source software licenses, you are entitled to obtain the corresponding source files.  You may find corresponding source files for the Software at http://opensource.dell.com or other locations that may be specified to you by Dell.
+
+17. Right to Preliminary and Injunctive Relief. You agree that money damages would be an inadequate remedy for Dell in the event of a breach or threatened breach by you of the provisions set forth in this EULA; therefore, you agree that in the event of a breach or threatened breach of any such provisions, Dell may, in addition to any other remedies to which it is entitled, be entitled to such preliminary or injunctive relief (including an order prohibiting you from taking actions in breach of such provisions) and specific performance as may be appropriate to preserve all of Dell’s rights. All rights and remedies afforded Dell by law shall be cumulative and not exclusive.  
+
+18. Choice of Law and Language.  This EULA shall be governed by the laws of the State of Texas, USA, to the exclusion of the UN Convention on Contracts for the International Sale of Goods.  You acknowledge that the headquarters of the Dell family of companies is located in Texas, and that the software licensed under this EULA and the related products marketed in connection with such software were in substantial part conceived, developed, and marketed by Dell personnel in Texas.  Further, you acknowledge, agree, and stipulate that the laws of the State of Texas bear a substantial relationship to this EULA and that the selection of Texas law to govern this EULA and the license of the Software hereunder is reasonable and appropriate, and you consent to the selection of such law to govern this EULA and the relationship of the parties hereto.   This EULA has been agreed only in the English language, which version of this EULA shall be controlling regardless of whether any translations of this EULA have been prepared or exchanged.  As an exception to the preceding sentence, if Dell provides this EULA to you only in a non-English language version, then such non-English language version shall control.  You acknowledge and represent that you have carefully reviewed this EULA with the involvement and assistance of your employees, advisors, and/or legal counsel fluent in the English language, that you have consulted with local legal counsel and counsel competent to render advice with respect to transactions governed by the law applicable to this EULA, that you have no questions regarding the meaning or effect of any of this EULA’s terms, and that you have obtained high-quality translations of this EULA for use by you or any of your team who are not fluent in the English language, with the understanding that you alone shall bear the risk of any misunderstandings that may arise as a result of such translation.  All communications in connection with this EULA shall be in the English language.
+
+Les parties ont demandé que cette convention ainsi que tous les documents qui s'y rattachent soient rédigés en anglais. 
+
+19. Dispute Resolution and Binding Arbitration.  ANY CLAIM, DISPUTE, OR CONTROVERSY (WHETHER IN CONTRACT, TORT, OR OTHERWISE, WHETHER PREEXISTING, PRESENT OR FUTURE, AND INCLUDING STATUTORY, COMMON LAW, INTENTIONAL TORT AND EQUITABLE CLAIMS) BETWEEN YOU AND DELL arising out of or in connection with this EULA, or the breach, termination or validity thereof shall be finally settled under the Rules of Arbitration of the International Chamber of Commerce (“ICC”) by one or more arbitrators with expertise in software licensing appointed in accordance with such rules. The arbitration shall be conducted in the English language.  The place of the arbitration shall be a commercial center reasonably chosen by the arbitration panel in a third country so as to ensure that the award resulting from the arbitration shall be of an international character and enforceable under the New York Convention on the Recognition and Enforcement of Foreign Arbitral Awards.  The arbitration panel shall be empowered to grant whatever relief would be available in court, including without limitation preliminary relief, injunctive relief, and specific performance.  Any award of the arbitration panel shall be final and binding immediately when rendered, and judgment on the award may be entered in any court of competent jurisdiction.  Neither you nor Dell shall be entitled to join, consolidate, or include any claims belonging to or alleged or arising from, by, or on behalf of any third party to an arbitration brought hereunder.  The individual (non-class) nature of this dispute resolution provision goes to the essence of the parties' dispute resolution agreement, and if found unenforceable, the entire arbitration and dispute resolution provision shall be void.  Notwithstanding the foregoing, Dell may apply to any relevant government agency or any court of competent jurisdiction to preserve its rights under this EULA and to obtain any injunctive or preliminary relief, or any award of specific performance, to which it may be entitled, either against you or against a non-party; provided, however, that no such administrative or judicial authority shall have the right or power to render a judgment or award (or to enjoin the rendering of an arbitral award) for damages that may be due to or from either party under this EULA, which right and power shall be reserved exclusively to an arbitration panel proceeding in accordance herewith. 
+
+20. No Waiver.  No waiver of breach or failure to exercise any option, right, or privilege under the terms of this EULA on any occasion shall be construed to be a waiver of a subsequent breach or right to exercise any option, right, or privilege.
+
+21. Force Majeure.  Dell shall not be responsible for any delay or failure in performance of any part of this EULA to the extent that such delay or failure is caused by fire, flood, explosion, war, embargo, government requirement, civil, or military authority, act of God, act or omission of carriers, failure of the Internet or other similar causes beyond its control.
+
+22. No Assignment.   Except as set forth herein, you may not assign or transfer your interests, rights or obligations under this EULA by written agreement, merger, consolidation, operation of law or otherwise, without the prior written consent of an authorized executive officer of Dell.  Any attempt to assign this EULA by you without such prior written consent from Dell shall be null and void.
+
+23. Entire Agreement.  Unless you have entered into another written agreement with respect to the Software which has been signed by you and an authorized representative of Dell and which conflicts with the terms of this EULA, you agree that this EULA supersedes all prior written or oral agreements, warranties or representations, including any and all other click-wrap, shrink-wrap or similar licenses or agreements, with respect to the Software.  No amendment to or modification of this EULA, in whole or in part, will be valid or binding unless it is in writing and executed by authorized representatives of both parties. If any term of this EULA is found to be invalid or unenforceable, the remaining provisions will remain effective.    You agree that any principle of construction or rule of law that provides that an agreement shall be construed against the drafter shall not apply to the terms and conditions of this EULA.  
+
+24. Notices.  Notice to Dell under this EULA must be in writing and sent to the address below or to such other address (including facsimile or e-mail) as specified in writing, and will be effective upon receipt.
+
+Dell Inc., Attn: Dell Legal
+One Dell Way, Round Rock, Texas 78682
+Last rev. 021812
+
+
+1 1.	VMware Player may be freely downloaded from VMware’s website
+2 JavaScript Object Notation http://www.json.org/
+---------------
+
+------------------------------------------------------------
+
+---------------
+
+------------------------------------------------------------
+
+OpenStack Deployment Guide 		July 2012
+
+Revision 1.30Do Not Distribute013
+
+
+
+_THIS GUIDE HAS NOT BEEN FORMATED!!_
+
+This guide is based on the **Dell OpenStack™ Powered Cloud Solution Deployment Guide** please update as needed.  OpenStack specific items should be moved to the OpenStack deployment guide.
+
+### Notes, Cautions, and Warnings
+
+> NOTE: A NOTE indicates important information that helps you make better use of your system.
+> CAUTION: A CAUTION indicates potential damage to hardware or loss of data if 
+instructions are not followed.
+> WARNING: A WARNING indicates a potential for property damage, personal 
+injury, or death.

--- a/doc/misc_docs/licenses.md
+++ b/doc/misc_docs/licenses.md
@@ -1,0 +1,15 @@
+# System Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+## License Abbreviations
+
+This documentation set uses the following abbreviations to identify subcomponent licenses
+
+* Apache 2 - http://www.apache.org/licenses/LICENSE-2.0    
+* MIT - URL here?
+* GPL - URL here?
+* GNU - URL here?
+* Proprietary - varies by provider
+
+

--- a/doc/misc_docs/testing.md
+++ b/doc/misc_docs/testing.md
@@ -1,0 +1,40 @@
+## Testing Crowbar
+
+The Dell Crowbar team believes in testing!  We want you to write tests for your code and include it in your pull requests.
+
+We have several mechanisms for testing and the following sections will help you understand them, use them and love them.
+
+### Automated tests [![Build Status](https://travis-ci.org/crowbar/travis-ci-crowbar.png?branch=master)](https://travis-ci.org/crowbar/travis-ci-crowbar)
+
+* Unit tests - these validate core logic assumptions in the models and controllers
+   * they are written in Ruby and are integrated with the Rails framework
+   * they are tightly coupled to the code of the system
+   * they are currently implemented in two forms:
+      * [tests under `crowbar_framework/test/unit/`, based on Test::Unit](testing/units.md)
+      * [tests under `crowbar_framework/spec/`, based on RSpec](testing/rspec.md)
+   * RSpec is the preferred framework for new tests, due to its popularity and high quality integration with the rest of the Rails ecosystem (e.g. [guard](https://github.com/guard/guard) and [spork](https://github.com/sporkrb/spork)).
+* [Behaviour-Driven Development (BDD) tests](testing/bdd.md)
+   * these are system integration tests that exercise the web UI without any integration to the code
+
+It is recommended to [run these automated tests via the `./dev` tool](testing/devtool.md).
+
+Some of these tests are [automatically run on a regular basis by Travis CI](testing/travis.md),
+and the badge above shows the latest result.
+
+### Code coverage reports [![Coverage Status](https://coveralls.io/repos/crowbar/travis-ci-crowbar/badge.png?branch=master)](https://coveralls.io/r/crowbar/travis-ci-crowbar)
+
+Code coverage reports are automatically generated when the tests are
+run, and can be accessed via the Rails app's webserver at e.g.
+http://192.168.124.10:3000/coverage/ - see [here](testing/web-ui.md)
+for how to start the web server.
+
+They are also [tracked online via Coveralls](https://coveralls.io/r/crowbar/travis-ci-crowbar)
+which is seriously cool - check it out!
+
+### Automated code analysis
+
+See the [analysis](analysis.md) page.
+
+### Manual tests
+
+* [Testing the web UI](testing/web-ui.md)

--- a/doc/misc_docs/testing/bdd.md
+++ b/doc/misc_docs/testing/bdd.md
@@ -1,0 +1,33 @@
+### BDD integration tests
+
+The BDD (Behaviour-Driven Development) tests reside under the `BDD/` directory, and should focus on UI/API controller and view testing.  They complement the [unit tests](../testing.md) which focus on model and non-visible controller tests.
+
+The BDD tests are written in a "Cucumber-like" domain specific language (DSL), and the testing framework is written in Erlang.
+
+#### Running the tests via the dev tool
+
+[Running the tests via the dev tool](devtool.md) is the recommended approach.
+
+#### Running the tests outside the dev tool
+
+*NOTE:* Unfortunately the BDD tests (written in Erlang) currently do not work
+on openSUSE yet.
+
+   ````
+   cd /tmp/crowbar-dev-test/opt/dell/crowbar_framework/BDD
+   ./linux_compile.sh
+   ./linux_run.sh
+   ````
+
+Note that the BDD tests require a running instance of Crowbar, which is
+started by `linux_run.sh`.  If it fails with an error message like:
+
+   ````
+   ERROR: step run found error:{badmatch,{error,econnrefused}}
+   ...
+   ````
+
+this means that the Crowbar server is not running and can usually be fixed
+by running `linux_run.sh` again.
+
+Once the server is running on `localhost`, you can run the BDD tests interactively from erlang (`erl`) in from the code area (not just the test area) using commands like `bdd:test(crowbar).` and `bdd:debug(crowbar, myfeature, mytestid, debug).`  

--- a/doc/misc_docs/testing/chefspec.md
+++ b/doc/misc_docs/testing/chefspec.md
@@ -1,0 +1,14 @@
+### Chef Recipe Unit Tests
+
+Crowbar also includes chefspec for unit testing chef recipes.  This is still a work in progress in the Chef community but has some potential for at least making sure things are doing basic tests.
+
+The current tests reside under spec in each cookbook.
+
+Steps to execute tests on an installed admin node:
+
+1. `cd /opt/dell/chef/cookbooks`
+1. `rm README`
+1. `rspec *`
+
+Each cookbook can provide their own spec tests.
+

--- a/doc/misc_docs/testing/devtool.md
+++ b/doc/misc_docs/testing/devtool.md
@@ -1,0 +1,53 @@
+### Dev Tool Helpers 
+
+The dev tool allows you to set up a test environment and run tests
+from it.
+
+Firstly ensure you have [set up a development VM](../dev-vm.md) which has
+the correct dependencies installed.
+
+The following commands work for UNIX environments.  When you first run
+`./dev tests run`, use the `--update-gem-cache` option to make sure you
+have the gems.
+
+#### Setting up the test environment
+
+`./dev tests setup` builds a test environment in `/tmp/crowbar-dev-test`.
+On openSUSE, you should use the `--no-gem-cache` option.
+
+Setup includes the following tasks:
+
+* copying the sources into the right locations under
+  `/tmp/crowbar-dev-test/opt/dell`
+* running bundler to install required gems
+* creating a `coverage` symlink under the Rails app's `public/`
+  directory so that the web server will serve up the HTML coverage
+  reports
+* compiling the BDD tests
+
+#### Running the tests
+
+    ./dev tests run       # executes the Rails specs, Chef specs, unit tests, and BDD tests
+
+You can also run them with finer granularity:
+
+    ./dev tests run-unit  # executes the Rails specs, Chef specs, and unit tests
+    ./dev tests run-BDD   # executes the BDD tests
+
+After changing code, you can re-run the above command after first
+rebuilding fixtures and performing any required data base migrations via:
+
+    ./dev tests reload    # builds fixtures and migrates data for /tmp/crowbar-dev-test
+
+For debugging, the `/tmp/crowbar-dev-test/opt/dell/crowbar_framework`
+environment can be used as a Rails app for [manual UI testing](web-ui.md).
+
+Note: only the `/tmp/crowbar-dev-test` area will have all the tests available because of the barclamp rollup.
+
+#### Cleaning up
+
+    ./dev tests clear     # Removes the /tmp/crowbar-dev-test environment
+
+#### More information
+
+See the [Testing page](../testing.md) for more information on each set of tests.

--- a/doc/misc_docs/testing/rspec.md
+++ b/doc/misc_docs/testing/rspec.md
@@ -1,0 +1,25 @@
+### Rails RSpec Testing
+
+Crowbar includes unit tests based on RSpec for more complex unit testing needs.  The [default unit tests](units.md) will be [phased out over time](../testing.md).
+
+The RSpec tests reside under the `spec/` directory.  They should focus on model and non-visible controller tests.  In contrast, [BDD tests](bdd.md) should focus on UI/API controller and view testing.
+
+#### Running the tests via the dev tool
+
+[Running the tests via the dev tool](devtool.md) is the recommended approach.
+
+#### Running the tests outside the dev tool
+
+On an installed admin node, first `cd` to `/opt/dell/crowbar_framework`.
+In a [development environment](../dev-vm.md), instead `cd` to `/tmp/crowbar-dev-test/opt/dell/crowbar_framework`.
+
+Then run the following commands:
+
+1. `rake db:drop`
+1. `rake railties:install:migrations`
+1. `rake db:migrate`
+1. `rake spec`
+
+#### Adding new specs
+
+Each barclamp can add tests by dumping them into the `spec/` directory.  The spec tests will pick them up and attempt to run them.

--- a/doc/misc_docs/testing/travis.md
+++ b/doc/misc_docs/testing/travis.md
@@ -1,0 +1,133 @@
+# Crowbar and Travis CI [![Build Status](https://travis-ci.org/crowbar/travis-ci-crowbar.png?branch=master)](https://travis-ci.org/crowbar/travis-ci-crowbar) [![Coverage Status](https://coveralls.io/repos/crowbar/travis-ci-crowbar/badge.png?branch=master)](https://coveralls.io/r/crowbar/travis-ci-crowbar) [![Code Climate](https://codeclimate.com/github/crowbar/travis-ci-crowbar.png)](https://codeclimate.com/github/crowbar/travis-ci-crowbar)
+
+Crowbar uses Travis CI (among other things) to perform continuous integration.
+The badges above represent (left to right):
+
+  * Travis CI - Are the unit and RSpec tests passing?
+  * Coverage status - What % of the code is covered by our tests above?
+  * Code Climate - How's the code in terms of complexity and static analysis
+    scoring?
+
+Clicking on the each badge will bring you to the respective detailed reports,
+which all developers should look at perodically to see where and how we can
+improve our code quality. These badges (and others) are also on the [main
+project page](../../../#readme).
+
+Test failure notifications are sent to the Crowbar mailing and IRC (#crowbar on
+irc.freenode.net).
+
+## Limitations
+
+The current setup works pretty nicely, but there are some limitations due to the
+Crowbar architecture:
+
+  * Tests run on batches of squashed commits instead of on every commit. This
+    makes it harder to find offending commits.
+  * Can't easily test each pull request before they are merged in.
+
+The goal is to ultimately use barclamps like regular gems, then Crowbar can
+adopt a standard Rails setup that doesn't have these limitations.
+
+## Setup details
+
+It's usually easy to setup Travis CI, but Crowbar needs to be assembled from
+several Git repositories. So we use the [update-git.sh]
+(../../../travis-ci/update-git.sh) script to do this and push changes to the
+[Travis CI repo](https://github.com/crowbar/travis-ci-crowbar). Each run of the
+script looks like this:
+
+```
+2013-01-13 01:30:01 +0100: Running ./dev fetch...
+2013-01-13 01:31:29 +0100: Running ./dev sync...
+2013-01-13 01:31:49 +0100: Running ./dev tests setup --no-gem-cache
+2013-01-13 01:32:08 +0100: Copying files...
+2013-01-13 01:32:08 +0100: Checking changed files...
+2013-01-13 01:32:09 +0100: Committing files...
+2013-01-13 01:32:09 +0100: Nothing to commit
+```
+
+This is script is run every 15 minutes by our public [Jenkins server]
+(https://ci.opensuse.org/job/crowbar-travis_ci-trackupstream/).
+
+### Debugging test failures
+
+You should be able to reproduce all test failures in your local dev environment,
+as Travis CI simply launches a fresh Ubuntu VM, sets up the environment and runs
+the tests. For example, you can see the [exact commands and output]
+(https://travis-ci.org/crowbar/travis-ci-crowbar/jobs/5616682#L1) for each run.
+Refer to the [Travis configuration]
+(https://github.com/crowbar/travis-ci-crowbar/blob/master/.travis.yml) for
+details.
+
+However it's possible that failures may be due to the subtle differences between
+the two environments. To more closely mimic the Travis CI environment, you can
+do the following:
+
+```bash
+git clone git://github.com/crowbar/travis-ci-crowbar.git
+cd travis-ci-crowbar/crowbar_framework
+
+# If you have rvm installed, you can optionally create a dedicated
+# rvm gemset here:
+rvm gemset create crowbar-travis-ci
+rvm use @crowbar-travis-ci
+
+# If not, you can add a --path=... parameter to the below to ensure
+# that the gems get installed to a clean dedicated environment:
+bundle install --without development
+
+# Now run the tests
+bundle exec rake db:drop railties:install:migrations db:migrate db:fixtures:dump test:units spec
+```
+
+### Setting up the openSUSE Jenkins node
+
+Here's how the openSUSE Jenkins node was setup:
+
+1. Setup the system as described in the [openSUSE dev guide]
+   (../dev-vm-SUSE.md).
+
+1. Create a new `crowbar` user account and switch to it.
+   ```
+   useradd -m crowbar
+   su - crowbar
+   ```
+
+1. Now ensure you have ssh keys set up for whichever github account you want to
+   commit from, then configure git with the corresponding identity (--global is
+   required to cover the multiple repositories we are about to clone),
+   e.g.:
+   ```
+   git config --global user.name "Crowbar Travis Bot"
+   git config --global user.email "crowbar.gravatar+travis@gmail.com"
+   ```
+
+1. Check out and configure the various Crowbar repositories:
+   ```
+   git clone git://github.com/crowbar/crowbar.git
+   cd crowbar
+   # GIT_ASKPASS works around a bug in ./dev where it tries to do stuff
+   # with Dell-proprietary barclamps.
+   GIT_ASKPASS=true ./dev setup --no-github
+   ```
+
+1. Check out the `travis-ci-crowbar` repository which the Jenkins job will keep
+   updated:
+   ```
+   cd
+   git clone git://github.com/crowbar/travis-ci-crowbar.git
+   cd travis-ci-crowbar
+   ```
+
+1. Set up a remote from which we can issue pull requests:
+   ```
+   git remote add personal git@github.com:crowbar-travis/travis-ci-crowbar.git
+   ```
+
+1. Perform a dummy push to ensure that the server's ssh key fingerprint
+   is in `.ssh/known_hosts`:
+   ```
+   git push -n personal HEAD
+   ```
+
+Now you're done!

--- a/doc/misc_docs/testing/units.md
+++ b/doc/misc_docs/testing/units.md
@@ -1,0 +1,31 @@
+### Rails Unit Testing
+
+Crowbar includes unit tests based on the `Test::Unit` framework.
+
+The current tests reside under `test/unit/`, and are only focused on model testing.  They use the already present Rails test framework and fixtures under `test/fixtures/`.
+
+#### Running the tests via the dev tool
+
+[Running the tests via the dev tool](devtool.md) is the recommended approach.
+
+#### Running the tests outside the dev tool
+
+On an installed admin node, first `cd` to `/opt/dell/crowbar_framework`.
+In a [development environment](../dev-vm.md), instead `cd` to `/tmp/crowbar-dev-test/opt/dell/crowbar_framework`.
+
+Then run the following commands:
+
+1. `rake db:drop`
+1. `rake railties:install:migrations`
+1. `rake db:migrate`
+1. `rake db:fixtures:dump`
+1. `rake test:units`
+
+If you want to run just 1 test file, use `rake test:units TEST=test/unit/i18n_test.rb` or similar.
+
+#### Adding new unit tests
+
+It is strongly recommended to write new unit tests using
+[RSpec](rspec.md) instead, for reasons listed in the [testing page](../testing.md).
+However, each barclamp can add tests by dumping them into the `test/`
+directory.  The unit tests will pick them up and attempt to run them.

--- a/doc/misc_docs/testing/web-ui.md
+++ b/doc/misc_docs/testing/web-ui.md
@@ -1,0 +1,23 @@
+### Manually testing the web UI
+
+Firstly [set up your development environment](devtool.md).
+
+#### Starting the Crowbar web interface
+
+   ````
+   cd /tmp/crowbar-dev-test/opt/dell/crowbar_framework
+   bundle exec rails s puma
+   ````
+
+You will want to keep this terminal open to see the Rails logs, which will
+come in very handy during development and debugging. The server can be
+terminated with `Ctrl-C`.
+
+The Crowbar web interface should now be accessible from your host web
+browser, e.g. at: http://192.168.124.10:3000
+
+#### Dashboard No Polling
+
+When you are troubleshooting the UI or REST APIs, the Node Dashboard (`dashboard`) polling can be a pain because it generates log traffic.  You can disable polling for debug by using the `nopoll` parameter.
+
+For example: http://192.168.124.10:3000/dashboard/89?nopoll

--- a/doc/misc_docs/ui.md
+++ b/doc/misc_docs/ui.md
@@ -1,0 +1,14 @@
+### User Interface (UI) Development
+
+The Crowbar UI is a Ruby on Rails (RoR) application.  Unlike traditional RoR applications, each barclamp contributes components into the overall application.  This allows barclamps to extend the UI in tightly integrated ways; unfortanately, it can also be confusing.
+
+The Crowbar UI framework provides some services including
+
+1. documentation
+1. menu
+1. localization
+1. default routes
+
+It is important to understand how barclamps leverage the UI.  
+
+There is a separate document on [how to test the web UI](testing/web-ui.md).

--- a/doc/misc_docs/use-cases.md
+++ b/doc/misc_docs/use-cases.md
@@ -1,0 +1,133 @@
+# Crowbar Use Cases
+
+## Personas
+
+| Name | Title | Notes |
+|------|-------|-------|
+| Oscar | Operations Chief | Knows of Chef or Puppet. Likely has some experience. Comfortable and likes Linux. Can work with network configuration, but does not own network. Has used VMware. |
+| Charlie | CIO | Concerned about time to market and ROI. Is working on commercial offering based on OpenStack. |
+| Denise | Cloud Developer | Working on adding features to OpenStack. Working on services to pair with OpenStack. Comfortable with Ruby code. |
+| Quick | Data Center Worker | Can operate systems. Can Power On/Off when supervised by Susan. In charge of rack and replacement of gear. Can Intiate Automation when directed and supervised, but not create automation. |
+| Sally | Support Center Worker | Person who takes calls about the installation. |
+| Susan | System Administrator | Responsible for the OS installation, tuning, config, the works. Knows of Chef/Puppet but decided they were not there yet, so wrote her own. Responsible for the Application Installation, but not the tuning or more than the base config. Responsible for Network connectivity to some point, but works with Networking Ops to ensure right. |
+| Albert | Security Analyst/Operations | Goal to prevent any Interaction with any Machine/OS/Application, unless the proper information/justification is supplied.|
+
+## Use cases
+
+### 1. Get equipment setup to base
+
+Event: The equipment has just arrived.
+
+* Quick checks the manifest to make sure that the equipment arrived.
+* Quick racks the servers and switch following the wiring chart provided by Oscar
+* Quick follows the installation guides BIOS and Raid configuration parameters for the Admin Node
+* Quick powers up the servers to make sure all the lights blink then turns them back off
+* Oscar arrives with his laptop and the crowbar ISO
+* As per instructions, Oscar wires his laptop to the admin server and uses VMplayer to bootstrap the ISO image
+* Oscar powers system and selects network boot (system may automatically do this out of the "box", but can reset if need be).
+* Once the bootstrap and installation of the Ubuntu-based image is completed, Oscar disconnects his laptop from the Admin server and connects into the switch
+* Oscar logs into the Admin node and configures base admin parameters:
+  * Hostname
+  * Networks (admin and public required): admin IPs, routers, masks, subnets, usable ranges (mostly for public).
+  * Optional: ntp server(s)
+  * Optional: forwarding nameserver(s)
+  * Passwords and accounts
+  * Manually edits files that get downloaded.
+* Run the Install Command
+* System validates configuration for syntax and obvious semantic issues.
+* Oscar clears switch config and sets the configuration per guide.
+* Oscar configures his laptop for DHCP to join the admin network.
+* Oscar looks at the Chef UI and verifies that it is running and he can see the Admin node in the list.
+  * The Install guide will describe this first step and initial passwords.
+  * The install guide will have a page describing a valid visualization of the environment.
+* Oscar powers on the next node in the system and monitors its progress in Chef.
+  * The install guide will have a page describing this process.
+  * The Crowbar status page will have the node arrive and can be monitored from there. Completion occurs when the node is "checked in". Intermediate states can be viewed by checking the nodes state attribute.
+  * Node transitions through defined flow process for discovery, bios update, bios setting, and installation of base image.
+  * crowbar_watch_status - for terminal status updates.
+* Once Oscar sees the node report into Crowbar, Oscar shows Quick how to check the system status and tells him to turn on the rest of the nodes and monitor them.
+* Quick monitors the nodes while they install. He calls Oscar when they are all in the “ready” state. Then he calls Oscar back.
+* Quick Verify BMC/IPMI/SSH availability
+* Oscar checks their health in Nagios and Ganglia (Report for Machine information).
+  * If there are any red warnings, Oscar works to fix them.
+
+### 2. Install OpenStack Swift
+
+Event: System checked out healthy from base configuration
+
+* Oscar logs into the Crowbar portal
+* Oscar selects swift role from role list
+* Oscar is presented with a current view of the swift deployment (Which starts empty).
+* Oscar asks for a proposal of swift layout
+  * The UI returns a list of storage, auth, proxy, and options.
+* Oscar may take the following actions:
+  * He may tweak attributes to better set deployment (Networking options...)
+  * He may force a node out or into a sub-role
+  * He may re-generate proposal
+  * He should verify the propsal
+  * He will edit/import the new proposal
+  * He may commit proposal
+* Oscar may validate progress by watching:
+  * Crowbar main screen to see that configuration has been updated.
+  * Nagios to validate that services have started
+  * Chef UI to see raw data..
+* Oscar checks the swift status page to validate that the swift validation tests have completed successfully.
+* If Nagios Swift Status reports failure, Oscar uses troubleshooting guide to correct problems or calls support.
+  * Swift is installed correctly
+  * Nagios reports it is installed
+  * Swift Installed Validation
+* Oscar re-verify the state that Nagios is reporting, to see if corrective action worked.
+* Oscar is directed to Swift On-line documentation for using a swift cloud from the install guide
+
+### 3. Install OpenStack Nova
+
+Event: System checked out healthy from base configuration
+
+* Oscar logs into the Crowbar portal
+* Oscar selects nova role from role list
+* Oscar is presented with a current view of the nova deployment (Which starts empty)
+* Oscar asks for a proposal of nova layout
+  * The UI returns a list of options, and current sub-role usage (6 or 7 roles).
+  * If Oscar has already configured swift, the system will automatically configure glance to use swift.
+* Oscar may take the following actions:
+  * He may tweak attributes to better set deployment (Use admin node in nova, Networking options...)
+  * He may force a node out or into a sub-role
+  * He may re-generate proposal
+  * He may commit proposal
+* Oscar finishes configuration proposal and commits proposal.
+* Oscar may validate progress by watching:
+  * Crowbar main screen to see that configuration has been updated.
+  * Nagios to validate that services have started
+  * Chef UI to see raw data
+* Oscar checks the nova status page to validate that the nova validation tests have completed successfully.
+* If nova validation tests fail, Oscar uses troubleshooting guide to correct problems or calls support.
+  * Oscar uses re-run validation test button to see if corrective action worked.
+* Oscar is directed to Nova On-line documentation for using a nova cloud from the install guide.
+
+### 4. Pilot and Beyond Use Cases
+
+#### 4a. Unattended refresh of system
+
+This is a special case, for Denise.
+
+* Denise is making daily changes to OpenStack’s code base and needed to test it. She has committed changes to their git code repository and started the automated build process
+* The system automatically receives that latest code and copies it to the admin server
+* A job on admin server sees there is new code resets all the work nodes to “uninstalled” and reboots them.
+* Crowbar reimages and reinstalls the images based on its cookbooks
+* Crowbar executes the test suites against OpenStack when the install completes
+* Denise reviews the test suite report in the morning.
+
+#### 4b. Integrate into existing management
+
+Event: System has passed lab inspection, is about to be connected into the corporate network (or hosting data center)
+
+* Charlie calls Oscar to find out when PoC will start moving into production
+* Oscar realizes that he must change from Nagios to BMC on all the nodes or they will be black listed on the network.
+* Oscar realizes that he needs to update the SSH certificates on the nodes so they can be access via remote. He also has to change the accounts that have root access.
+* Option 1: Reinstall.
+  * Oscar updates the Chef recipes to remove Nagios and add BMC, copy the cert and configure the accounts.
+  * Oscar sets all the nodes to “uninstalled” and reimages the system.
+  * Repeat above step until system is configured correctly
+* Option 2: Update Recipes
+  * Oscar updates the Chef recipes to remove Nagios and add BMC, copy the cert and configure the accounts.
+  * Oscar runs the Chef scripts and inspects one of the nodes to see if the changes were made


### PR DESCRIPTION
```
This commit moves all documentation from the crowbar repository
to the barclamp-crowbar repository. Since there are multiple repos
involed, it appears as a delete from crowbar, and new files in
barclamp-crowbar.
```

 doc/devguide/development/BUILD.md                  |  303 ++++++++
 doc/devguide/development/README.barclamp-packaging |  114 +++
 doc/devguide/development/README.build_cache        |   18 +
 .../development/README.dev-and-code-review         |  345 +++++++++
 doc/devguide/development/README.dev-and-workflow   |  325 +++++++++
 .../development/README.heterogenous-os-support     |   34 +
 doc/devguide/development/README.knife-config.md    |   36 +
 doc/devguide/development/README.online-install     |   46 ++
 doc/devguide/development/README.package-updates    |   36 +
 doc/devguide/development/README.sledgehammer       |   35 +
 doc/devguide/development/README.sledgehammer-hooks |   81 +++
 doc/devguide/development/README.smoketest          |   97 +++
 doc/devguide/development/README.uefi               |   81 +++
 doc/devguide/development/dev-vm-Fedora.md          |  105 +++
 doc/devguide/development/dev-vm-SUSE.md            |  166 +++++
 doc/devguide/development/dev-vm-Ubuntu.md          |  120 +++
 doc/devguide/development/dev-vm.md                 |   49 ++
 doc/devguide/development/openSUSE-images.md        |   24 +
 doc/devguide/devtool.md                            |   25 +
 doc/misc_docs/CLA.md                               |   10 +
 doc/misc_docs/README.md                            |    5 +
 doc/misc_docs/analysis.md                          |    7 +
 doc/misc_docs/api/README.md                        |   94 +++
 doc/misc_docs/api/attrib.md                        |  134 ++++
 doc/misc_docs/api/attrib_types.md                  |  123 ++++
 doc/misc_docs/api/barclamp.md                      |  185 +++++
 doc/misc_docs/api/group.md                         |  111 +++
 doc/misc_docs/api/jig.md                           |  122 ++++
 doc/misc_docs/api/nodes.md                         |  144 ++++
 doc/misc_docs/api/role_types.md                    |  110 +++
 doc/misc_docs/api/roles.md                         |  141 ++++
 doc/misc_docs/api/snapshots.md                     |  129 ++++
 doc/misc_docs/barclamps.md                         |  122 ++++
 doc/misc_docs/barclamps/create-stub.md             |   71 ++
 doc/misc_docs/barclamps/makingbarclamps.md         |  119 +++
 doc/misc_docs/barclamps/metadata.md                |   26 +
 doc/misc_docs/barclamps_intro.md                   |   20 +
 doc/misc_docs/browser-support.md                   |  119 +++
 doc/misc_docs/building.md                          |    4 +
 doc/misc_docs/contributing.md                      |  124 ++++
 doc/misc_docs/deployguide.md                       |   21 +
 doc/misc_docs/deployguide/introduction.md          |  766 ++++++++++++++++++++
 doc/misc_docs/licenses.md                          |   15 +
 doc/misc_docs/testing.md                           |   40 +
 doc/misc_docs/testing/bdd.md                       |   33 +
 doc/misc_docs/testing/chefspec.md                  |   14 +
 doc/misc_docs/testing/devtool.md                   |   53 ++
 doc/misc_docs/testing/rspec.md                     |   25 +
 doc/misc_docs/testing/travis.md                    |  133 ++++
 doc/misc_docs/testing/units.md                     |   31 +
 doc/misc_docs/testing/web-ui.md                    |   23 +
 doc/misc_docs/ui.md                                |   14 +
 doc/misc_docs/use-cases.md                         |  133 ++++
 53 files changed, 5261 insertions(+)

Crowbar-Pull-ID: 4575dffa56634296bb7517ba913f55767684f393

Crowbar-Release: development
