### PR TITLE
Revert some validation error string to previous state

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -739,7 +739,8 @@ class ServiceObject
     end
     Rails.logger.info "validating proposal #{@bc_name}"
 
-    @validation_errors = validator.validate(proposal)
+    errors = validator.validate(proposal)
+    @validation_errors = errors.map {|e| e.message}
     handle_validation_errors
   end
 
@@ -1302,7 +1303,7 @@ class ServiceObject
   def handle_validation_errors
     if @validation_errors && @validation_errors.length > 0
       Rails.logger.info "validation errors in proposal #{@bc_name}"
-      raise Chef::Exceptions::ValidationFailed.new(@validation_errors.join("\n"))
+      raise Chef::Exceptions::ValidationFailed.new("#{@validation_errors.join("\n")}\n")
     end
   end
 end


### PR DESCRIPTION
Commit a33f99a changed one string that is actually used by
barclamp-test:
https://github.com/crowbar/barclamp-test/blob/673b2ed830bea7d6b565495859e7625466a87a22/bin/barclamp_test.rb#L110

The string was:
  `[/attributes/foobar] key 'foobar:' is undefined.`
instead of:
  `key 'foobar:' is undefined.`

We also need to add the trailing \n (which could arguably matter in the
UI).
