### PR TITLE
Ensure backwards compatibility in transition

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -74,10 +74,16 @@ class BarclampController < ApplicationController
 
     status, response = @service_object.transition(id, name, state)
 
-    if status != 200 || !response[:name]
+    if status != 200
       render :text => response, :status => status
     else
-      render :json => NodeObject.find_node_by_name(response[:name]).to_hash
+      # Be backward compatible with barclamps returning a node hash, passing
+      # them intact.
+      if response[:name]
+        render :json => NodeObject.find_node_by_name(response[:name]).to_hash
+      else
+        render :json => response
+      end
     end
   end
   

--- a/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
@@ -69,6 +69,22 @@ describe CrowbarController do
       response.should be_server_error
       response.body.should == "error"
     end
+
+    it "returns node as a hash on success when passed a name" do
+      CrowbarService.any_instance.stubs(:transition).returns([200, { :name => "testing" } ])
+      post :transition, :barclamp => "crowbar", :id => "default", :state => "discovering", :name => "testing"
+      response.should be_success
+      json = JSON.parse(response.body)
+      json["name"].should == "testing.crowbar.com"
+    end
+
+    it "returns node as a hash on success when passed a node (backward compatibility)" do
+      CrowbarService.any_instance.stubs(:transition).returns([200, NodeObject.find_node_by_name("testing").to_hash ])
+      post :transition, :barclamp => "crowbar", :id => "default", :state => "discovering", :name => "testing"
+      response.should be_success
+      json = JSON.parse(response.body)
+      json["name"].should == "testing.crowbar.com"
+    end
   end
 
   describe "GET show" do


### PR DESCRIPTION
If a barclamp returns [status, node.to_hash], pass it along. Add tests covering this scenario.
