### PR TITLE
Fix the "for" bit of labels generated with the DSL

### DIFF
--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -252,7 +252,7 @@ module Dsl
         content_tag(
           :label,
           t(translation_key.join(".")),
-          :for => attribute
+          :for => sanitize_to_id(attribute_name)
         )
       end
 


### PR DESCRIPTION
We were missing all the _ between path elements.
