### PR TITLE
Fixed form field name for deployment dsl

### DIFF
--- a/crowbar_framework/lib/dsl/proposal/deployment.rb
+++ b/crowbar_framework/lib/dsl/proposal/deployment.rb
@@ -18,9 +18,9 @@ module Dsl
       def deployments_field
         tag(
           :input,
-          :id => "proposal_attributes",
+          :id => "proposal_deployment",
           :type => "hidden",
-          :name => "proposal_attributes",
+          :name => "proposal_deployment",
           :value => attrs.to_json
         )
       end


### PR DESCRIPTION
Without this saving the crowbar proposal after the initial deployment fails
with an "can't convert nil into String" error.

Fixes https://bugzilla.novell.com/show_bug.cgi?id=883408
(cherry picked from commit 9162532520d7e1972ad4d6e8052e539571237450)
