### PR TITLE
Display node list in node show view as well

### DIFF
--- a/crowbar_framework/app/views/nodes/_node_groups.html.haml
+++ b/crowbar_framework/app/views/nodes/_node_groups.html.haml
@@ -1,0 +1,34 @@
+- if @draggable
+  .alert.alert-info{ "data-id" => "AUTOMATIC", "data-droppable" => "true" }
+    = t(".drag_hint")
+
+#nodegroups.row
+  - @groups.sort.each do |group_name, group|
+    .col-xs-3{ "data-id" => group_name, "data-droppable" => @draggable, "data-group" => group_name }
+      .panel.panel-default
+        .panel-heading
+          %h2
+            = piechart_for group
+            = truncate(group_name || t("unknown"), :length => 25)
+
+        %ul.list-group
+          - group[:nodes].values.sort_by { |handle| @nodes[handle][:alias] }.each do |handle|
+            - @nodes[handle].tap do |node|
+              %li.list-group-item{ "data-id" => handle.parameterize, "data-draggable" => @draggable, "data-update" => group_change_path(:id => handle.parameterize, :group => "{0}".html_safe) }
+                %span.led{ :class => node[:status], :title => t(node[:state], :scope => "state", :default => node[:state].titlecase), "data-node" => handle }
+                = link_to(truncate(node[:alias], :length => 25), node_path(handle), :title => node[:description])
+
+- if @draggable
+  %script#group-panel{ :type => "text/x-handlebars-template" }
+    .col-xs-3.group-panel{ "data-id" => "{{group}}", "data-droppable" => @draggable }
+      .panel.panel-default
+        .panel-heading
+          %h2
+            = link_to icon_tag("trash"), "#", "data-group-delete" => "true"
+
+            %span
+              {{group}}
+
+        %ul.list-group
+          %li.list-group-item.empty
+            = t(".new_drag")

--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -25,3 +25,5 @@
 
       .btn-group
         = render :partial => "buttons_chef"
+
+= render "node_groups"

--- a/crowbar_framework/app/views/nodes/index.html.haml
+++ b/crowbar_framework/app/views/nodes/index.html.haml
@@ -14,42 +14,11 @@
             .input-group-btn
               = submit_tag t(".add"), :class => "btn btn-default input-sm"
 
-.alert.alert-info{ "data-id" => "AUTOMATIC", "data-droppable" => "true" }
-  = t(".drag_hint")
-
-#nodegroups.row
-  - @groups.sort.each do |group_name, group|
-    .col-xs-3{ "data-id" => group_name, "data-droppable" => "true", "data-group" => group_name }
-      .panel.panel-default
-        .panel-heading
-          %h2
-            = piechart_for group
-            = truncate(group_name || t("unknown"), :length => 25)
-
-        %ul.list-group
-          - group[:nodes].values.sort_by { |handle| @nodes[handle][:alias] }.each do |handle|
-            - @nodes[handle].tap do |node|
-              %li.list-group-item{ "data-id" => handle.parameterize, "data-draggable" => "true", "data-update" => group_change_path(:id => handle.parameterize, :group => "{0}".html_safe) }
-                %span.led{ :class => node[:status], :title => t(node[:state], :scope => "state", :default => node[:state].titlecase), "data-node" => handle }
-                = link_to(truncate(node[:alias], :length => 25), node_path(handle), :title => node[:description])
-
-%script#group-panel{ :type => "text/x-handlebars-template" }
-  .col-xs-3.group-panel{ "data-id" => "{{group}}", "data-droppable" => "true" }
-    .panel.panel-default
-      .panel-heading
-        %h2
-          = link_to icon_tag("trash"), "#", "data-group-delete" => "true"
-
-          %span
-            {{group}}
-
-      %ul.list-group
-        %li.list-group-item.empty
-          = t(".new_drag")
-
 %script#group-invalid{ :type => "text/x-handlebars-template" }
   .alert.alert-danger.alert-dismissable.group-invalid
     %button.close{ :type => "button", "data-dismiss" => "alert", "aria-hidden" => true }
       &times;
 
     = t(".add_group_error")
+
+= render "node_groups"


### PR DESCRIPTION
https://bugzilla.novell.com/show_bug.cgi?id=872347#c5

Once in the node show view, there is no easy way to navigate to other node w/o going to the dashboard.

Display the (uneditable) node list below the node info.

Refactor the fetching of node groups into a separate method, then re-use it in the show action. Similarly, split out the node list table into a partial, then render the partial in both the index and the show views.
