### PR TITLE
Fix the reload of the page if the export is finally processed

### DIFF
--- a/crowbar_framework/app/controllers/support_controller.rb
+++ b/crowbar_framework/app/controllers/support_controller.rb
@@ -36,7 +36,7 @@ class SupportController < ApplicationController
     @export = Utils::ExtendedHash.new({
       :waiting => params[:waiting] == "true" || params[:format] == "json",
       :counter => 0,
-      :current => params["file"],
+      :current => params["file"].to_s.gsub("-DOT-", "."),
       :files => {
         :logs => [],
         :cli => [],


### PR DESCRIPTION
As requested on **bnc#856771** the page reloads now again if the exported file is finally processed.
