### PR TITLE
extending 'wait for chef' for other states

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -940,14 +940,14 @@ class NodeObject < ChefObject
       save
     end
 
-    # wait with reboot for the finish of configuration update by local chef-client
-    # (so dhcp & PXE config is prepared when node is rebooted)
-    while state == "reinstall" && File.exist?("/var/run/crowbar/chef-client.lock")
-      Rails.logger.debug("chef client still running")
-      sleep(1)
-    end
+    if %w(reset reinstall update).include? state
+      # wait with reboot for the finish of configuration update by local chef-client
+      # (so dhcp & PXE config is prepared when node is rebooted)
+      while File.exist?("/var/run/crowbar/chef-client.lock")
+        Rails.logger.debug("chef client still running")
+        sleep(1)
+      end
 
-    if state == "reset" or state == "reinstall" or state == "update"
       if CHEF_ONLINE
         bmc_cmd("power cycle")
       else


### PR DESCRIPTION
Before the node is rebooted for reinstallation or after de-allocation, we need to wait for local chef-client to write pxe/dhcp config, so rebooted nodes can correctly pxe-boot.

https://bugzilla.novell.com/show_bug.cgi?id=844681
