### PR TITLE
Removed positive messages from node selector

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
@@ -17,10 +17,6 @@
       $('#nodelist-alert').html()
     );
 
-    this.successTemplate = Handlebars.compile(
-      $('#nodelist-success').html()
-    );
-
     this.warningTemplate = Handlebars.compile(
       $('#nodelist-warning').html()
     );
@@ -134,13 +130,6 @@
       var alias = $node.data('alias');
       var role = $node.data('role');
 
-      self.successMessage(
-        'barclamp.node_selector.removed'.localize().format(
-          alias,
-          role
-        )
-      );
-
       if (self.json.elements[role]) {
         self.json.elements[role].removeValue(id);
       }
@@ -182,27 +171,6 @@
     );
 
     var message = $('.alert-danger.alert-dismissable.disappear:last');
-
-    win.setTimeout(
-      function() {
-        message.slideUp(500, function() {
-          $(this).remove();
-        });
-      },
-      3000
-    );
-  };
-
-  NodeList.prototype.successMessage = function(message) {
-    var self = this;
-
-    self.$root.before(
-      self.successTemplate({
-        message: message
-      })
-    );
-
-    var message = $('.alert-success.alert-dismissable.disappear:last');
 
     win.setTimeout(
       function() {
@@ -317,13 +285,6 @@
     if ($.inArray(id, self.json.elements[role]) < 0) {
       self.json.elements[role].push(id);
       self.updateJson();
-
-      return self.successMessage(
-        'Added {0} to {1}'.format(
-          alias,
-          role
-        )
-      );
     }
 
     return true;

--- a/crowbar_framework/app/assets/javascripts/misc/stringLocalize.js
+++ b/crowbar_framework/app/assets/javascripts/misc/stringLocalize.js
@@ -21,7 +21,6 @@
 if (!String.prototype.localize) {
   String.prototype.localize = function() {
     values = {
-      'barclamp.node_selector.removed': 'Removed {0} from {1}',
       'barclamp.node_selector.duplicate': 'Node {0} is already assigned to {1}',
       'barclamp.node_selector.outdated': 'There have been deleted old nodes removed, please save this deployment.',
       'barclamp.node_selector.no_admin': 'Failed to assign {0} to {1}, no admin nodes allowed',

--- a/crowbar_framework/app/views/barclamp/_node_selector.html.haml
+++ b/crowbar_framework/app/views/barclamp/_node_selector.html.haml
@@ -66,10 +66,3 @@
       &times;
 
     {{message}}
-
-%script#nodelist-success{ :type => "text/x-handlebars-template" }
-  .alert.alert-success.alert-dismissable.disappear
-    %button.close{ :type => "button", "data-dismiss" => "alert", "aria-hidden" => true }
-      &times;
-
-    {{message}}


### PR DESCRIPTION
As suggested on the IRC, it's annoying to scroll up and down with all the positive messages while adding or removing nodes.
