### PR TITLE
CB 2.0: Display the version string again. [1/2]

### DIFF
--- a/crowbar_framework/app/views/layouts/application.html.haml
+++ b/crowbar_framework/app/views/layouts/application.html.haml
@@ -48,4 +48,4 @@
         %img{:src=>"/images/layout/dell.png", :alt=>"Dell, Inc.", :title=>"Dell, Inc.", :style=>"vertical-align:middle;padding-bottom:2px"}
       %a{:href=>"http://dell.com/crowbar", :target=>"_new", :alt=>"Dell, Inc."}
         CloudEdge Solutions team
-      =t 'version', :version=>(Rails.env.development? ? "Development" : BarclampCrowbar::Barclamp.all.first.commit)
+      =t 'version', :version=>(Rails.env.development? ? "Development" : (IO.read("/opt/dell/crowbar_framework/.version").strip rescue "Unknown"))


### PR DESCRIPTION
Once upon a time, we displayed a meaningful version string in the UI.
It bitrotted away.  This restores it to something vaguely useful.

 crowbar_framework/app/views/layouts/application.html.haml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: d182851598ec5c2e583c9397ff2dd97229a61b2a

Crowbar-Release: development
