### PR TITLE
Fix: Must specify the version being used for the activesupport gem.

### DIFF
--- a/chef/cookbooks/bluepill/recipes/default.rb
+++ b/chef/cookbooks/bluepill/recipes/default.rb
@@ -22,6 +22,7 @@ gem_package "i18n" do
 end
 
 gem_package "activesupport" do
+  version "2.3.17"
   action :install
 end
 


### PR DESCRIPTION
If the version is not specified it tries the newest which we
can not support on Roxy due to the ruby version in use.

2.3.17 is what is available on the admin server.

Signed-off-by: JuanJose 'JJ' Galvez jj.galvez@inktank.com
