### PR TITLE
Adding network API call for role to ip allocation mapping. CES-1424 [1/2]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -48,7 +48,7 @@ roles:
       - provisioner-dhcp-database
       - provisioner-repos
   - name: crowbar-managed-node
-    description: "Crowbar Node Service Bundle (discovered)"
+    description: "Crowbar Node Service Bundle"
     jig: noop
     flags:
       - discovery
@@ -59,7 +59,7 @@ roles:
       - ntp-client
       - provisioner-repos
   - name: crowbar-installed-node
-    description: "Crowbar Node Ready Checkpoint (allocated)"
+    description: "Crowbar Node Ready Checkpoint"
     jig: noop
     flags:
       - implicit


### PR DESCRIPTION
Adding network API call and CLI for role to ip allocation mapping. 

CES-1424 - enable smoketest for NTP and DNS barclamps 

 bin/crowbar |    6 ++++++
 1 file changed, 6 insertions(+)

Crowbar-Pull-ID: d1bebf4e091834477c2252170b9f7f9b81be6d14

Crowbar-Release: development
