### PR TITLE
RFC: role locks (BNC#861527)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -384,7 +384,7 @@ class NodeObject < ChefObject
   def allocated=(value)
     return false if @role.nil?
     Rails.logger.info("Setting allocate state for #{@node.name} to #{value}")
-    @role.save do |role|
+    @role.save(:sync => true) do |role|
       role.default_attributes["crowbar"]["allocated"] = value
     end
     value

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -181,15 +181,18 @@ class RoleObject < ChefObject
     end
   end
 
-  def save
+  def save(options = {})
+    sync_role = options.fetch(:sync) { false }
+
     Rails.logger.debug("Saving role: #{@role.name} - #{crowbar_revision}")
     role_lock = FileLock.acquire "role:#{@role.name}"
     begin
-      if block_given?
+      if sync_role
         upstream_role = RoleObject.find_role_by_name(@role.name)
         @role = upstream_role.role
-        yield(@role)
       end
+
+      yield(@role) if block_given?
 
       increment_crowbar_revision!
       @role.save


### PR DESCRIPTION
This is basically #1028, but missing a lock in allocate! (https://github.com/crowbar/barclamp-crowbar/pull/1028/files#diff-496ddf4ffc5694a5fcdddbff8206dc8dL384).

The problem I'm not sure how to solve is that we need to both sync the node and role attributes and also sync the role with whatever is in the chef DB, and if the node <> role sync should not be locked as well.
