### PR TITLE
[roxy] Added chef without version to Gemfile again

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -38,6 +38,11 @@ gem "syslogger", "1.3.0"
 gem "tilt", "1.3.3"
 gem "mime-types", "1.18", :require => "mime/types"
 
+# We are not adding any version here because the SLES and Ubuntu chef 
+# packaging differ for the version, but we need this to load the chef 
+# gem correctly within the initializer.
+gem "chef"
+
 group :development do
   gem "brakeman", "1.8.2"
   gem "rspec-rails", "1.3.4"


### PR DESCRIPTION
We need to add the chef gem back to Gemfile otherwise the chef initializer will sometimes fail.
