### PR TITLE
Made the edit deployment partial optional

### DIFF
--- a/crowbar_framework/app/helpers/barclamps_helper.rb
+++ b/crowbar_framework/app/helpers/barclamps_helper.rb
@@ -92,7 +92,13 @@ module BarclampsHelper
     if raw
       render :partial => 'barclamp/edit_attributes_raw'
     else
-      render :partial => "barclamp/#{proposal.barclamp}/edit_attributes"
+      if Rails.root.join("app", "views", "barclamp", proposal.barclamp, "_edit_attributes.html.haml").file?
+        render :partial => "barclamp/#{proposal.barclamp}/edit_attributes"
+      else
+        # Currently this view does not exist, but should be the 
+        # fallback way to show a generic form or message
+        render :partial => "barclamp/general/edit_attributes"
+      end
     end
   rescue ::ActionView::MissingTemplate
     render :partial => "barclamp/edit_attributes_raw"
@@ -110,7 +116,11 @@ module BarclampsHelper
     if raw
       render :partial => 'barclamp/edit_deployment_raw'
     else
-      render :partial => "barclamp/#{proposal.barclamp}/edit_deployment"
+      if Rails.root.join("app", "views", "barclamp", proposal.barclamp, "_edit_deployment.html.haml").file?
+        render :partial => "barclamp/#{proposal.barclamp}/edit_deployment"
+      else
+        render :partial => "barclamp/general/edit_deployment"
+      end
     end
   rescue ::ActionView::MissingTemplate
     render :partial => "barclamp/edit_deployment_raw"

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -23,6 +23,8 @@ require 'json'
 require 'hash_only_merge'
 
 class ServiceObject
+  extend Forwardable
+
   FORBIDDEN_PROPOSAL_NAMES=["template","nodes","commit","status"]
 
   attr_accessor :bc_name
@@ -36,6 +38,20 @@ class ServiceObject
   # OVERRIDE AS NEEDED! true if barclamp can have multiple proposals
   def self.allow_multiple_proposals?
     false
+  end
+
+  def_delegator self, :role_constraints
+
+  class << self
+    def role_constraints
+      # We are using this single assignment to define this hash really 
+      # only once. And with this surrounding block we can add expensive 
+      # calls too that get only executed once. Feel free to extend this 
+      # method within your service objects.
+      @role_constraint ||= begin
+        {}
+      end
+    end
   end
 
   def validation_error message

--- a/crowbar_framework/app/views/barclamp/crowbar/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/crowbar/_edit_deployment.html.haml
@@ -1,13 +1,7 @@
-%input#proposal_development{ :type => "hidden", :name => "proposal_deployment", :value => @proposal.raw_deployment.to_json }
+= deployment_for @proposal do
+  .panel-sub
+    = header @dep_raw, true
 
-.panel-sub
-  %h3
-    = t("barclamp.deployment")
-
-    .pull-right
-      %small
-        = proposal_raw_button @proposal, :dep_raw => true, :attr_raw => @attr_raw
-
-.panel-body
-  .alert.alert-info
-    = t(".noconfig")
+  .panel-body
+    .alert.alert-info
+      = t(".noconfig")

--- a/crowbar_framework/app/views/barclamp/general/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/general/_edit_deployment.html.haml
@@ -1,0 +1,1 @@
+= render :partial => "barclamp/node_selector", :locals => { :constraints => @service_object.role_constraints }

--- a/crowbar_framework/lib/dsl/proposal/deployment.rb
+++ b/crowbar_framework/lib/dsl/proposal/deployment.rb
@@ -15,7 +15,7 @@ module Dsl
         )
       end
 
-      def attributes_field
+      def deployments_field
         tag(
           :input,
           :id => "proposal_attributes",


### PR DESCRIPTION
- The edit_deployment partial is now optional
- Added empty role constraints to avoid any error
- Made the role constraint available for instances too
- Fixed deployment DSL
