### PR TITLE
Fix crash happening from time to time

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -85,7 +85,7 @@ class ServiceObject
   def self.barclamp_category(barclamp)
     value = barclamp_categories.map do |parent, members|
       next unless members.include? barclamp
-      barclamp_catalog["barclamps"][parent]["display"]
+      barclamp_catalog["barclamps"][parent]["display"] rescue nil
     end
 
     value.compact.first || "Unknown"


### PR DESCRIPTION
This is definitely a band-aid, and not a perfect fix, but I'm not able
to identify why this crash sometimes happens and sometimes doesn't:

F, [2014-02-10T18:44:19.682639 #22058] FATAL -- :
ActionView::TemplateError (undefined method `[]' for nil:NilClass) on line #5 of app/views/nodes/_show_barclamps.html.haml:
2:   %th
3:     = t("model.attributes.node.barclamps")
4:   %td{ :colspan => 3 }
5:     = node_barclamp_list(@node)

```
app/models/service_object.rb:88:in `barclamp_category'
/usr/lib64/ruby/1.8/net/protocol.rb:135:in `map'
app/models/service_object.rb:86:in `each'
app/models/service_object.rb:86:in `map'
app/models/service_object.rb:86:in `barclamp_category'
app/models/proposal_object.rb:131:in `category'
app/helpers/nodes_helper.rb:377:in `node_barclamp_list'
app/helpers/nodes_helper.rb:357:in `map'
app/helpers/nodes_helper.rb:357:in `node_barclamp_list'
app/helpers/nodes_helper.rb:356:in `tap'
app/helpers/nodes_helper.rb:356:in `node_barclamp_list'
app/views/nodes/_show_barclamps.html.haml:5:in `_run_haml_app47views47nodes47_show_barclamps46html46haml_locals_object_show_barclamps'
haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
haml (3.1.6) lib/haml/helpers.rb:90:in `non_haml'
haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
app/views/nodes/_show.html.haml:18:in `_run_haml_app47views47nodes47_show46html46haml_locals_object_show'
haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
haml (3.1.6) lib/haml/helpers.rb:90:in `non_haml'
haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
app/views/nodes/show.html.haml:6:in `_run_haml_app47views47nodes47show46html46haml'
haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:13:in `render'
haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:13:in `render'
app/controllers/nodes_controller.rb:310:in `show'
sass (3.2.12) rails/./lib/sass/plugin/rack.rb:54:in `call'
sass (3.2.12) rails/./lib/sass/plugin/rack.rb:54:in `call'
rainbows (4.3.1) lib/rainbows/event_machine/client.rb:41:in `app_call'
rainbows (4.3.1) lib/rainbows/event_machine/client.rb:40:in `catch'
rainbows (4.3.1) lib/rainbows/event_machine/client.rb:40:in `app_call'
rainbows (4.3.1) lib/rainbows/ev_core.rb:97:in `on_read'
rainbows (4.3.1) lib/rainbows/event_machine/client.rb:25:in `receive_data'
eventmachine (1.0.3) lib/eventmachine.rb:187:in `run_machine'
eventmachine (1.0.3) lib/eventmachine.rb:187:in `run'
rainbows (4.3.1) lib/rainbows/event_machine.rb:86:in `worker_loop'
rainbows (4.3.1) lib/rainbows/http_server.rb:44:in `worker_loop'
unicorn (4.1.0) lib/unicorn/http_server.rb:485:in `spawn_missing_workers'
rainbows (4.3.1) lib/rainbows/http_server.rb:60:in `spawn_missing_workers'
unicorn (4.1.0) lib/unicorn/http_server.rb:135:in `start'
rainbows (4.3.1) bin/rainbows:122
/usr/bin/rainbows:19:in `load'
/usr/bin/rainbows:19
```
