### PR TITLE
Handle removed node referenced by another proposal

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
@@ -74,7 +74,14 @@
             true
           );
         } else {
-          $.event.trigger('nodeListNodeUnallocated', { role: role, id: source.data('id'), alias: source.data('alias') });
+          // We need to handle the case when the referenced node has been
+          // removed by another proposal, and there is no corresponding element
+          // in the node list. In that case, the alias is no longer available.
+          if (source.length == 0) {
+            $.event.trigger('nodeListNodeUnallocated', { role: role, id: node, alias: undefined });
+          } else {
+            $.event.trigger('nodeListNodeUnallocated', { role: role, id: source.data('id'), alias: source.data('alias') });
+          }
           toRemove.push(index);
         }
       });


### PR DESCRIPTION
When another proposal removes a node which the current proposal
references, the corresponding DOM element is no longer available in the
deployment list. However, info from this element is needed by the
nodeList, when it triggers an event that a node has been removed.

Make the nodeList look up the info in some other way.
