### PR TITLE
wait with reboot for the finish of configuration update by local chef-client

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -16,6 +16,7 @@
 #
 
 require 'chef/mixin/deep_merge'
+require 'timeout'
 
 class NodeObject < ChefObject
   extend CrowbarOffline
@@ -951,7 +952,7 @@ class NodeObject < ChefObject
           end
         end
       rescue Timeout::Error
-        Rails.logger.warn("chef client seems to be running after 5 minutes, going to reboot anyway")
+        Rails.logger.warn("chef client seems to be still running after 5 minutes of wait; going on with the reboot")
       end
 
       if CHEF_ONLINE


### PR DESCRIPTION
Before the node is rebooted for reinstallation or after de-allocation, we need to wait for local chef-client to write pxe/dhcp config, so rebooted nodes can correctly pxe-boot.

https://bugzilla.novell.com/show_bug.cgi?id=844681

(backport of https://github.com/crowbar/barclamp-crowbar/pull/795)
