### PR TITLE
Lookup dynamic form path translations with a fixed string

### DIFF
--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -242,6 +242,10 @@ module Dsl
         translation_key = attribute.clone
         translation_key.unshift("")
 
+        translation_key.map! do |v|
+          v == "{{@index}}" ? "index" : v
+        end
+
         content_tag(
           :label,
           t(translation_key.join(".")),


### PR DESCRIPTION
When using Handlebarjs in order to generate dynamic form elements
in arrays, the lookup was done via "{{index}}". Replace that
with index to have a slightly nicer lookup path.
