### PR TITLE
Fixed form field name for deployment dsl

### DIFF
--- a/crowbar_framework/lib/dsl/proposal/deployment.rb
+++ b/crowbar_framework/lib/dsl/proposal/deployment.rb
@@ -18,9 +18,9 @@ module Dsl
       def deployments_field
         tag(
           :input,
-          :id => "proposal_attributes",
+          :id => "proposal_deployment",
           :type => "hidden",
-          :name => "proposal_attributes",
+          :name => "proposal_deployment",
           :value => attrs.to_json
         )
       end


### PR DESCRIPTION
With the old value we can't save deployments oO
