### PR TITLE
Fix hostname for virtual IP in admin network

### DIFF
--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -3,7 +3,7 @@ module CrowbarHelper
     if use_cluster && defined?(CrowbarPacemakerHelper)
       # loose dependency on the pacemaker cookbook
       cluster_vhostname = CrowbarPacemakerHelper.cluster_vhostname(node)
-      "admin.#{cluster_vhostname}.#{node[:domain]}"
+      "#{cluster_vhostname}.#{node[:domain]}"
     else
       node[:fqdn]
     end


### PR DESCRIPTION
It should not be prefixed with "admin.".

This depends on https://github.com/crowbar/barclamp-dns/pull/93
