### PR TITLE
Switch rspec format to nested

### DIFF
--- a/crowbar_framework/spec/spec.opts
+++ b/crowbar_framework/spec/spec.opts
@@ -1,4 +1,4 @@
 --colour
---format progress
+--format nested
 --loadby mtime
 --reverse


### PR DESCRIPTION
Makes test results more readable (and they can also serve as a documentation).
