### PR TITLE
Refactor machine controller

### DIFF
--- a/crowbar_framework/app/controllers/machines_controller.rb
+++ b/crowbar_framework/app/controllers/machines_controller.rb
@@ -134,7 +134,7 @@ class MachinesController < ApplicationController
   def render_not_found
     flash.now[:alert] = "Could not find node for name #{@name}"
     respond_to do |format|
-      format.json { render :text => "Host not found", :status => 404 }
+      format.json { render :json => {:alert => "Host not found"}, :status => 404 }
     end
   end
 

--- a/crowbar_framework/spec/controllers/machines_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/machines_controller_spec.rb
@@ -71,8 +71,6 @@ describe MachinesController do
       NodeObject.stubs(:find_node_by_name).returns(nil)
     end
 
-=begin
-    FIXME: decide if this is a bug
     describe "POST action" do
       it "fails with JSON when w/ not found" do
         post :reinstall, :name => "testing"
@@ -81,7 +79,10 @@ describe MachinesController do
           JSON.parse(response.body)
         }.to_not raise_error
       end
+    end
 
+=begin
+    FIXME: decide if this is a bug
       it "fails with a reasonable error when name not passed" do
         post :reinstall
         response.should be_bad_request
@@ -91,10 +92,10 @@ describe MachinesController do
 
     ["poweron", "allocate", "delete", "reboot", "shutdown", "identify", "reset", "update", "reinstall"].each do |operation|
       describe "POST #{operation}" do
-        it "renders error text w/ not found" do
-          post operation, :name => "testing"
+        it "renders error JSON w/ not alert found" do
+          response = post operation, :name => "testing"
           response.should be_missing
-          response.body.should == "Host not found"
+          JSON.parse(response.body)["alert"].should == "Host not found"
         end
 
         it "does not call node operation" do


### PR DESCRIPTION
This patchset adds tests for and refactors (mostly removes duplicates) MachinesController.

In 3e8659f, tests are added, making sure that we don't break its API.

The only change in functionality is in 60d9460 - before, `session[:domain]` was set only for the `list`, `index` and `show` actions. However, this appears to be a bug - if user / client would hit any other action first, then, due to the missing domain, the node name would not be correctly set and the corresponding node object might not be found. So this patch makes sure that the `session[:domain]` is set for every action (if it hasn't been set yet).

I also noticed two more possible issues (but I'm not sure if they indeed pose a real problem, so feel free to discuss):
1. The response code is 200 even if e.g. `machine.reboot` fails, making it hard to detect that something went wrong.
2. 404 responses are plain text, not JSON as the 200s. This might possibly cause client to fail if it decides to parse the response (e.g. to get an error text).
