### PR TITLE
Selecting raw mode w/o loosing data (bnc#882976)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -7,11 +7,13 @@
 
 jQuery(document).ready(function($) {
   $('textarea.editor').each(function() {
-    CodeMirror.fromTextArea(this, {
+    var cm = CodeMirror.fromTextArea(this, {
       lineNumbers: true,
       matchBrackets: true,
       tabSize: 2
     });
+
+    $(this).data('codeMirror', cm);
   });
 
   $('[data-default]').each(function() {
@@ -238,6 +240,7 @@ jQuery(document).ready(function($) {
   $('[data-ledupdate]').ledUpdate();
   $('[data-show-for-clusters-only="true"]').hideShowClusterConf();
 
+  $('#proposal_attributes, #proposal_deployment').changedState();
   $('#nodelist').nodeList();
   $('input[type=password]').hideShowPassword();
 

--- a/crowbar_framework/app/assets/javascripts/jquery.js
+++ b/crowbar_framework/app/assets/javascripts/jquery.js
@@ -14,3 +14,4 @@
 //= require jquery/updateAttribute
 //= require jquery/messages
 //= require jquery/dynamicTable
+//= require jquery/changeDetection

--- a/crowbar_framework/app/assets/javascripts/jquery/changeDetection.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/changeDetection.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2011-2013, Dell
+ * Copyright 2013-2014, SUSE LINUX Products GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+;(function($, doc, win) {
+  'use strict';
+
+  function ChangedState(el, options) {
+    this.$el = $(el);
+
+    this.defaults = {
+      attribute: 'changedState',
+      sourceEvents: 'change',
+      targetElements: 'a.customview, a.rawview, .nav a',
+      targetEvents: 'click',
+      message: this.$el.data('changed-state')
+    };
+
+    this.options = $.extend(
+      this.defaults,
+      options
+    );
+
+    this.init();
+  }
+
+  ChangedState.prototype.init = function() {
+    var self = this;
+    var state = false;
+
+    var cm = this.$el.data('codeMirror');
+
+    this.$el.live(
+      self.options.sourceEvents,
+      function() {
+        state = true;
+      }
+    );
+
+    if (cm) {
+      cm.setOption('onChange', function() {
+        state = true;
+      });
+    }
+
+    $(self.options.targetElements).live(
+      self.options.targetEvents,
+      function(event) {
+        if (state) {
+          if (!confirm(self.options.message)) {
+            event.preventDefault();
+          }
+        }
+      }
+    );
+  };
+
+  $.fn.changedState = function(options) {
+    return this.each(function() {
+      new ChangedState(this, options);
+    });
+  };
+}(jQuery, document, window));

--- a/crowbar_framework/app/assets/javascripts/jquery/jsonAttribute.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/jsonAttribute.js
@@ -36,7 +36,7 @@
   JsonAttribute.prototype.writeJson = function() {
     this.el.val(
       JSON.stringify(this.json)
-    );
+    ).trigger('change');
   };
 
   JsonAttribute.prototype.write = function(key, value, type) {

--- a/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
@@ -91,11 +91,10 @@
           self.json.elements[role].remove(value);
         });
 
+        self.updateJson();
         self.removedNodes();
       }
     });
-
-    self.updateJson();
   };
 
   NodeList.prototype.initDraggable = function() {
@@ -180,7 +179,7 @@
 
     self.input.val(
       JSON.stringify(self.json)
-    );
+    ).trigger('change');
   };
 
   NodeList.prototype.errorMessage = function(message) {
@@ -307,8 +306,6 @@
             break;
           default:
             if (self.json.elements[role].length >= constraints.count) {
-              console.log(alias, role, self.json.elements[role].length, constraints.count);
-
               return self.errorMessage(
                 'barclamp.node_selector.max_count'.localize().format(
                   alias,

--- a/crowbar_framework/app/views/barclamp/_edit_attributes_raw.html.haml
+++ b/crowbar_framework/app/views/barclamp/_edit_attributes_raw.html.haml
@@ -9,8 +9,8 @@
 .panel-body
   .form-group
     - if request.env['HTTP_USER_AGENT'].downcase.index('msie 7')
-      %textarea#proposal_attributes{ :name => "proposal_attributes", :rows => 30, :cols => 80 }
+      %textarea#proposal_attributes{ :name => "proposal_attributes", :rows => 30, :cols => 80, :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
         = @proposal.pretty_attributes_json
     - else
-      %textarea#proposal_attributes.editor{ :name => "proposal_attributes" }
+      %textarea#proposal_attributes.editor{ :name => "proposal_attributes", :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
         = @proposal.pretty_attributes_json

--- a/crowbar_framework/app/views/barclamp/_edit_deployment_raw.html.haml
+++ b/crowbar_framework/app/views/barclamp/_edit_deployment_raw.html.haml
@@ -9,8 +9,8 @@
 .panel-body
   .form-group
     - if request.env['HTTP_USER_AGENT'].downcase.index('msie 7')
-      %textarea#proposal_deployment{ :name => "proposal_deployment", :rows => 30, :cols => 80 }
+      %textarea#proposal_deployment{ :name => "proposal_deployment", :rows => 30, :cols => 80, :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
         = @proposal.pretty_deployment_json
     - else
-      %textarea#proposal_deployment.editor{ :name => "proposal_deployment" }
+      %textarea#proposal_deployment.editor{ :name => "proposal_deployment", :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
         = @proposal.pretty_deployment_json

--- a/crowbar_framework/app/views/barclamp/_node_selector.html.haml
+++ b/crowbar_framework/app/views/barclamp/_node_selector.html.haml
@@ -7,7 +7,7 @@
         = t(".msie_fail")
 
 - else
-  %input#proposal_deployment{ :type => "hidden", :name => "proposal_deployment", :value => @proposal.raw_deployment.to_json }
+  %input#proposal_deployment{ :type => "hidden", :name => "proposal_deployment", :value => @proposal.raw_deployment.to_json, :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
 
   .panel-sub
     %h3

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -189,6 +189,7 @@ en:
       duplicate_elements_in_role: 'Duplicate elements detected in role'
       unknown_node: 'Unable to find any node named'
       unknown_cluster: 'Unable to find any cluster named'
+      unsaved_changes: 'You might have unsaved changes; do you really want to switch to another page?'
 
   docs:
     index:

--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -47,7 +47,8 @@ module Dsl
           :id => "proposal_attributes",
           :type => "hidden",
           :name => "proposal_attributes",
-          :value => attrs.to_json
+          :value => attrs.to_json,
+          "data-changed-state" => I18n.t("proposal.failures.unsaved_changes")
         )
       end
 

--- a/crowbar_framework/lib/dsl/proposal/deployment.rb
+++ b/crowbar_framework/lib/dsl/proposal/deployment.rb
@@ -38,7 +38,8 @@ module Dsl
           :id => "proposal_deployment",
           :type => "hidden",
           :name => "proposal_deployment",
-          :value => attrs.to_json
+          :value => attrs.to_json,
+          "data-changed-state" => I18n.t("proposal.failures.unsaved_changes")
         )
       end
 


### PR DESCRIPTION
The ticket https://bugzilla.novell.com/show_bug.cgi?id=882976 explains
that we loose data if we switch from the custom proposal form into raw
proposal form.

To prevent loosing data i have integrated a confirmation dialog that
have to be accepted before we can switch to another page if we have
changed something on the current proposal form.

This solution is a shortterm solution until we get a better javascript
library with dynamic data binding to switch between raw and custom view
without a page reload and without loosing data.
