### PR TITLE
Add missing string

### DIFF
--- a/crowbar_framework/config/locales/en.yml
+++ b/crowbar_framework/config/locales/en.yml
@@ -347,6 +347,7 @@ en:
       no_entry: No address assigned
     show_links:
       links: Links
+      bmc: IPMI
       no_entry: No links available
     show_roles:
       no_entry: No role assigned


### PR DESCRIPTION
It's used in the node_link_list method of nodes_helper.rb.
