### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/barclamp_model/crowbar_framework/app/controllers/==BC-MODEL==_controller.rb
+++ b/crowbar_framework/barclamp_model/crowbar_framework/app/controllers/==BC-MODEL==_controller.rb
@@ -18,8 +18,10 @@
 #
 
 class ==^BC-MODEL==Controller < BarclampController
-  def initialize
+
+  protected
+
+  def initialize_service
     @service_object = ==^BC-MODEL==Service.new logger
   end
 end
-


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.

This was missing for the barclamp model.
