### PR TITLE
add apply_role_post_chef_call

### DIFF
--- a/crowbar_framework/barclamp_model/crowbar_framework/app/models/==BC-MODEL==_service.rb
+++ b/crowbar_framework/barclamp_model/crowbar_framework/app/models/==BC-MODEL==_service.rb
@@ -60,5 +60,12 @@ class ==^BC-MODEL==Service < ServiceObject
     @logger.debug("==*BC-MODEL== apply_role_pre_chef_call: leaving")
   end
 
+  # Similar to above - delete or uncomment for actions to be run after
+  # chef-client runs.
+  # def apply_role_post_chef_call(old_role, role, all_nodes)
+  #   @logger.debug("==*BC-MODEL== apply_role_post_chef_call: entering #{all_nodes.inspect}")
+  #   @logger.debug("==*BC-MODEL== apply_role_post_chef_call: leaving")
+  # end
+
 end
 


### PR DESCRIPTION
This new hook mirrors apply_role_pre_chef_call, but is run after all the
chef-client runs are complete.  This can be used for things inserting
links into node.crowbar["crowbar"]["links"], since the links should not
show up until the chef-client runs succeeded.
