### PR TITLE
Updated instructions to force bundler to 1.3.5 [1/1]

### DIFF
--- a/doc/devguide/development/dev-vm-Ubuntu.md
+++ b/doc/devguide/development/dev-vm-Ubuntu.md
@@ -148,10 +148,10 @@ community on LTS releases.
     export PGCLUSTER=9.3/main
     psql postgresql://crowbar@:5439/template1 -c 'select true;'
 
-
     # let's install some needed gems next
     sudo gem install builder bluecloth
-    sudo gem install json net-http-digest_auth kwalify bundler delayed_job delayed_job_active_record rake simplecov rspec pg --no-ri --no-rdoc
+    sudo gem install bundler --version '1.3.5' --no-ri --no-rdoc
+    sudo gem install json net-http-digest_auth kwalify delayed_job delayed_job_active_record rake simplecov rspec pg --no-ri --no-rdoc
 
 ## Building Crowbar 
 


### PR DESCRIPTION
Updated the instructions for setting up an Ubuntu build VM to force
bundler to 1.3.5 since the prior instructions would install 1.5.1, which
does not work.

 doc/devguide/development/dev-vm-Ubuntu.md |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 0e652a210a25077c00ed62602483118b18c0040d

Crowbar-Release: development
