### PR TITLE
Fix typo in variable reference

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -155,7 +155,7 @@ class NodesController < ApplicationController
         end
 
         flash.now[:alert] = I18n.t(
-          report[:duplicate] ? "nodes.list.duplicates" : "nodes.list.failed",
+          @report[:duplicate] ? "nodes.list.duplicates" : "nodes.list.failed",
           :failed => node_list.to_sentence
         )
       elsif @report[:success].length > 0


### PR DESCRIPTION
report variable was referenced out of its scope.
