### PR TITLE
Consolidate ./dev tests info into 1 place [1/1]

### DIFF
--- a/doc/devguide/devtool-build.md
+++ b/doc/devguide/devtool-build.md
@@ -103,13 +103,7 @@ If you receive any messages stating "new file:   README.empty-branch" and the ./
     cd ..
     find / -name README.empty-branch -delete
 
-#### Running the test suites
-
-We've put a lot of effort into creating test suites:
-
-   ./dev tests setup --update-gem-cache
-
-##### Building the discovery image
+#### Building the discovery image
 During the cluster deployment Crowbar uses a special stripped down image (Sledgehammer) for node discovery. As part of our build process we also need to build Sledgehammer. This is a one time process and doesn't need to be repeated everytime. **Note:** This next step will take some time.
 
     cd ~/crowbar
@@ -165,13 +159,12 @@ The above results in the following viable combinations:
 * **Hadoop:** 
   hadoop-2.3/hadoop-os-build for the latest and most stable Hadoop build
 
-#### Building
-With the above knowledge we can now kick off our Hadoop or OpenStack build. 
-
 **Note:** The Dev Tool currently has a bug where it litters README.empty-branch files. Those will be problematic during `dev switch` operations. In order to **clean them up run the following commands** any time you run into this issue.
 
     # clean up any .empty-branch files first
     cd ~/crowbar/barclamps
     for bc in *; do (cd "$bc"; git clean -f -x -d 1>/dev/null 2>&1; git reset --hard 1>/dev/null 2>&1); done 
 
+#### Running the test suites
 
+We've put a lot of effort into creating test suites that can all be run directly on the development VM.  See the [Testing Using The Dev Tool](../misc_docs/testing/devtool.md) page for details.

--- a/doc/devguide/devtool.md
+++ b/doc/devguide/devtool.md
@@ -13,13 +13,4 @@ The DevTool has significant inline documentation.  It is strongly recommended to
 
 #### Running Tests
 
-Prerequs
-1. Ubuntu 12.04.01 as the OS for DevTool
-1. `sudo gem install i18n active_support builder rails`
-
-To run the tests with DevTool, you must first setup the tests using `./dev tests setup`.  DevTool will prompt you to install any missing components.
-
-
-After you have completed setup, use `./dev tests run` to run the tests.
-
-If you want to troubleshoot the tests, all the files are in `/tmp/crowbar-dev-test/opt/dell/crowbar_framework/`.  You can manually run the DevTool rails application by running `bundle exec rails s` from the dev test directory.
+To run the tests with DevTool, See the [Testing Using The Dev Tool](../misc_docs/testing/devtool.md) page.

--- a/doc/misc_docs/testing/devtool.md
+++ b/doc/misc_docs/testing/devtool.md
@@ -1,29 +1,30 @@
-### Dev Tool Helpers 
+### Testing Using The Dev Tool
 
 The dev tool allows you to set up a test environment and run tests
-from it.
+from it on the development VM.
 
 Firstly ensure you have [set up a development VM](../dev-vm.md) which has
 the correct dependencies installed.
 
-The following commands work for UNIX environments.  When you first run
-`./dev tests run`, use the `--update-gem-cache` option to make sure you
-have the gems.
+The following commands work for UNIX environments.
 
 #### Setting up the test environment
 
-`./dev tests setup` builds a test environment in `/tmp/crowbar-dev-test`.
-On openSUSE, you should use the `--no-gem-cache` option.
+Before running the tests, you must set up the test environment.
 
-Setup includes the following tasks:
+* If you are working internal to Dell and are using the gitolite build cache then run './dev tests setup'
+* If you are working external to Dell or are not using the gitolite build cache, then run './dev tests setup --update-gem-cache' to make sure you have the necessary gems
+* If you are working on openSUSE, you should run './dev tests setup --no-gem-cache`
 
-* copying the sources into the right locations under
+Setup performs the following tasks:
+
+* Copies the sources into the right locations under
   `/tmp/crowbar-dev-test/opt/dell`
-* running bundler to install required gems
-* creating a `coverage` symlink under the Rails app's `public/`
+* Runs bundler to install required gems
+* Creates a `coverage` symlink under the Rails app's `public/`
   directory so that the web server will serve up the HTML coverage
   reports
-* compiling the BDD tests
+* Compiles the BDD tests
 
 #### Running the tests
 
@@ -31,7 +32,7 @@ Setup includes the following tasks:
 
 You can also run them with finer granularity:
 
-    ./dev tests run-unit  # executes the Rails specs, Chef specs, and unit tests
+    ./dev tests run-units  # executes the Rails specs, Chef specs, and unit tests
     ./dev tests run-BDD   # executes the BDD tests
 
 After changing code, you can re-run the above command after first


### PR DESCRIPTION
Consolidated "./dev tests" info into 1 place.  Made a few tweaks to dev tests info.  Fixed typo.

 doc/devguide/devtool-build.md    |   13 +++----------
 doc/devguide/devtool.md          |   11 +----------
 doc/misc_docs/testing/devtool.md |   27 ++++++++++++++-------------
 3 files changed, 18 insertions(+), 33 deletions(-)

Crowbar-Pull-ID: 5d29cb40726cb17789719a868b0c06d5fc54c915

Crowbar-Release: development
