### PR TITLE
Add zeropad class to td, th elements

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/content/table.css.scss
+++ b/crowbar_framework/app/assets/stylesheets/content/table.css.scss
@@ -73,5 +73,9 @@ table {
         margin-bottom: 0;
       }
     }
+
+    &.zeropad {
+      padding: 0 !important;
+    }
   }
 }


### PR DESCRIPTION
Part of a fix for https://bugzilla.novell.com/show_bug.cgi?id=859074 in https://github.com/crowbar/barclamp-provisioner/pull/315
