### PR TITLE
Interm Berkshelf support [1/6]

### DIFF
--- a/doc/misc_docs/barclamps/crowbar.yml.md
+++ b/doc/misc_docs/barclamps/crowbar.yml.md
@@ -35,5 +35,5 @@
     * Contains a list of barclamps that your barclamp is dependent on
     * For example:
 <pre>            requires:
-               - os-base
+               - openstack-base
                - messaging</pre>


### PR DESCRIPTION
This set of pull request is the first in a series that implements
interm Berkshelf support.

Design:

This assumes that there is a berkshelf checked in to the openstack
barclamp.  This change will come in a separate pull request so as
to not muddy the waters.

When the user clicks the table cell to target a role to a node,
on_proposed is called on the role.  This causes "berks package"
to be called, which creates a package.tar.gz file that contains
all of the dependent cookbooks.  Note that this only happens
once for each role.

The chef-solo jig then scp's the package.tar.gz to the target
node, and unzips it.

All of this only occurs if there is a file named
Berksfile.central in the same directory as the Berksfile for
the barclamp, so it will not effect current operation.

Pull requests to come:
- pull request that checks in the berkshelf to the openstack bc
- pull request that adds a nasty hack to make appropriate dirs
  writeable so that "berks package" can work
- pull request that removes all of the unneeded copies of the
  dependent cookbooks

These pull requests do not address how the berkshelf is initially
created.  Discretion is the better part of valor, and the crowbar
team will address this as part of on-line mode.

 doc/misc_docs/barclamps/crowbar.yml.md |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: c883448c62c77b5d87ff5d0e991668b6e825ec1d

Crowbar-Release: development
