### PR TITLE
Change how we deal with multi-proposals barclamps in list of barclamps

### DIFF
--- a/crowbar_framework/app/views/barclamp/_show_simplified_index.html.haml
+++ b/crowbar_framework/app/views/barclamp/_show_simplified_index.html.haml
@@ -1,27 +1,7 @@
 %tbody
   - @modules.each do |barclamp_name, barclamp|
-    %tr.barclamp{ :id => barclamp_name.parameterize }
-      - if not barclamp[:allow_multiple_proposals] or barclamp[:proposals].length == 0
-        %td.col-xs-1.status
-          - if barclamp[:proposals].length > 0
-            - barclamp[:proposals].sort.each do |proposal_name, proposal|
-              = display_led_for(proposal[:status], "#{barclamp_name.parameterize}_#{proposal_name.parameterize}")
-          - else
-            = display_led_for(:none, "#{barclamp_name.parameterize}_none")
-        %td.col-xs-2
-          = display_name_for(barclamp_name)
-        %td.col-xs-8
-          = barclamp[:description]
-        %td.col-xs-1.actions
-          - if barclamp[:proposals].length == 0
-            - create_proposal_form_for(barclamp_name) do
-              = hidden_field_tag :barclamp, barclamp_name
-              = hidden_field_tag :name, "default"
-              = hidden_field_tag :description, t(".created_on", :date => l(Time.now))
-              %input.btn.btn-default.btn-block{ :type => "submit", :value => t("proposal.actions.create") }
-          - else
-            = link_to t("proposal.actions.edit"), proposal_barclamp_path(:controller => barclamp_name, :id => barclamp[:proposals].first.first), :class => "btn btn-default btn-block"
-      - else
+    - if barclamp[:allow_multiple_proposals]
+      %tr.barclamp{ :id => barclamp_name.parameterize }
         %td.col-xs-1.status
           - if barclamp[:proposals].length > 0
             - barclamp[:proposals].sort.each do |proposal_name, proposal|
@@ -34,8 +14,6 @@
           = barclamp[:description]
         %td.col-xs-1.actions
           = link_to t("proposal.actions.edit"), "#toggle", :class => (params[:id] == barclamp_name or barclamp[:expand]) ? "btn btn-default btn-block expanded" : "btn btn-default btn-block", "data-toggle-action" => barclamp_name
-
-    - if barclamp[:allow_multiple_proposals] and not barclamp[:proposals].length == 0
       %tr{ :class => (params[:id] == barclamp_name or barclamp[:expand]) ? "proposal visible" : "proposal hidden", "data-toggle-target" => barclamp_name }
         %td{ :colspan => "4" }
           %table.table.table-condensed
@@ -64,3 +42,24 @@
                   %td.col-xs-1.actions
                     = hidden_field_tag :barclamp, barclamp_name
                     %input.btn.btn-default.btn-block{ :type => "submit", :value => t("proposal.actions.create") }
+    - else
+      %tr.barclamp{ :id => barclamp_name.parameterize }
+        %td.col-xs-1.status
+          - if barclamp[:proposals].length > 0
+            - barclamp[:proposals].sort.each do |proposal_name, proposal|
+              = display_led_for(proposal[:status], "#{barclamp_name.parameterize}_#{proposal_name.parameterize}")
+          - else
+            = display_led_for(:none, "#{barclamp_name.parameterize}_none")
+        %td.col-xs-2
+          = display_name_for(barclamp_name)
+        %td.col-xs-8
+          = barclamp[:description]
+        %td.col-xs-1.actions
+          - if barclamp[:proposals].length == 0
+            - create_proposal_form_for(barclamp_name) do
+              = hidden_field_tag :barclamp, barclamp_name
+              = hidden_field_tag :name, "default"
+              = hidden_field_tag :description, t(".created_on", :date => l(Time.now))
+              %input.btn.btn-default.btn-block{ :type => "submit", :value => t("proposal.actions.create") }
+          - else
+            = link_to t("proposal.actions.edit"), proposal_barclamp_path(:controller => barclamp_name, :id => barclamp[:proposals].first.first), :class => "btn btn-default btn-block"


### PR DESCRIPTION
Until now, when a multi-proposal barclamp had no proposal, we were just
displaying a Create button that created a proposal named "default". And
then, later on, we were allowing the creation of new proposals with
different names.

Since "default" is not a great name and people will likely want to
change this, we now directly allow creating proposals with any name.
