### PR TITLE
[roxy] Fixed switch name if it is available

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -209,19 +209,19 @@ module NodesHelper
         show_name = if @node.switch_name.nil?
           false
         else
-          @node.switch_name >= 0
+          @node.switch_name.to_i != -1
         end
 
         show_port = if @node.switch_port.nil?
           false
         else
-          @node.switch_port >= 0
+          @node.switch_port.to_i != -1
         end
 
         show_unit = if @node.switch_unit.nil?
           false
         else
-          @node.switch_unit >= 0
+          @node.switch_unit.to_i != -1
         end
 
         if @node.switch_unit.nil?


### PR DESCRIPTION
This pull request fixes the error mentioned on mailing list: 

```
Hi,

I am getting error when i click the nodes. Below is the error from
production log when i tried to enter
http://10.236.9.10:3000/nodes/d00-1e-4f-3d-ce-8b:

Processing NodesController#show (for 10.102.235.60 at 2014-02-26 17:06:15)
[GET]
I, [2014-02-26T17:06:15.874486 #376]  INFO -- :   Parameters:
{"name"=>"d00-1e-4f-3d-ce-8b"}
I, [2014-02-26T17:06:16.150679 #376]  INFO -- : Rendering template within
layouts/application
I, [2014-02-26T17:06:16.150848 #376]  INFO -- : Rendering nodes/show
F, [2014-02-26T17:06:16.225422 #376] FATAL -- :
ActionView::TemplateError (comparison of String with 0 failed) on line #1
of app/views/nodes/_show_details.html.haml:
1: - 0.upto(node_detail_count - 1).each do |row|
2:   %tr
3:     - node_detail_software[row].tap do |software|
4:       - if software.nil?

    app/helpers/nodes_helper.rb:212:in `>='
    app/helpers/nodes_helper.rb:212:in `node_detail_hardware'
    app/helpers/nodes_helper.rb:175:in `tap'
    app/helpers/nodes_helper.rb:175:in `node_detail_hardware'
    app/helpers/nodes_helper.rb:108:in `node_detail_count'
    app/views/nodes/_show_details.html.haml:1:in
`_run_haml_app47views47nodes47_show_details46html46haml_locals_object_show_details'
    haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
    haml (3.1.6) lib/haml/helpers.rb:90:in `non_haml'
    haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
    app/views/nodes/_show.html.haml:14:in
`_run_haml_app47views47nodes47_show46html46haml_locals_object_show'
    haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
    haml (3.1.6) lib/haml/helpers.rb:90:in `non_haml'
    haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:11:in `render'
    app/views/nodes/show.html.haml:6:in
`_run_haml_app47views47nodes47show46html46haml'
    haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:13:in `render'
    haml (3.1.6) rails/./lib/haml/helpers/action_view_mods.rb:13:in `render'
    app/controllers/nodes_controller.rb:310:in `show'
    sass (3.2.12) rails/./lib/sass/plugin/rack.rb:54:in `call'
    sass (3.2.12) rails/./lib/sass/plugin/rack.rb:54:in `call'
    rainbows (4.3.1) lib/rainbows/event_machine/client.rb:41:in `app_call'
    rainbows (4.3.1) lib/rainbows/event_machine/client.rb:40:in `catch'
    rainbows (4.3.1) lib/rainbows/event_machine/client.rb:40:in `app_call'
    rainbows (4.3.1) lib/rainbows/ev_core.rb:97:in `on_read'
    rainbows (4.3.1) lib/rainbows/event_machine/client.rb:25:in
`receive_data'
    /usr/lib/ruby/vendor_ruby/eventmachine.rb:257:in `run_machine'
    /usr/lib/ruby/vendor_ruby/eventmachine.rb:257:in `run'
    rainbows (4.3.1) lib/rainbows/event_machine.rb:86:in `worker_loop'
    rainbows (4.3.1) lib/rainbows/http_server.rb:44:in `worker_loop'
    unicorn (4.8.2) lib/unicorn/http_server.rb:521:in
`spawn_missing_workers'
    rainbows (4.3.1) lib/rainbows/http_server.rb:60:in
`spawn_missing_workers'
    unicorn (4.8.2) lib/unicorn/http_server.rb:140:in `start'
    rainbows (4.3.1) bin/rainbows:122
    /usr/local/bin/rainbows:19:in `load'
    /usr/local/bin/rainbows:19


I, [2014-02-26T17:06:16.226077 #376]  INFO -- : Rendering
/opt/dell/crowbar_framework/public/500.html (500 Internal Server Error)
I, [2014-02-26T17:06:17.405905 #374]  INFO -- :

The admin node is installed via the ISO created from Roxy branch and i
installed proposals, database, keystone, rabbitmq, cinder, glance  and
neutron on to two nodes till now using the same UI. I couldn't figured it
out the reason of the problem. Any idea?
```
