### PR TITLE
Add helper for finding unclaimed drives

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -487,6 +487,10 @@ class NodeObject < ChefObject
     end
   end
 
+  def unclaimed_physical_drives
+    physical_drives.select { |disk| disk_owner(disk).blank? }
+  end
+
   def physical_drives
     # This needs to be kept in sync with the fixed method in
     # barclamp_library.rb in in the deployer barclamp.


### PR DESCRIPTION
This is a prereq for cinder to check if any disk-backed volume can be
created.
