### PR TITLE
Ubuntu fix for uncreated run directory.

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -142,6 +142,14 @@ else
   end
 end
 
+directory "/var/run/crowbar" do
+  owner "crowbar"
+  group "crowbar"
+  mode "755"
+  action :create
+  only_if { node[:platform] == "ubuntu" }
+end
+
 # mode 0755 so subdirs can be nfs mounted to admin-exported shares
 directory logdir do
   owner "crowbar"


### PR DESCRIPTION
Because the directory is not created, PXE installations fails with
waiting *.install files and rebooting again.
