### PR TITLE
Interm Berkshelf support [1/6]

### DIFF
--- a/doc/misc_docs/barclamps/crowbar.yml.md
+++ b/doc/misc_docs/barclamps/crowbar.yml.md
@@ -35,5 +35,5 @@
     * Contains a list of barclamps that your barclamp is dependent on
     * For example:
 <pre>            requires:
-               - os-base
+               - openstack-base
                - messaging</pre>


### PR DESCRIPTION
These changes get things to the point where there is a centralized
berkshelf so that we only need to check in 1 copy of the upstream cookbooks

 doc/misc_docs/barclamps/crowbar.yml.md |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 651b5e8f8b7dd85967f4ecf104c8b44082568c45

Crowbar-Release: development
