### PR TITLE
Display IPMI ip address fallback

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -381,7 +381,7 @@ class NodesController < ApplicationController
         @node.networks.each do |intf, data|
           if data["usage"] == "bmc"
             ifname = "bmc"
-            address = @node["crowbar_wall"]["ipmi"]["address"] rescue nil
+            address = @node["crowbar_wall"]["ipmi"]["address"] rescue data["address"]
           else
             ifname, ifs, team = @node.lookup_interface_info(data["conduit"])
             if ifname.nil? or ifs.nil?


### PR DESCRIPTION
If you deploy the IPMI functionality after discovery you get no bmc
address displayed on the node detail page. With this fix we always
display as a fallback the network section entry as for other ip's too.

For further fixing like the crowbar wall link list we will try to plan that in an upcoming sprint.
