### PR TITLE
dynamicTable overwrites changes w/ old data

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/dynamicTable.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/dynamicTable.js
@@ -141,6 +141,7 @@
     var self = this;
 
     self.root.find('[data-add]').live('click', function(event) {
+      self.prepareJson();
       event.preventDefault();
 
       if (self.invalidEntry()) {
@@ -231,6 +232,7 @@
     });
 
     self.root.find('[data-remove]').live('click', function(event) {
+      self.prepareJson();
       event.preventDefault();
 
       var data = self.json;
@@ -260,6 +262,8 @@
     });
 
     self.root.find('tbody input').live('change', function(event) {
+      self.prepareJson();
+
       var data = self.json;
       var namespace = $(this).data('update').toString().split('/');
 


### PR DESCRIPTION
BNC#865526

The dynamicTable plugin caches the proposal attributes JSON in it's json
property and does not take into account that the data might have
changed when it writes its own copy back.

This fix minimizes the race window. Another one would be to
make sure we always operate only on the path + value that changed.
