### PR TITLE
Restructured node roles and barclamps listings

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/crowbar/dashboard.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/crowbar/dashboard.js
@@ -19,40 +19,6 @@
  */
 
 jQuery(document).ready(function($) {
-  $('#nodedetails .roles a').live('click', function(event) {
-    $.getJSON($(this).data('href'), function(data) {
-      $('a.highlight').removeClass('highlight');
-      $(this).addClass('highlight');
-
-      $('.list-group-item.selected').removeClass('selected');
-
-      if (data['nodes']) {
-        $.each(data['nodes'], function(i, node) {
-          $('[data-id={0}]'.format(node)).addClass('selected');
-        });
-      }
-    });
-
-    event.preventDefault();
-  });
-
-  $('#nodedetails .barclamps a').live('click', function(event) {
-    $.getJSON($(this).data('href'), function(data) {
-      $('a.highlight').removeClass('highlight');
-      $(this).addClass('highlight');
-
-      $('.list-group-item.selected').removeClass('selected');
-
-      if (data['nodes']) {
-        $.each(data['nodes'], function(i, node) {
-          $('[data-id={0}]'.format(node)).addClass('selected');
-        });
-      }
-    });
-
-    event.preventDefault();
-  });
-
   $('.list-group-item a').live('click', function(event) {
     $('.list-group-item').removeClass('selected');
     $(this).parents('.list-group-item').addClass('selected');

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -127,6 +127,10 @@ class ProposalObject < ChefObject
     )
   end
 
+  def category
+    @category ||= ServiceObject.barclamp_category(barclamp)
+  end
+
   def item
     @item
   end

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -86,7 +86,22 @@ class RoleObject < ChefObject
   end
 
   def barclamp
-    @role.name.split("-")[0]
+    name = @role.name.split("-")[0]
+
+    case name
+    when "switch_config"
+      "network"
+    when "bmc"
+      "ipmi"
+    when "nfs"
+      "nfs_client"
+    else
+      name
+    end
+  end
+
+  def category
+    @category ||= ServiceObject.barclamp_category(barclamp)
   end
 
   def inst

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -68,7 +68,27 @@ class ServiceObject
   end
 
   def self.barclamp_catalog
-    YAML.load_file(File.join( 'config', 'catalog.yml'))
+    @barclamp_catalog ||= YAML.load_file(File.join( 'config', 'catalog.yml'))
+  end
+
+  def self.barclamp_categories
+    @barclamp_categories ||= begin
+      {}.tap do |result|
+        barclamp_catalog["barclamps"].each do |barclamp, attrs|
+          next if attrs["members"].nil?
+          result[barclamp] = attrs["members"].keys
+        end
+      end
+    end
+  end
+
+  def self.barclamp_category(barclamp)
+    value = barclamp_categories.map do |parent, members|
+      next unless members.include? barclamp
+      barclamp_catalog["barclamps"][parent]["display"]
+    end
+
+    value.compact.first || "Unknown"
   end
 
   def self.all

--- a/crowbar_framework/app/views/nodes/_show_barclamps.html.haml
+++ b/crowbar_framework/app/views/nodes/_show_barclamps.html.haml
@@ -2,4 +2,4 @@
   %th
     = t("model.attributes.node.barclamps")
   %td{ :colspan => 3 }
-    = node_barclamp_list(@node.roles)
+    = node_barclamp_list(@node)

--- a/crowbar_framework/app/views/nodes/_show_roles.html.haml
+++ b/crowbar_framework/app/views/nodes/_show_roles.html.haml
@@ -2,4 +2,4 @@
   %th
     = t("model.attributes.node.roles")
   %td{ :colspan => 3 }
-    = node_role_list(@node.roles)
+    = node_role_list(@node)

--- a/crowbar_framework/config/locales/en.yml
+++ b/crowbar_framework/config/locales/en.yml
@@ -245,8 +245,8 @@ en:
         number_of_drives: Disk Drives
         description: Description
         description_not_set: Node description not set
-        roles: Roles
-        barclamps: Barclamps
+        roles: Applied Roles
+        barclamps: Applied Barclamps
         asset_tag: Service Tag
         license_key: License Key
         license_key_not_set: Not set


### PR DESCRIPTION
This pull requests changes the barclamp and roles list within node view on dashboard into real lists with barclamp display name, optional proposal name and link directly into the barclamp proposal page. 
**Addresses bnc#860614**
