### PR TITLE
Do not repeatedly look up the node in transition exit

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -72,9 +72,13 @@ class BarclampController < ApplicationController
     state = params[:state] # State of node transitioning
     name = params[:name] # Name of node transitioning
 
-    ret = @service_object.transition(id, name, state)
-    return render :text => ret[1], :status => ret[0] if ret[0] != 200
-    render :json => ret[1]
+    status, response = @service_object.transition(id, name, state)
+
+    if status != 200 || !response[:name]
+      render :text => response, :status => status
+    else
+      render :json => NodeObject.find_node_by_name(response[:name]).to_hash
+    end
   end
   
   #

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -149,7 +149,7 @@ class CrowbarService < ServiceObject
     end
 
     @logger.debug("Crowbar transition leaving: #{name} to #{state}")
-    [200, NodeObject.find_node_by_name(name).to_hash ]
+    [200, { :name => name } ]
   end
 
   def create_proposal


### PR DESCRIPTION
Instead of looking up the node after each transition finishes,
load it once in the controller.

This shaves off ~ 0.2 seconds for every transition in barclamps referencing this PR.
