### PR TITLE
Use ActiveRecordStore as session store

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -102,7 +102,7 @@ debs:
     - patch
     # crowbar stuff
     - curl
-    - sqlite
+    - sqlite3
     - libsqlite3-dev
     - libshadow-ruby1.8
     - chef
@@ -240,6 +240,7 @@ gems:
     - haml-(~>3.1)
     - net-http-digest_auth
     - rails-2.3.18
+    - activerecord-2.3.11
     - activesupport-2.3.18
     - bundler
     - builder
@@ -247,7 +248,7 @@ gems:
     - eventmachine
     - rainbows
     - sendfile
-    - sqlite3-ruby
+    - sqlite3
     - app_config-1.0.2
     # rdoc
     - net-ssh-multi

--- a/crowbar_framework/config/environment.rb
+++ b/crowbar_framework/config/environment.rb
@@ -31,7 +31,6 @@ Rails::Initializer.run do |config|
     config.gem "sprockets-helpers"
   end
 
-  config.frameworks -= [ :active_record ]
   config.time_zone = "UTC"
 
   CROWBAR_LOG_DIR = "/var/log/crowbar" unless defined? CROWBAR_LOG_DIR

--- a/crowbar_framework/config/initializers/session.rb
+++ b/crowbar_framework/config/initializers/session.rb
@@ -21,3 +21,4 @@ ActionController::Base.session = {
   :key => "_crowbar_framework_session",
   :secret => "ae66894fcee606d20eab9637a28684a8e9a12d36a91d075035e5703ed49bb26a0f9163fd0954185dea2b701cf79cefad152fb6da0075af43066b790707f52424"
 }
+ActionController::Base.session_store = :active_record_store


### PR DESCRIPTION
When saving a proposal fails due to JSON validation errors (missing
mappings / options / typos), Crowbar presents a flash message with the
JSON parsing error. However, messages like "743: unexpected token at
'{234 "use_virtualenv": false,..." may easily cross the 4k border that
the default session store (CookieStore) can handle. In these cases,
Crowbar just bails out with a 500.

The only solution is to set a different session_store. MemCacheStore
would probably work too but needs more refactoring due to more funny
session object fiddling inside ApplicationController.rb. Therefore it's
probably best to use good old ActiveRecordStore. However, this
re-introduces the dependency on ActiveRecord and it needs a database.
The default sqlite3 should be sufficient since we don't expect many
users to use crowbar at the same time.

Require sqlite3 gem (sqlite3-ruby was renamed)
