### PR TITLE
NodeList triggers add/remove node events

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
@@ -97,7 +97,7 @@
     this.$root.find("[data-draggable=true]").draggable({
       opacity: 0.7,
       helper: "clone",
-      revert: "valid"
+      revert: "invalid"
     });
   };
 


### PR DESCRIPTION
Whenever a node is allocated to a role, or removed from it, the NodeList
triggers an appropriate event, passing along the role name, node id and
the node alias. This way, other UI components can listen and react to
these events.

Example usage would be:

``` javascript
$('#element').on('nodeListNodeUnallocated', function(evt, data) {
  // do stuff here
});
```
