### PR TITLE
fix broken unclaimed_physical_drives method

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -468,7 +468,10 @@ class NodeObject < ChefObject
   end
 
   def unclaimed_physical_drives
-    physical_drives.select { |disk| disk_owner(disk).blank? }
+    physical_drives.select do |disk, data|
+      device = unique_device_for(disk)
+      device && disk_owner(device).blank?
+    end
   end
 
   def physical_drives


### PR DESCRIPTION
The list returned by `phyisical_drives` contains two element lists where the
first element is the OS mount path/name for the device. This then needs to be
turned into the device unique name in order to use the
`disk_owner` method.

This also fixes the unclaimed physical disks validation in the cinder 
barclamp.

Fixes bnc#830868
