### PR TITLE
Check for odd number of ceph-mon in proposal [1/2]

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -842,6 +842,17 @@ class ServiceObject
     end
   end
 
+  #
+  # Ensure that the proposal contains an odd number of nodes for role
+  #
+  def validate_count_as_odd_for_role(proposal, role)
+    elements = proposal["deployment"][@bc_name]["elements"]
+
+    if not elements.has_key?(role) or elements[role].length.to_i.even?
+      validation_error("Need an odd number of #{role} nodes.")
+    end
+  end
+
   def validate_dep_proposal_is_active(bc, proposal)
     const_service = Kernel.const_get("#{bc.camelize}Service")
     service = const_service.new @logger


### PR DESCRIPTION
Ceph deployments should have an odd number of ceph-mon processes.

 crowbar_framework/app/models/service_object.rb |   11 +++++++++++
 1 file changed, 11 insertions(+)

Crowbar-Pull-ID: 5458bf315d94064341d4731918096a43df5e57ae

Crowbar-Release: roxy
