### PR TITLE
[WIP] Refactor chef finder methods into a single module

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -17,7 +17,7 @@
 
 module NodesHelper
   def nodes_by_role(role)
-    NodeObject.find("roles:#{role}").sort_by(&:alias)
+    NodeObject.where(:roles => role).sort_by(&:alias)
   end
 
   def piechart_for(group)

--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -16,7 +16,10 @@
 #
 
 class ChefObject
-  class_attribute :chef_type
+  class << self
+    include ChefFinders
+    include Deprecate
+  end
 
   @@CrowbarDomain = nil
   
@@ -53,7 +56,7 @@ class ChefObject
 
   def export(name = nil)
     name ||= self.respond_to?(:name) ? self.name : "unknown"
-    file   = Rails.root.join("db", "#{self.chef_type}_#{name}.json")
+    file   = Rails.root.join("db", "#{self.class.chef_type}_#{name}.json")
     File.open(file, "w") { |f| f.write(self.to_json) }
   end
 end

--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -40,20 +40,6 @@ class ChefObject
     end
   end
 
-  def self.query_chef
-    begin
-      return Chef::Search::Query.new
-    rescue Errno::ECONNREFUSED => e
-      raise Crowbar::Error::ChefOffline.new
-    rescue StandardError => e
-      return Chef::Node.new
-    end
-  end
-
-  def self.chef_escape(str)
-    str.gsub("-:") { |c| '\\' + c }
-  end
-
   def export(name = nil)
     name ||= self.respond_to?(:name) ? self.name : "unknown"
     file   = Rails.root.join("db", "#{self.class.chef_type}_#{name}.json")

--- a/crowbar_framework/app/models/client_object.rb
+++ b/crowbar_framework/app/models/client_object.rb
@@ -18,11 +18,6 @@
 class ClientObject < ChefObject
   attr_reader :client
 
-  class << self
-    include ChefFinders
-    include Deprecate
-  end
-
   def initialize(client)
     @client = client
   end

--- a/crowbar_framework/app/models/client_object.rb
+++ b/crowbar_framework/app/models/client_object.rb
@@ -16,26 +16,35 @@
 #
 
 class ClientObject < ChefObject
-  def self.find_client_by_name(name)
-    begin
-      return ClientObject.new Chef::ApiClient.load(name)
-    rescue Errno::ECONNREFUSED => e
-      raise Crowbar::Error::ChefOffline.new
-    rescue StandardError => e
-      Rails.logger.fatal("Failed to find client: #{name} #{e.message}")
-      return nil
-    end
+  attr_reader :client
+
+  class << self
+    include ChefFinders
+    include Deprecate
   end
 
   def initialize(client)
     @client = client
   end
 
+  def self.chef_class
+    Chef::ApiClient
+  end
+
+  def self.chef_type
+    "api_client"
+  end
+
+  def self.find_client_by_name(name)
+    deprecate_warning("load(name)", __FILE__, __LINE__)
+    load(name)
+  end
+
   def save
-    @client.save
+    client.save
   end
 
   def destroy
-    @client.destroy
+    client.destroy
   end
 end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -21,11 +21,6 @@ require 'timeout'
 class NodeObject < ChefObject
   attr_reader :node, :role
 
-  class << self
-    include ChefFinders
-    include Deprecate
-  end
-
   def self.chef_class
     Chef::Node
   end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -37,9 +37,9 @@ class NodeObject < ChefObject
     deprecate_warning("where(:key => 'value1', :another => 'value2') or find_by_key_and_another(value1, value2)", __FILE__, __LINE__)
     answer = []
     nodes = if search.nil?
-      ChefObject.query_chef.search "node"
+      query_object.search "node"
     else
-      ChefObject.query_chef.search "node", "#{chef_escape(search)}"
+      query_object.search "node", "#{chef_escape(search)}"
     end
 
     if nodes.is_a?(Array) and nodes[2] != 0 and !nodes[0].nil?

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -52,7 +52,7 @@ class NodeObject < ChefObject
       answer = nodes[0].map do |x|
         NodeObject.new x
       end
-      answer.delete_if { |x| @role.nil? }
+      answer.delete_if { |x| x.role.nil? }
     end
     return answer
   end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -19,9 +19,27 @@ require 'chef/mixin/deep_merge'
 require 'timeout'
 
 class NodeObject < ChefObject
-  self.chef_type = "node"
+  attr_reader :node, :role
+
+  class << self
+    include ChefFinders
+    include Deprecate
+  end
+
+  def self.chef_class
+    Chef::Node
+  end
+
+  def self.chef_type
+    "node"
+  end
+
+  def self.after_find_filter(nodes)
+    nodes.compact.reject { |n| n.role.nil? }
+  end
 
   def self.find(search)
+    deprecate_warning("where(:key => 'value1', :another => 'value2') or find_by_key_and_another(value1, value2)", __FILE__, __LINE__)
     answer = []
     nodes = if search.nil?
       ChefObject.query_chef.search "node"
@@ -34,32 +52,28 @@ class NodeObject < ChefObject
       answer = nodes[0].map do |x|
         NodeObject.new x
       end
-      answer.delete_if { |x| !x.has_chef_server_roles? }
+      answer.delete_if { |x| @role.nil? }
     end
     return answer
   end
 
-  def has_chef_server_roles?
-      return !@role.nil?
-  end
-
   def self.find_all_nodes
-    self.find nil
+    deprecate_warning("all", __FILE__, __LINE__)
+    all
   end
 
   def self.find_nodes_by_name(name)
-    self.find "name:#{chef_escape(name)}"
+    deprecate_warning("find_all_by_name(name) or where(:name => name)", __FILE__, __LINE__)
+    where(:name => name)
   end
 
+  # FIXME: is duplicated node aliases valid use case?
   def self.find_node_by_alias(name)
-    nodes = self.find_all_nodes.select { |n| n.alias.downcase == name.downcase }
-    if nodes.length == 1
-      return nodes[0]
-    elsif nodes.length == 0
-      nil
-    else
-      raise "#{I18n.t('multiple_node_alias', :scope => 'model.node')}: #{nodes.join(',')}"
+    nodes = all.select { |n| n.alias.downcase == name.downcase }
+    if nodes.length > 1
+      raise "#{I18n.t('multiple_node_alias', :scope=>'model.node')}: #{nodes.join(',')}"
     end
+    nodes.first
   end
 
   def self.default_platform
@@ -109,41 +123,21 @@ class NodeObject < ChefObject
   end
 
   def self.find_node_by_public_name(name)
-    nodes = self.find "crowbar_public_name:#{chef_escape(name)}"
-    if nodes.length == 1
-      return nodes[0]
-    elsif nodes.length == 0
-      nil
-    else
-      raise "#{I18n.t('multiple_node_public_name', :scope => 'model.node')}: #{nodes.join(',')}"
+    nodes = where(:crowbar_public_name => name)
+    if nodes.length > 1
+      raise "#{I18n.t('multiple_node_public_name', :scope=>'model.node')}: #{nodes.join(',')}"
     end
+    nodes.first
   end
 
   def self.find_node_by_name(name)
     name += ".#{ChefObject.cloud_domain}" unless name =~ /(.*)\.(.)/
-    val = begin
-      Chef::Node.load(name)
-    rescue Errno::ECONNREFUSED => e
-      raise Crowbar::Error::ChefOffline.new
-    rescue StandardError => e
-      Rails.logger.warn("Could not recover Chef Crowbar Node on load #{name}: #{e.inspect}")
-      nil
-    end
-    return val.nil? ? nil : NodeObject.new(val)
+    deprecate_warning("load(name) and fix the missing cloud_domain at the call site if possible", __FILE__, __LINE__)
+    load(name)
   end
 
   def self.find_node_by_name_or_alias(name)
-    node = find_node_by_name(name)
-
-    if node.nil?
-      find_node_by_alias(name)
-    else
-      node
-    end
-  end
-
-  def self.all
-    self.find nil
+    find_by_name(name) || find_node_by_alias(name)
   end
 
   def self.make_role_name(name)

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -18,11 +18,6 @@
 class ProposalObject < ChefObject
   attr_reader :item
 
-  class << self
-    include ChefFinders
-    include Deprecate
-  end
-
   def self.chef_type
     "crowbar"
   end

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -16,39 +16,39 @@
 #
 
 class ProposalObject < ChefObject
-  self.chef_type = "data_bag_item"
+  attr_reader :item
+
+  class << self
+    include ChefFinders
+    include Deprecate
+  end
+
+  def self.chef_type
+    "crowbar"
+  end
+
+  def self.chef_class
+    Chef::DataBag
+  end
+
+  def self.after_find_filter(proposals)
+    proposals.compact.reject { |p| p.item.nil? }
+  end
 
   BC_PREFIX = 'bc-template-'
 
   def self.find_data_bag_item(bag)
-    begin
-      bag = ProposalObject.new(Chef::DataBag.load bag)  #should use new syntax
-      return bag
-    rescue Errno::ECONNREFUSED => e
-      raise Crowbar::Error::ChefOffline.new
-    rescue StandardError => e
-      return nil
-    end
+    deprecate_warning("load(bag)", __FILE__, __LINE__)
+    load(bag)
   end
-  
+
   def self.find(search)
-    props = [] 
-    begin
-      arr = ChefObject.query_chef.search("crowbar", "id:#{chef_escape(search)}") 
-      if arr[2] != 0
-        props = arr[0].map do |x| 
-          ProposalObject.new x 
-        end
-        props.delete_if { |x| x.nil? or x.item.nil? }
-      end
-    rescue StandardError => e
-       Rails.logger.error("Could not recover Chef Crowbar data searching for '#{search}' due to '#{e.inspect}'")
-    end
-    return props
+    deprecate_warning("where(:id => search)", __FILE__, __LINE__)
+    where(:id => search)
   end
-    
+
   def self.all
-    self.find 'bc-*'
+    where(:id => 'bc-*')
   end
 
   def self.select_proposals(barclamp, all = ProposalObject.all)
@@ -56,27 +56,24 @@ class ProposalObject < ChefObject
   end
 
   def self.find_proposals(barclamp)
-    self.find "bc-#{barclamp}-*"
-  end
-
-  def self.find_barclamp(barclamp)
-    self.find_proposal_by_id "bc-template-#{barclamp}"
+    where(:id => "bc-#{barclamp}-*")
   end
 
   def self.find_proposal(barclamp, name)
-    self.find_proposal_by_id "bc-#{barclamp}-#{name}"
+    load("crowbar/bc-#{barclamp}-#{name}")
+  end
+
+  def self.find_barclamps
+    where(:id => "bc-tempate-*")
+  end
+
+  def self.find_barclamp(barclamp)
+    load("crowbar/bc-template-#{barclamp}")
   end
 
   def self.find_proposal_by_id(id)
-    val = begin
-      Chef::DataBag.load "crowbar/#{id}"
-    rescue Errno::ECONNREFUSED => e
-      raise Crowbar::Error::ChefOffline.new
-    rescue StandardError => e
-      Rails.logger.warn("Could not recover Chef Crowbar Data on load #{id}: #{e.inspect}")
-      nil
-    end
-    return val.nil? ? nil : ProposalObject.new(val)
+    deprecate_warning('load("crowbar/#{id}")', __FILE__, __LINE__)
+    load("crowbar/#{id}")
   end
 
   def raw_attributes
@@ -125,10 +122,6 @@ class ProposalObject < ChefObject
 
   def category
     @category ||= BarclampCatalog.category(barclamp)
-  end
-
-  def item
-    @item
   end
 
   def id

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -178,9 +178,9 @@ class RoleObject < ChefObject
     deprecate_warning("find_all_by_name(name) or where(:name => name)", __FILE__, __LINE__)
     roles = []
     arr = if search.nil?
-      ChefObject.query_chef.search "role"
+      query_object.search "role"
     else
-      ChefObject.query_chef.search "role", search
+      query_object.search "role", search
     end
     if arr[2] != 0
       roles = arr[0].map { |x| RoleObject.new x }

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -18,7 +18,7 @@
 require 'ostruct'
 
 class RoleObject < ChefObject
-  self.chef_type = "role"
+  attr_reader :role
 
   def cluster_roles(roles = RoleObject.all)
     @cluster_roles ||= begin
@@ -125,8 +125,21 @@ class RoleObject < ChefObject
     @role.name.to_s =~ /.*\-config\-.*/
   end
 
-  def self.all
-    self.find_roles_by_search(nil)
+  class << self
+    include Deprecate
+    include ChefFinders
+  end
+
+  def self.chef_type
+    "role"
+  end
+
+  def self.chef_class
+    Chef::Role
+  end
+
+  def self.after_find_filter(roles)
+    roles.compact.reject { |r| r.role.nil? }
   end
 
   def self.all_dependencies
@@ -149,25 +162,20 @@ class RoleObject < ChefObject
 
   def self.active(barclamp = nil, inst = nil)
     full = if barclamp.nil?
-      RoleObject.find_roles_by_name "*-config-*"
+      where(:name => "*-config-*")
     else
-      RoleObject.find_roles_by_name "#{barclamp}-config-#{inst || "*"}"
+      where(:name => "#{barclamp}-config-#{inst || "*"}")
     end
     full.map { |x| "#{x.barclamp}_#{x.inst}" }
   end
 
   def self.find_roles_by_name(name)
-    roles = []
-    #TODO this call could be moved to fild_roles_by_search
-    arr = ChefObject.query_chef.search "role", "name:#{chef_escape(name)}"
-    if arr[2] != 0
-      roles = arr[0].map { |x| RoleObject.new x }
-      roles.delete_if { |x| x.nil? or x.role.nil? }
-    end
-    roles
+    deprecate_warning("find_all_by_name(name) or where(:name => name)", __FILE__, __LINE__)
+    where(:name => name)
   end
 
   def self.find_roles_by_search(search)
+    deprecate_warning("find_all_by_name(name) or where(:name => name)", __FILE__, __LINE__)
     roles = []
     arr = if search.nil?
       ChefObject.query_chef.search "role"
@@ -182,14 +190,8 @@ class RoleObject < ChefObject
   end
 
   def self.find_role_by_name(name)
-    begin
-      return RoleObject.new Chef::Role.load(name)
-    rescue Errno::ECONNREFUSED => e
-      raise Crowbar::Error::ChefOffline.new
-    rescue Net::HTTPServerException => e
-      return nil if e.response.code == "404"
-      raise e
-    end
+    deprecate_warning("load(name)", __FILE__, __LINE__)
+    load(name)
   end
 
   def barclamp
@@ -229,10 +231,6 @@ class RoleObject < ChefObject
 
   def allow_multiple_proposals?
     ServiceObject.get_service(barclamp).allow_multiple_proposals?
-  end
-
-  def role
-    @role
   end
 
   def name

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -68,9 +68,9 @@ module ChefFinders
 
   def query_object
     begin
-      return Chef::Search::Query.new
+      Chef::Search::Query.new
     rescue
-      return Chef::Node.new
+      Chef::Node.new
     end
   end
 

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -43,7 +43,10 @@ module ChefFinders
 
   def load(id)
     begin
-      new(chef_class.load(id))
+      result = benchmark_query(id) do
+        chef_class.load(id)
+      end
+      new(result)
     rescue Net::HTTPServerException => e
       if e.response.code == "404"
         Rails.logger.warn("[chef search] #{chef_type} #{id} not found.")

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -1,0 +1,96 @@
+module ChefFinders
+  class RecordNotFound < StandardError; end
+
+  def chef_class
+    Class
+  end
+
+  def chef_type
+    "class"
+  end
+
+  def after_find_filter(results)
+    results
+  end
+
+  def method_missing(m, *a, &block)
+    return super unless m.to_s =~ /^find_(all_)?by_(.*?)(!)?$/
+
+    find_or_fail = !$3.blank?
+    find_first   =  $1.blank?
+    params       =  $2.split("_and_").map(&:to_sym)
+
+    unless params.count == a.count
+      raise ArgumentError.new("Wrong number of arguments (#{a.count} for #{params.count})")
+    end
+
+    args       = a.slice(0, params.count)
+    conditions = Hash[params.zip(args)]
+    result     = where(conditions)
+
+    if find_first && result
+      result = result.first
+    end
+
+    if find_or_fail && ( (find_first && result.nil?) || result.empty? )
+      raise RecordNotFound.new("Cannot find record matching query #{build_query(conditions)}")
+    end
+
+    result
+  end
+
+  def load(id)
+    begin
+      return new(chef_class.load(id))
+    rescue Net::HTTPServerException => e
+      if e.response.code == "404"
+        Rails.logger.warn("#{chef_class} #{id} not found.")
+        nil
+      else
+        raise e
+      end
+    end
+  end
+
+  def all
+    where(nil)
+  end
+
+  def where(conditions = nil)
+    results, offset, count = raw_search(conditions)
+    results.map! { |r| new(r) }
+    after_find_filter(results)
+  end
+
+  def chef_escape(str)
+    str.to_s.gsub("-:") { |c| '\\' + c }
+  end
+
+  def query_object
+    begin
+      return Chef::Search::Query.new
+    rescue
+      return Chef::Node.new
+    end
+  end
+
+  def raw_search(conditions = nil)
+    if conditions
+      query_object.search(chef_type, build_query(conditions))
+    else
+      query_object.search(chef_type)
+    end
+  end
+
+  def build_query(conditions = {}, op = :and)
+    conditions.map do |k, v|
+      if v.is_a?(Array)
+        v.map { |x| "#{k}:#{chef_escape(x)}" }.join(" #{op} ")
+      elsif v.is_a?(Hash)
+        "(" + build_query(v, k == :or ? :or : :and) + ")"
+      else
+        "#{k}:#{chef_escape(v)}"
+      end
+    end.join(" #{op} ")
+  end
+end

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -32,8 +32,10 @@ module ChefFinders
       result = result.first
     end
 
-    if find_or_fail && ( (find_first && result.nil?) || result.empty? )
-      raise RecordNotFound.new("Cannot find record matching query #{build_query(conditions)}")
+    if find_or_fail
+      if (find_first && result.nil?) || (!find_first && result.empty?)
+        raise RecordNotFound.new("Cannot find any records matching query #{build_query(conditions)}")
+      end
     end
 
     result

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -89,7 +89,7 @@ module ChefFinders
   end
 
   def benchmark_query(query)
-    ActiveRecord::Base.benchmark("[chef search] #{chef_type} #{query}") do
+    ActiveRecord::Base.benchmark("[chef search] #{chef_type} #{query}", Logger::DEBUG) do
       yield if block_given?
     end
   end

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -78,7 +78,15 @@ module ChefFinders
 
   def raw_search(conditions = {})
     query = build_query(conditions)
-    query_object.search(chef_type, query)
+    benchmark_query(query) do
+      query_object.search(chef_type, query)
+    end
+  end
+
+  def benchmark_query(query)
+    ActiveRecord::Base.benchmark("[chef search] #{chef_type} #{query}") do
+      yield if block_given?
+    end
   end
 
   def build_query(conditions = {}, op = :and)

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -1,14 +1,15 @@
 module ChefFinders
   class RecordNotFound < StandardError; end
+  class NotImplemented < StandardError; end
 
   # Chef::Node, Chef::Role, Chef::DataBag...
   def chef_class
-    Class
+    raise NotImplemented.new
   end
 
   # 'node', 'role', 'data_bag'...
   def chef_type
-    "class"
+    raise NotImplemented.new
   end
 
   def after_find_filter(results)

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -75,11 +75,8 @@ module ChefFinders
   end
 
   def raw_search(conditions = nil)
-    if conditions
-      query_object.search(chef_type, build_query(conditions))
-    else
-      query_object.search(chef_type)
-    end
+    query = build_query(conditions || {})
+    query_object.search(chef_type, query)
   end
 
   def build_query(conditions = {}, op = :and)

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -43,7 +43,7 @@ module ChefFinders
 
   def load(id)
     begin
-      return new(chef_class.load(id))
+      new(chef_class.load(id))
     rescue Net::HTTPServerException => e
       if e.response.code == "404"
         Rails.logger.warn("[chef search] #{chef_type} #{id} not found.")

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -46,7 +46,7 @@ module ChefFinders
       return new(chef_class.load(id))
     rescue Net::HTTPServerException => e
       if e.response.code == "404"
-        Rails.logger.warn("#{chef_class} #{id} not found.")
+        Rails.logger.warn("[chef search] #{chef_type} #{id} not found.")
         nil
       else
         raise e

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -90,7 +90,7 @@ module ChefFinders
   end
 
   def benchmark_query(query)
-    ActiveRecord::Base.benchmark("[chef search] #{chef_type} #{query}", Logger::DEBUG) do
+    ActiveRecord::Base.benchmark("[chef search] #{chef_type} #{query}", :level => :debug) do
       yield if block_given?
     end
   end

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -1,10 +1,12 @@
 module ChefFinders
   class RecordNotFound < StandardError; end
 
+  # Chef::Node, Chef::Role, Chef::DataBag...
   def chef_class
     Class
   end
 
+  # 'node', 'role', 'data_bag'...
   def chef_type
     "class"
   end

--- a/crowbar_framework/lib/chef_finders.rb
+++ b/crowbar_framework/lib/chef_finders.rb
@@ -53,10 +53,10 @@ module ChefFinders
   end
 
   def all
-    where(nil)
+    where
   end
 
-  def where(conditions = nil)
+  def where(conditions = {})
     results, offset, count = raw_search(conditions)
     results.map! { |r| new(r) }
     after_find_filter(results)
@@ -74,12 +74,14 @@ module ChefFinders
     end
   end
 
-  def raw_search(conditions = nil)
-    query = build_query(conditions || {})
+  def raw_search(conditions = {})
+    query = build_query(conditions)
     query_object.search(chef_type, query)
   end
 
   def build_query(conditions = {}, op = :and)
+    return chef_escape("*:*") if conditions.empty?
+
     conditions.map do |k, v|
       if v.is_a?(Array)
         v.map { |x| "#{k}:#{chef_escape(x)}" }.join(" #{op} ")

--- a/crowbar_framework/lib/deprecate.rb
+++ b/crowbar_framework/lib/deprecate.rb
@@ -1,0 +1,8 @@
+module Deprecate
+  def deprecate_warning(new_method, file, line, options = {})
+    old     = caller[0].match(/`(.*)'/)[1]
+    logger  = options.fetch(:logger) { Rails.logger }
+    message = options.fetch(:message) { "[DEPRECATED] #{old}, defined at #{file.gsub(RAILS_ROOT, '')} #{line} is deprecated and will be removed, please use #{new_method} instead.\nCalled from #{caller[3]}" }
+    logger.warn(message)
+  end
+end

--- a/crowbar_framework/lib/deprecate.rb
+++ b/crowbar_framework/lib/deprecate.rb
@@ -2,7 +2,7 @@ module Deprecate
   def deprecate_warning(new_method, file, line, options = {})
     old     = caller[0].match(/`(.*)'/)[1]
     logger  = options.fetch(:logger) { Rails.logger }
-    message = options.fetch(:message) { "[DEPRECATED] #{old}, defined at #{file.gsub(RAILS_ROOT, '')} #{line} is deprecated and will be removed, please use #{new_method} instead.\nCalled from #{caller[3]}" }
+    message = options.fetch(:message) { "[DEPRECATED] #{old}, defined at #{file.gsub(Rails.root.to_s, '')} #{line} is deprecated and will be removed, please use #{new_method} instead.\nCalled from #{caller[3]}" }
     logger.warn(message)
   end
 end

--- a/crowbar_framework/spec/lib/chef_finders_spec.rb
+++ b/crowbar_framework/spec/lib/chef_finders_spec.rb
@@ -24,7 +24,7 @@ describe ChefFinders do
     end
 
     it "joins multiple attributes with and" do
-      FinderKlass.build_query(:id => :something, :foo => :else).should == "foo:else and id:something"
+      FinderKlass.build_query(:foo => :else, :id => :something).should == "foo:else and id:something"
     end
 
     it "works with or as a string" do
@@ -32,7 +32,7 @@ describe ChefFinders do
     end
 
     it "works with or as a single hash" do
-      FinderKlass.build_query(:or => { :id => :something, :foo => :else }).should == "(foo:else or id:something)"
+      FinderKlass.build_query(:or => { :foo => :else, :id => :something}).should == "(foo:else or id:something)"
     end
 
     it "works with nested ors" do

--- a/crowbar_framework/spec/lib/chef_finders_spec.rb
+++ b/crowbar_framework/spec/lib/chef_finders_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe ChefFinders do
+  FinderKlass = Struct.new("FinderKlass") do
+    class << self
+      include ChefFinders
+    end
+  end
+
+  describe "build_query" do
+    it "concatenates single attribute and its value" do
+      FinderKlass.build_query(:id => :something).should == "id:something"
+    end
+
+    it "joins multiple attributes with and" do
+      FinderKlass.build_query(:id => :something, :foo => :else).should == "foo:else and id:something"
+    end
+
+    it "works with or as a string" do
+      FinderKlass.build_query(:or => :something).should == "or:something"
+    end
+
+    it "works with or as a single hash" do
+      FinderKlass.build_query(:or => { :id => :something, :foo => :else }).should == "(foo:else or id:something)"
+    end
+
+    it "works with nested ors" do
+      query = FinderKlass.build_query(:transitions => true, :or => { :transition_list => [:all, :running] })
+      query.should include("(transition_list:all or transition_list:running)")
+      query.should include("transitions:true")
+    end
+  end
+
+  describe "after_find_filter" do
+    it "is called after search" do
+      FinderKlass.expects(:after_find_filter).once
+      FinderKlass.all
+    end
+  end
+
+  describe "dynamic finders" do
+    it "resolves to regular finder" do
+      FinderKlass.expects(:where).with({:name => "test"}).once
+      FinderKlass.find_all_by_name("test")
+    end
+
+    it "accepts multiple params separated by and" do
+      FinderKlass.expects(:where).with({:name => "test", :foo => "bar"}).once
+      FinderKlass.find_all_by_name_and_foo("test", "bar")
+    end
+
+    it "raises argument error w/ too many arguments" do
+      expect {
+        FinderKlass.find_all_by_name("test", "bar", :raw => true)
+      }.to raise_error(ArgumentError)
+
+      expect {
+        FinderKlass.find_all_by_name("test", {:raw => true}, "bar")
+      }.to raise_error(ArgumentError)
+
+      expect {
+        FinderKlass.find_all_by_name("test", "bar")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises argument error w/ too few arguments" do
+      expect {
+        FinderKlass.find_all_by_name_and_foo("test")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "returns the collection" do
+      FinderKlass.stubs(:where).returns(["a", "b"])
+      FinderKlass.find_all_by_name("foo").should == ["a", "b"]
+    end
+
+    it "returns the first record if called w/o all" do
+      FinderKlass.stubs(:where).returns(["a", "b"])
+      FinderKlass.find_by_name_and_place("foo", "bar").should == "a"
+    end
+
+    it "raises w/ missing record when called with !" do
+      FinderKlass.stubs(:where).returns(nil)
+      expect {
+        FinderKlass.find_by_name_and_place!("foo", "bar")
+      }.to raise_error(ChefFinders::RecordNotFound)
+    end
+
+    it "raises w/ empty collection when called with !" do
+      FinderKlass.stubs(:where).returns([])
+      expect {
+        FinderKlass.find_all_by_name_and_place!("foo", "bar")
+      }.to raise_error(ChefFinders::RecordNotFound)
+    end
+  end
+end

--- a/crowbar_framework/spec/lib/chef_finders_spec.rb
+++ b/crowbar_framework/spec/lib/chef_finders_spec.rb
@@ -1,9 +1,20 @@
 require 'spec_helper'
 
 describe ChefFinders do
-  FinderKlass = Struct.new("FinderKlass") do
+  class FinderKlass
     class << self
       include ChefFinders
+    end
+
+    def initialize(item)
+    end
+
+    def self.chef_type
+      "node"
+    end
+
+    def self.chef_class
+      Chef::Node
     end
   end
 

--- a/crowbar_framework/spec/models/chef_object_spec.rb
+++ b/crowbar_framework/spec/models/chef_object_spec.rb
@@ -32,17 +32,6 @@ describe ChefObject do
     end
   end
 
-  describe "query chef" do
-    it "returns new query" do
-      chef_object.query_chef.should be_a(Chef::Search::Query)
-    end
-
-    it "returns empty node on failure" do
-      Chef::Search::Query.stubs(:new).raises(StandardError)
-      chef_object.query_chef.should be_a(Chef::Node)
-    end
-  end
-
   describe "cloud domain" do
     it "looks up the proposal object" do
       domain = "localdomain"

--- a/crowbar_framework/spec/models/client_object_spec.rb
+++ b/crowbar_framework/spec/models/client_object_spec.rb
@@ -2,9 +2,14 @@ require 'spec_helper'
 
 describe ClientObject do
   describe "finders" do
-    describe "interface" do
-      it "responds to find_client_by_name" do
+    describe "find_client_by_name" do
+      it "responds to it" do
         ClientObject.should respond_to(:find_client_by_name)
+      end
+
+      it "prints a deprecation warning" do
+        ClientObject.expects(:deprecate_warning).once
+        ClientObject.find_client_by_name("test")
       end
     end
   end

--- a/crowbar_framework/spec/models/client_object_spec.rb
+++ b/crowbar_framework/spec/models/client_object_spec.rb
@@ -8,6 +8,7 @@ describe ClientObject do
       end
 
       it "prints a deprecation warning" do
+        ClientObject.stubs(:load).returns(true)
         ClientObject.expects(:deprecate_warning).once
         ClientObject.find_client_by_name("test")
       end


### PR DESCRIPTION
Refactor the chef finders into a single module, then include them into *Objects.

This can help in debugging and profiling the chef queries, and keeps the syntax consistent across the *Object classes.

The existing methods were covered by tests (#1041), to ensure the API won't change. Also, they now emit a deprecation warning to help in transitioning to the new syntax.

The patch set is currently not field tested, which is why its marked WIP.