### PR TITLE
Pinned ohai version

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -38,6 +38,7 @@ gem "tilt", "1.3.3"
 gem "mime-types", "1.18", :require => "mime/types"
 
 gem "chef", "~> 10.0"
+gem "ohai", "~> 6.14"
 
 group :development do
   gem "brakeman", "1.8.2"


### PR DESCRIPTION
While working with bundler for development it tries to install ohai 7
without this version constraint and the new ohai version is not the
version we currently want to ship and it produces some warnings on the
quite outdated ruby 1.8 version.
