### PR TITLE
Make icon tag accept options

### DIFF
--- a/crowbar_framework/app/helpers/tag_helper.rb
+++ b/crowbar_framework/app/helpers/tag_helper.rb
@@ -48,13 +48,10 @@ module TagHelper
   end
 
   # Directly generate a tag for the glyphicons web font icons
-  def icon_tag(icon, text = nil)
+  def icon_tag(icon, text = nil, options = {})
+    options[:class] = [options[:class], "glyphicon", "glyphicon-#{icon}"].compact.join(" ")
     [
-      content_tag(
-        :span,
-        "",
-        :class => "glyphicon glyphicon-#{icon}"
-      ),
+      content_tag(:span, "", options),
       text
     ].flatten.join("\n")
   end


### PR DESCRIPTION
Allow passing options to the icon tag, e.g. title, which will be displayed on the icon hover.
