### PR TITLE
Separate the cluster related pacemaker-crowbar proxies

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -24,6 +24,8 @@ require 'hash_only_merge'
 require 'securerandom'
 
 class ServiceObject
+  include CrowbarPacemakerProxy
+
   FORBIDDEN_PROPOSAL_NAMES=["template","nodes","commit","status"]
 
   attr_accessor :bc_name
@@ -142,93 +144,6 @@ class ServiceObject
 
   def release_lock(f)
     FileLock.release(f, :logger => @logger)
-  end
-
-#
-# Helper related to clusters
-#
-
-  # There's no way to have the core of crowbar not know about clusters. This
-  # means that we have a loose dependency (in terms of architecture) on the
-  # barclamps defining clusters (eg, Pacemaker) here.
-
-  # Returns: list of available clusters
-  def available_clusters
-    @available_clusters ||= begin
-      clusters = {}
-      if defined?(PacemakerServiceObject)
-        clusters.merge!(PacemakerServiceObject.available_clusters)
-      end
-      clusters
-    end
-  end
-
-  # Returns: name of the barclamp and of the proposal for this cluster
-  def cluster_get_barclamp_and_proposal(element)
-    result = nil
-
-    if defined?(PacemakerServiceObject)
-      result ||= PacemakerServiceObject.cluster_get_barclamp_and_proposal(element)
-    end
-
-    result ||= [nil, nil]
-  end
-
-  def is_cluster?(element)
-    result = false
-
-    if defined?(PacemakerServiceObject)
-      result ||= PacemakerServiceObject.is_cluster?(element)
-    end
-
-    result
-  end
-
-  # Returns: name of the cluster, or nil if it's not a cluster
-  def cluster_name(element)
-    name = nil
-
-    if defined?(PacemakerServiceObject)
-      name ||= PacemakerServiceObject.cluster_name(element)
-    end
-
-    name
-  end
-
-  def cluster_exists?(element)
-    !available_clusters[element].nil?
-  end
-
-  # Returns: a list with two things:
-  #  - the list of all nodes in items; if item contains clusters, these
-  #    clusters will be expanded to the list of nodes they're made of
-  #    For instance [ node1, cluster1 ] will be expanded to [node1,
-  #    node1-of-cluster1, node2-of-cluster1]
-  #  - the list of items that are not nodes but that we failed to expand. This
-  #    can be used for knowing that expansion partially failed matters.
-  def expand_nodes_for_all(items)
-    nodes = []
-    failures = []
-
-    items.each do |item|
-      expanded = nil
-
-      if is_cluster? item
-        if defined?(PacemakerServiceObject)
-          expanded = PacemakerServiceObject.expand_nodes(item)
-        end
-
-        if expanded.nil?
-          failures << item
-        else
-          nodes.concat(expanded)
-        end
-      else
-        nodes << item
-      end
-    end
-
-    [nodes, failures]
   end
 
 #

--- a/crowbar_framework/lib/crowbar_pacemaker_proxy.rb
+++ b/crowbar_framework/lib/crowbar_pacemaker_proxy.rb
@@ -1,0 +1,89 @@
+#
+# Helper related to clusters
+#
+
+module CrowbarPacemakerProxy
+  # There's no way to have the core of crowbar not know about clusters. This
+  # means that we have a loose dependency (in terms of architecture) on the
+  # barclamps defining clusters (eg, Pacemaker) here.
+
+  # Returns: list of available clusters
+  def available_clusters
+    @available_clusters ||= begin
+      clusters = {}
+      if defined?(PacemakerServiceObject)
+        clusters.merge!(PacemakerServiceObject.available_clusters)
+      end
+      clusters
+    end
+  end
+
+  # Returns: name of the barclamp and of the proposal for this cluster
+  def cluster_get_barclamp_and_proposal(element)
+    result = nil
+
+    if defined?(PacemakerServiceObject)
+      result ||= PacemakerServiceObject.cluster_get_barclamp_and_proposal(element)
+    end
+
+    result ||= [nil, nil]
+  end
+
+  def is_cluster?(element)
+    result = false
+
+    if defined?(PacemakerServiceObject)
+      result ||= PacemakerServiceObject.is_cluster?(element)
+    end
+
+    result
+  end
+
+  # Returns: name of the cluster, or nil if it's not a cluster
+  def cluster_name(element)
+    name = nil
+
+    if defined?(PacemakerServiceObject)
+      name ||= PacemakerServiceObject.cluster_name(element)
+    end
+
+    name
+  end
+
+  def cluster_exists?(element)
+    !available_clusters[element].nil?
+  end
+
+  # Returns: a list with two things:
+  #  - the list of all nodes in items; if item contains clusters, these
+  #    clusters will be expanded to the list of nodes they're made of
+  #    For instance [ node1, cluster1 ] will be expanded to [node1,
+  #    node1-of-cluster1, node2-of-cluster1]
+  #  - the list of items that are not nodes but that we failed to expand. This
+  #    can be used for knowing that expansion partially failed matters.
+  def expand_nodes_for_all(items)
+    nodes = []
+    failures = []
+
+    items.each do |item|
+      expanded = nil
+
+      if is_cluster? item
+        if defined?(PacemakerServiceObject)
+          expanded = PacemakerServiceObject.expand_nodes(item)
+        end
+
+        if expanded.nil?
+          failures << item
+        else
+          nodes.concat(expanded)
+        end
+      else
+        nodes << item
+      end
+    end
+
+    [nodes, failures]
+  end
+
+end

--- a/crowbar_framework/spec/models/service_object_spec.rb
+++ b/crowbar_framework/spec/models/service_object_spec.rb
@@ -9,6 +9,12 @@ describe ServiceObject do
       ["dns",     ["admin", "testing"] ],
     ]}
 
+  describe "service object" do
+    it "responds to include cluster method" do
+      service_object.should respond_to(:available_clusters)
+    end
+  end
+
   describe "validate_proposal_elements" do
     it "raises on duplicate nodes" do
       pe = proposal_elements


### PR DESCRIPTION
Move the proxy methods out into separate module, then include the module into ServiceObject. Add a trivial test that checks the inclusion.

The cluster-related methods are required, but are not directly related to the ServiceObject, so they're better kept in a separate file.
