### PR TITLE
Fix export

### DIFF
--- a/crowbar_framework/app/controllers/support_controller.rb
+++ b/crowbar_framework/app/controllers/support_controller.rb
@@ -138,8 +138,8 @@ class SupportController < ApplicationController
         exports = Dir.glob(Rails.root.join("db", "*.json").to_s)
         cmd     = ["tar", "-czf", Rails.root.join("tmp", filename), *exports]
 
-        system(*cmd)
-        File.rename(Rails.root.join("tmp", filename), export_dir.join(filename))
+        ok = system(*cmd)
+        File.rename(Rails.root.join("tmp", filename), export_dir.join(filename)) if ok
       end
 
       Process.detach(pid)


### PR DESCRIPTION
Due to shell expansion not being in effect when calling system with
array of arguments, the tarball w/ chef export ended up empty.

Pass a list of files to be archived as individual arguments instead
of a glob.
