### PR TITLE
Do not rely on TCP keep-alive for running commands through ssh

### DIFF
--- a/crowbar_framework/lib/remote_node.rb
+++ b/crowbar_framework/lib/remote_node.rb
@@ -73,7 +73,9 @@ module RemoteNode
   end
 
   def self.ssh_cmd(host_or_ip, cmd)
-    system("sudo", "-i", "-u", "root", "--", "ssh", "root@#{host_or_ip}", cmd)
+    ssh = ["sudo", "-i", "-u", "root", "--", "ssh", "-o", "TCPKeepAlive=no", "-o", "ServerAliveInterval=15", "root@#{host_or_ip}"]
+    ssh << cmd
+    system(*ssh)
   end
 
   def self.port_open?(ip, port)


### PR DESCRIPTION
The timeout for this is huge (not sure how big, but certainly more than
10 minutes). This is extremely bad when we run chef-client over ssh
while applying a proposal because if the host goes down, we will be
totally blocked for too long. This happens even more since we have HA
and STONITH can kill nodes.

Instead, we use the ServerAliveInterval=15 option, which means we use a
ssh-internal mechanism for a 15s timeout. It will try this three times,
resulting in a 45s timeout before giving up. This is largely enough in
the context of crowbar.
