### PR TITLE
timeout must be integer

### DIFF
--- a/bin/barclamp_lib.rb
+++ b/bin/barclamp_lib.rb
@@ -456,7 +456,7 @@ def opt_parse()
       when '--data'
         @data = arg
       when '--timeout'
-        @timeout = arg
+        @timeout = arg.to_i
       when '--file'
         @data = File.read(arg)
       else


### PR DESCRIPTION
Timeout used during authentication must be integer.

SUSE reference: https://bugzilla.novell.com/show_bug.cgi?id=854430

(backport of https://github.com/crowbar/barclamp-crowbar/pull/798)
