### PR TITLE
Do not consider cinder volumes as local disks

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -422,7 +422,7 @@ class NodeObject < ChefObject
     # On windows platform there is no block_device chef entry.
     if defined?(@node[:block_device]) and !@node[:block_device].nil?
       @node[:block_device].find_all do |disk,data|
-        disk =~ /^([hsv]d|cciss)/ && data[:removable] == "0"
+        disk =~ /^([hsv]d|cciss)/ && data[:removable] == "0" && !(data[:vendor] == "cinder" && data[:model] =~ /^volume-/)
       end.length
     else
       -1


### PR DESCRIPTION
They belong to the VMs really, so don't add them to the fixed/unclaimed
disks list. Fixes bnc#826569

This is the same as https://github.com/crowbar/barclamp-deployer/pull/172
