### PR TITLE
Fix i18n strings moved in #1059

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -293,6 +293,7 @@ en:
       add: 'Add'
       add_group_error: 'Group name should start with a letter and only contain letters, digits, -, _, ., or :.'
       hide: 'Hide Group'
+    node_groups:
       drag_hint: 'You may regroup nodes by dragging a node into the desired group. You may drop a node [here] to reset to <i>automatic grouping</i>.'
       new_drag: 'To move nodes, drag onto this box'
     list:


### PR DESCRIPTION
in #1059 a part of the nodes view was moved into a partial. With it, the relative paths in `t()` ceased referencing the correct strings. This patch fixes the locale file so they work again.
