### PR TITLE
Added more strict gem version constraint

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -37,8 +37,8 @@ gem "syslogger", "1.3.0"
 gem "tilt", "1.3.3"
 gem "mime-types", "1.18", :require => "mime/types"
 
-gem "chef", "~> 10.0"
-gem "ohai", "~> 6.14"
+gem "chef", "~> 10.24.0"
+gem "ohai", "~> 6.14.0"
 
 group :development do
   gem "brakeman", "1.8.2"


### PR DESCRIPTION
I have added a more strict version constraint because the previous
versioning doesn't work if you work on the git base. If you bundle
install in the crowbar_framework folder it always installs upstream chef
10.32.x and ohai 6.22.x. Installing this chef version breaks pacemaker
as it works with subfolders on libraries folders, these files won't get
uploaded to the chef server with upstream chef client.
