### PR TITLE
Fix a typo in nodes helper

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -205,7 +205,7 @@ module NodesHelper
     entries = [].tap do |result|
       ips.each do |network, addresses|
         unless network == "~notconnected" and addresses.nil?
-          network_list = if %w([not managed] [dhcp]).include? network
+          network_list = if ["[not managed]", "[dhcp]"].include? network
             address_list = addresses.to_a.map do |address|
               content_tag(
                 :li,


### PR DESCRIPTION
%w([not managed]) would not include "[not managed]" as %w() splits on
whitespace.
