### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -21,6 +21,7 @@ require 'chef'
 require 'json'
 
 class BarclampController < ApplicationController
+  before_filter :initialize_service
   before_filter :controller_to_barclamp
 
   def controller_to_barclamp
@@ -29,10 +30,6 @@ class BarclampController < ApplicationController
   end
 
   self.help_contents = Array.new(superclass.help_contents)
-  def initialize
-    super()
-    @service_object = ServiceObject.new logger
-  end
 
   #
   # Barclamp List (generic)
@@ -501,5 +498,10 @@ class BarclampController < ApplicationController
       flash[:alert] += ": " + answer[1].to_s unless answer[1].to_s.empty?
     end
   end
-end
 
+  protected
+
+  def initialize_service
+    @service_object = ServiceObject.new logger
+  end
+end

--- a/crowbar_framework/app/controllers/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/crowbar_controller.rb
@@ -18,8 +18,11 @@
 #
 
 class CrowbarController < BarclampController
-  def initialize
-    @service_object = CrowbarService.new(logger)
+
+  protected
+
+  def initialize_service
+    @service_object = CrowbarService.new logger
   end
 end
 


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.

The other barclamps will follow with a small fixing pull request.
