### PR TITLE
Move crowbar_node and crowbar_data out of ChefObject

### DIFF
--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -51,24 +51,6 @@ class ChefObject
     str.gsub("-:") { |c| '\\' + c }
   end
 
-  def self.crowbar_node(name)
-    begin 
-      return Chef::Node.load(name)
-    rescue StandardError => e
-      Rails.logger.warn("Could not recover Chef Crowbar Node on load #{name}: #{e.inspect}")
-      return nil
-    end
-  end
-
-  def self.crowbar_data(bag_item)
-    begin 
-      return Chef::DataBag.load "crowbar/#{bag_item}"
-    rescue StandardError => e
-      Rails.logger.warn("Could not recover Chef Crowbar Data on load #{bag_item}: #{e.inspect}")
-      return nil
-    end
-  end
-
   def export(name = nil)
     name ||= self.respond_to?(:name) ? self.name : "unknown"
     file   = Rails.root.join("db", "#{self.chef_type}_#{name}.json")

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -76,7 +76,12 @@ class NodeObject < ChefObject
 
   def self.find_node_by_name(name)
     name += ".#{ChefObject.cloud_domain}" unless name =~ /(.*)\.(.)/
-    val = ChefObject.crowbar_node(name)
+    val = begin
+      Chef::Node.load(name)
+    rescue StandardError => e
+      Rails.logger.warn("Could not recover Chef Crowbar Node on load #{name}: #{e.inspect}")
+      nil
+    end
     return val.nil? ? nil : NodeObject.new(val)
   end
 

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -64,7 +64,12 @@ class ProposalObject < ChefObject
   end
 
   def self.find_proposal_by_id(id)
-    val = ChefObject.crowbar_data(id)
+    val = begin
+      Chef::DataBag.load "crowbar/#{id}"
+    rescue StandardError => e
+      Rails.logger.warn("Could not recover Chef Crowbar Data on load #{id}: #{e.inspect}")
+      nil
+    end
     return val.nil? ? nil : ProposalObject.new(val)
   end
 

--- a/crowbar_framework/spec/models/chef_object_spec.rb
+++ b/crowbar_framework/spec/models/chef_object_spec.rb
@@ -43,20 +43,4 @@ describe ChefObject do
       chef_object.cloud_domain
     end
   end
-
-  describe "crowbar_node" do
-    it "looks up a node by name" do
-      node = chef_object.crowbar_node("testing.crowbar.com")
-      node.should be_a(Chef::Node)
-      node.name.should == "testing.crowbar.com"
-    end
-  end
-
-  describe "crowbar_data" do
-    it "looks up a data bag in crowbar namespace" do
-      data_bag = chef_object.crowbar_data("bc-crowbar-default")
-      data_bag.should be_a(Chef::DataBagItem)
-      data_bag.id.should == "bc-crowbar-default"
-    end
-  end
 end


### PR DESCRIPTION
These methods are specific to NodeObject and ProposalObject, so they
should not be inherited by other classes.

They were used only on two other places, so move them over to where
they're called.
