### PR TITLE
Add a basic disk reservation system to CB 2.0, and fix up the Ceph barclamp to use it. [1/3]

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -216,10 +216,13 @@ class Node < ActiveRecord::Base
   end
 
   def discovery=(arg)
-    arg = JSON.parse(arg) unless arg.is_a? Hash
-    data = discovery.merge arg
-    write_attribute("discovery",JSON.generate(data))
-    data
+    Node.transaction do 
+      arg = JSON.parse(arg) unless arg.is_a? Hash
+      data = discovery.merge arg
+      write_attribute("discovery",JSON.generate(data))
+      save!
+      return data
+    end
   end
 
   def discovery_update(val)


### PR DESCRIPTION
This adds a basic framework to allow Chef recipes to reserve disks on
nodes, along with core Crowbar support for making sure those
reservations are known to all noderole runs.

 crowbar_framework/app/models/jig.rb  | 14 ++++++++++++++
 crowbar_framework/app/models/node.rb | 11 +++++++----
 2 files changed, 21 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 49d97fa8999a043f27517044314ccec9d4ee9065

Crowbar-Release: development
