### PR TITLE
Run brakeman automatically in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ before_install:
   - gem --version
 install:
   - cd crowbar_framework
-  - bundle install --without development
+  - bundle install
   - bundle exec rake db:migrate
   - sed -i -e "s#use_bundler\:\ false#use_bundler\:\ true#" config/app_config.yml
   - cp config/catalog.yml.example config/catalog.yml
 script:
   - bundle exec rake spec
+  - bundle exec rake brakeman:run


### PR DESCRIPTION
As we're already including brakeman in our gem bundle, it'd be nice
to actually run it automatically.

When we're green w/ the vulnerabilities, we can turn on the -z option
and let the build fail on new ones.
