### PR TITLE
Fix potential race condition in node update

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -74,11 +74,11 @@ class CrowbarService < ServiceObject
         save_it = true
         pop_it = true
       end
+
+      node.save if save_it
     ensure
       release_lock f
     end
-
-    node.save if save_it
 
     if pop_it
       #


### PR DESCRIPTION
Refs BNC#861527

Processes:

| A | B |
| --- | --- |
| Enters locked block | Spins on the lock |
| Loads node info X |  |
| Modifies node info X+a |  |
| Exits locked block | Enters locked block |
|  | Loads node info X |
| Saves node info X+a | Modifies node info X+b |
|  | Exits locked block |
|  | Saves node info X+b |

Expected behavior is that B already works with updated info X+a.
