### PR TITLE
Move contents of ChefObject#chef_init into an initializer

### DIFF
--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -40,27 +40,18 @@ class ChefObject
 
   def self.query_chef
     begin
-      chef_init
       return Chef::Search::Query.new
     rescue
       return Chef::Node.new
     end
   end
 
-  def self.chef_init
-    Chef::Config.node_name CHEF_NODE_NAME
-    Chef::Config.client_key CHEF_CLIENT_KEY
-    Chef::Config.chef_server_url CHEF_SERVER_URL
-    puts "CHEF_OFFLINE" unless CHEF_ONLINE
-  end
-  
   def self.chef_escape(str)
     str.gsub("-:") { |c| '\\' + c }
   end
 
   def self.crowbar_node(name)
     begin 
-      chef_init
       return Chef::Node.load(name)
     rescue StandardError => e
       Rails.logger.warn("Could not recover Chef Crowbar Node on load #{name}: #{e.inspect}")
@@ -70,7 +61,6 @@ class ChefObject
 
   def self.crowbar_data(bag_item)
     begin 
-      chef_init
       return Chef::DataBag.load "crowbar/#{bag_item}"
     rescue StandardError => e
       Rails.logger.warn("Could not recover Chef Crowbar Data on load #{bag_item}: #{e.inspect}")

--- a/crowbar_framework/app/models/client_object.rb
+++ b/crowbar_framework/app/models/client_object.rb
@@ -20,7 +20,6 @@
 class ClientObject < ChefObject
   def self.find_client_by_name(name)
     begin
-      chef_init
       return ClientObject.new Chef::ApiClient.load(name)
     rescue StandardError => e
       Rails.logger.fatal("Failed to find client: #{name} #{e.message}")

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -24,7 +24,6 @@ class ProposalObject < ChefObject
   
   def self.find_data_bag_item(bag)
     begin
-      chef_init #elimiate
       bag = ProposalObject.new(Chef::DataBag.load bag)  #should use new syntax
       return bag
     rescue

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -70,7 +70,6 @@ class RoleObject < ChefObject
   def self.find_role_by_name(name)
     if CHEF_ONLINE
       begin
-        chef_init
         return RoleObject.new Chef::Role.load(name)
       rescue Net::HTTPServerException => e
         return nil if e.response.code == "404"

--- a/crowbar_framework/config/initializers/chef.rb
+++ b/crowbar_framework/config/initializers/chef.rb
@@ -1,0 +1,3 @@
+Chef::Config.node_name CHEF_NODE_NAME
+Chef::Config.client_key CHEF_CLIENT_KEY
+Chef::Config.chef_server_url CHEF_SERVER_URL

--- a/crowbar_framework/spec/models/chef_object_spec.rb
+++ b/crowbar_framework/spec/models/chef_object_spec.rb
@@ -19,7 +19,7 @@ describe ChefObject do
     end
 
     it "returns empty node on failure" do
-      chef_object.stubs(:chef_init).raises(StandardError)
+      Chef::Search::Query.stubs(:new).raises(StandardError)
       chef_object.query_chef.should be_a(Chef::Node)
     end
   end

--- a/crowbar_framework/spec/support/env_setup.rb
+++ b/crowbar_framework/spec/support/env_setup.rb
@@ -3,3 +3,5 @@ silence_warnings do
   CHEF_CLIENT_KEY = nil
   CHEF_ONLINE     = true
 end
+
+Chef::Config.client_key CHEF_CLIENT_KEY


### PR DESCRIPTION
If the chef settings stay constant throughout the app life cycle, they
can be safely moved into an initializer.

Move ChefObject#chef_init into config/initializers/chef.rb, then remove
references to this method from the code.

Update the tests so they keep passing.
