### PR TITLE
Attribute updates for annealer hygene, round 2 [1/1]

### DIFF
--- a/BDD/features/attrib.feature
+++ b/BDD/features/attrib.feature
@@ -19,19 +19,18 @@ Feature: Attrib(utes)
   Scenario: REST Attrib List
     When REST gets the {object:attrib} list
     Then the list should have an object with key "name" value "random"
-    Then the list should have an object with key "map" value "random"
+    Then the list should have an object with key "map" value "test/random"
 
   Scenario: REST JSON check
     When REST gets the {object:attrib} "random"
     Then the {object:attrib} is properly formatted
 
-    
   Scenario: REST Can Delete
     Given REST creates the {object:attrib} "bdd_foo"
     When REST deletes the {object:attrib} "bdd_foo"
     Then I get a {integer:200} result
       And there is not a {object:attrib} "bdd_foo"
-  
+
   Scenario: REST Get 404
     When REST gets the {object:attrib} "thisdoesnotexist"
     Then I get a {integer:404} error

--- a/crowbar_framework/app/controllers/attribs_controller.rb
+++ b/crowbar_framework/app/controllers/attribs_controller.rb
@@ -48,9 +48,9 @@ class AttribsController < ApplicationController
   def update
     if params.key? :node_id and params.key? :value
       node = Node.find_key params[:node_id]
-      attrib = Attrib.find_key params[:id]
-      node.discovery = attrib.discovery(params[:value])
-      node.save!
+      attrib = Attrib.find_key(params[:id])
+      attrib.set(node,params[:value])
+      node.reload
       render api_show :node, Node, nil, nil, node
     else
       respond_to do |format|
@@ -66,5 +66,5 @@ class AttribsController < ApplicationController
       format.json { render api_delete Attrib }
     end
   end
-      
+
 end

--- a/crowbar_framework/app/models/attrib.rb
+++ b/crowbar_framework/app/models/attrib.rb
@@ -24,18 +24,6 @@ class Attrib < ActiveRecord::Base
 
   scope           :by_name,              ->(name) { where(:name=>name) }
 
-  # Get the requested value from the passed blob of data using map as a
-  # sleector into the deeply nested hash table that we assume data is.
-  def get(data)
-    begin
-      d = data
-      map.split('/').each{|s|d = d[s]}
-      return d
-    rescue
-      nil
-    end
-  end
-
   # Return a deeply nested hash table built from the map with this attribute's
   # data at the end.
   def template(value)
@@ -48,12 +36,57 @@ class Attrib < ActiveRecord::Base
     res
   end
 
+  # Get the attribute value from the passed object.
+  # For now, we are encoding information about the objects we can use directly in to
+  # the Attrib class, and failing hard if we were passed something that
+  # we do not know how to handle.
+  def get(from)
+    from = __resolve(from)
+    d = case
+        when from.is_a?(Node) then from.discovery
+        when from.is_a?(DeploymentRole) then from.wall.deep_merge(from.data)
+        when from.is_a?(NodeRole) then from.attrib_data
+        when from.is_a?(Role) then from.template
+        else raise("Cannot extract attribute data from #{from.class.to_s}")
+        end
+    begin
+      map.split('/').each{|s|d = d[s]}
+      return d
+    rescue
+      nil
+    end
+  end
+
+  # Gets the requested value from the passed data, but returns it wrapped in template()
+  # unless this attribute is not in the passed blob, in which case it returns nil.
+  def extract(from)
+    r = get(from)
+    return r unless r
+    template(r)
+  end
+
+  def wall_set(to,value)
+    __set(to,value,:wall)
+  end
+
+  def user_set(to,value)
+    __set(to,value,:user)
+  end
+
+  def system_set(to,value)
+    __set(to,value,:system)
+  end
+
+  def set(to,value)
+    Rails.logger.warn("Please do not use attrib.set")
+    __set(to,value,:system)
+  end
+
   private
 
   # This method ensures that we have a type defined for
   def create_type_from_name
     raise "attribs require a name" if self.name.nil?
-    raise "attribs require a role" if self.barclamp_id.nil?
     # remove the redundant part of the name (if any)
     name = self.name.gsub('-','_').camelize
     # Find the proper class to use to instantiate this attribute
@@ -74,6 +107,41 @@ class Attrib < ActiveRecord::Base
       end
     end
     raise "Cannot find the appropriate class for attribute #{self.name}"
+  end
+
+  # If we were asked to do something with an attribute on a node,
+  # but that attribute is part of a node role bound to that node,
+  # use the node role instead.
+  def __resolve(to)
+    return to unless to.is_a?(Node) && self.role_id
+    res = to.node_roles.where(:role_id => self.role_id).first
+    raise("#{self.name} belongs to role #{role.name}, but node #{node.name} does not have a binding for it!") unless res
+    res
+  end
+
+  # Set a new value for this attribute onto the passed object.
+  # The last parameter is what area the new attribute should be placed on
+  def __set(to,value,target=:system)
+    to = __resolve(to)
+    attr = case
+           when to.is_a?(Node) then "discovery"
+           when to.is_a?(Role) then "template"
+           when to.is_a?(DeploymentRole) then target == :system ? "wall" : "data"
+           when to.is_a?(NodeRole)
+             case target
+             when :system then 'systemdata'
+             when :user then 'userdata'
+             when :wall then 'wall'
+             else raise("#{target} is not a valid target to write data to!")
+             end
+           else raise("Cannot write attribute data to #{to.class.to_s}")
+           end
+    transaction do
+      data = JSON.parse(to.send(:read_attribute,attr))
+      data.deep_merge(template(value))
+      to.send(:write_attribute,attr,JSON.generate(data))
+      to.save!
+    end
   end
 
 end

--- a/crowbar_framework/app/models/deployment_role.rb
+++ b/crowbar_framework/app/models/deployment_role.rb
@@ -26,11 +26,13 @@ class DeploymentRole < ActiveRecord::Base
 
   belongs_to :role
   has_one    :barclamp, :through => :role
+  has_many   :attribs, :through => :role
 
   scope      :snapshot_and_role,     ->(ss,role)  { where(['snapshot_id=? AND role_id=?', ss.id, role.id]) }
 
 
   # convenience methods
+
   def name
     role.name
   end

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -60,6 +60,15 @@ class Node < ActiveRecord::Base
   scope    :alive,              -> { where(:alive => true) }
   scope    :available,          -> { where(:available => true) }
 
+  # Get all the attributes applicable to a node.
+  # This includes:
+  # * All attributes that are defined for our node roles, by virtue of
+  #   being defined as part of the role that the node role is bound to, and
+  # * All attributes that are not defined as part of a node.
+  def attribs
+    Attrib.where(["attribs.role_id IS NULL OR attribs.role_id in (select role_id from node_roles where node_id = ?)",self.id])
+  end
+
   # look at Node state by scanning all node roles.
   def state
     node_roles.each do |nr|
@@ -130,11 +139,7 @@ class Node < ActiveRecord::Base
   # retrieves the Attrib from Attrib
   def get_attrib(attrib)
     attrib = Attrib.find_key attrib unless attrib.is_a? ActiveRecord::Base
-    if attrib and self.discovery
-      attrib.get(self.discovery)
-    else
-      nil
-    end
+    attrib.get(self) rescue nil
   end
 
   def active_node_roles
@@ -159,7 +164,7 @@ class Node < ActiveRecord::Base
   def method_missing(m,*args,&block)
     method = m.to_s
     if method.starts_with? "attrib_"
-      return get_attrib method[7..100]
+      return get_attrib method[7..-1]
     else
       super
     end

--- a/crowbar_framework/app/models/node_role.rb
+++ b/crowbar_framework/app/models/node_role.rb
@@ -25,6 +25,7 @@ class NodeRole < ActiveRecord::Base
   belongs_to      :snapshot
   has_one         :deployment,        :through => :snapshot
   has_one         :barclamp,          :through => :role
+  has_many        :attribs,           :through => :role
   has_many        :runs,              :dependent => :destroy
 
   # find other node-roles in this snapshot using their role or node
@@ -311,6 +312,10 @@ class NodeRole < ActiveRecord::Base
     res.deep_merge!(sysdata)
     res.deep_merge!(data)
     res
+  end
+
+  def attrib_data
+    deployemnt_data.deep_merge(all_my_data)
   end
 
   def all_deployment_data

--- a/crowbar_framework/app/models/role.rb
+++ b/crowbar_framework/app/models/role.rb
@@ -56,7 +56,7 @@ class Role < ActiveRecord::Base
   scope           :server,             -> { where(:server => true) }
   scope           :active,             -> { joins(:jig).where(["jigs.active = ?", true]) }
 
-  # update just one value in the template 
+  # update just one value in the template
   # for >1 level deep, add method matching key to role!
   # use via /api/v2/roles/[role]/template/[key]/[value]
   def update_template(key, value)

--- a/crowbar_framework/app/views/nodes/show.html.haml
+++ b/crowbar_framework/app/views/nodes/show.html.haml
@@ -33,11 +33,11 @@
       %th= t '.value'
       %th= t '.description'
   %tbody
-    - Attrib.all.each do |a|
-      %tr    
+    - @node.attribs.each do |a|
+      %tr
         %td= link_to a.name, attrib_path(a.id)
         %td
-          - v = a.get(@node.discovery) rescue nil
+          - v = a.get(@node) rescue nil
           - unless v.nil?
             = v
           - else


### PR DESCRIPTION
- Make Attrib.get smart.
  Instead of passing a blob of JSON, it now accepts the object it should
  try to work with.  This centralizes the logic around what fields in an
  object are valid places to get attributes from, and will fail hard if
  you pass it something that should not work with the attribute system.
- Add matching Attrib.set methods.
  This provides an abstract interface for setting attributes on objects
  that matches the use of Attrib.get.
- Numerous trivial cleanups to make things work with the above changes.
  
  BDD/features/attrib.feature                        |   5 +-
  .../app/controllers/attribs_controller.rb          |   8 +-
  crowbar_framework/app/models/attrib.rb             |  94 +++++++++++--
  crowbar_framework/app/models/deployment_role.rb    | 150 +++++++++++----------
  crowbar_framework/app/models/node.rb               |  17 ++-
  crowbar_framework/app/models/node_role.rb          |   5 +
  crowbar_framework/app/models/role.rb               |   2 +-
  crowbar_framework/app/views/nodes/show.html.haml   |   6 +-
  8 files changed, 183 insertions(+), 104 deletions(-)

Crowbar-Pull-ID: bb6e98e76bf69457189462b48d3327adafdbdcb0

Crowbar-Release: development
