### PR TITLE
Fix: Freeze rake 10.1.1

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -244,7 +244,7 @@ gems:
     - state_machine-0.9.4
     - bluepill-0.0.51
     # crowbar stuff
-    - rake
+    - rake-10.1.1
     - json-1.5.2
     - syslogger
     - sass


### PR DESCRIPTION
Rake 10.2.x introduced in March 2014, it requires Ruby 1.9.
To fix this issue freeze version of rake to 10.1.1 - latest which require Ruby 1.8.
