### PR TITLE
Node target_platform fallbacks to default_platform

### DIFF
--- a/crowbar_framework/app/helpers/application_helper.rb
+++ b/crowbar_framework/app/helpers/application_helper.rb
@@ -248,10 +248,6 @@ module ApplicationHelper
   end
 
   def default_platform
-    NodeObject.find('role:crowbar').each do |node|
-      return "#{node[:platform]}-#{node[:platform_version]}" if node.admin?
-    end
-
-    ""
+    NodeObject.default_platform
   end
 end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -61,6 +61,17 @@ class NodeObject < ChefObject
     end
   end
 
+  def self.default_platform
+    @@default_platform ||= begin
+      admin = NodeObject.find("role:crowbar").select { |n| n.admin? }.first
+      if admin.nil?
+        ""
+      else
+        "#{admin[:platform]}-#{admin[:platform_version]}"
+      end
+    end
+  end
+
   def self.find_node_by_public_name(name)
     nodes = self.find "crowbar_public_name:#{chef_escape(name)}"
     if nodes.length == 1
@@ -148,8 +159,12 @@ class NodeObject < ChefObject
     @node = node
   end
 
+  def default_platform
+    self.class.default_platform
+  end
+
   def target_platform
-    @node[:target_platform]
+    @node[:target_platform] || default_platform
   end
 
   def pretty_target_platform


### PR DESCRIPTION
The default platform of the nodes is inferred from the platform of the
admin node (and is empty if there's no admin node - possible bug?)

Move the default_platform helper code to NodeObject class, where it gets
cached.

Then use it in the target_platform as a fallback.
