### PR TITLE
Initialize the Chef config in ProposalObject when saving a proposal

### DIFF
--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -249,6 +249,7 @@ class ProposalObject < ChefObject
     end
     Rails.logger.debug("Saving data bag item: #{@item["id"]} - #{@item["deployment"][barclamp]["crowbar-revision"]}")
     if CHEF_ONLINE
+      self.class.chef_init
       @item.save
     else
       ProposalObject.offline_cache(@item, ProposalObject.nfile('data_bag_item_crowbar', @item.id))


### PR DESCRIPTION
ProposalObject::save would use the wrong client certificate unless another
model already initialized the Chef config before.
