### PR TITLE
Rewrite NodeObject.unclaimed_physical_drives

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -468,7 +468,8 @@ class NodeObject < ChefObject
   end
 
   def unclaimed_physical_drives
-    physical_drives.select { |disk| disk_owner(disk).blank? }
+    unique_drives = physical_drives.map { |disk, data| unique_device_for(disk) }
+    unique_drives.select { |disk| disk_owner(disk).blank? }.compact
   end
 
   def physical_drives


### PR DESCRIPTION
We need to use NodeObject.unique_device_for() to get the right device
name when checking claimed disks, and we also need to pass just the
string ("sda"), not the whole disk metadata.
