### PR TITLE
Store initial value for boolean selects in data-initial-value too

### DIFF
--- a/crowbar_framework/app/assets/javascripts/misc.js
+++ b/crowbar_framework/app/assets/javascripts/misc.js
@@ -4,3 +4,9 @@
 //= require misc/localizedValue
 //= require misc/iefix
 //= require misc/handlebars
+
+$(document).ready(function($) {
+  Handlebars.registerHelper('toString', function (x) {
+    return (x === undefined) ? 'undefined' : x.toString();
+  });
+});

--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -105,6 +105,7 @@ module Dsl
               defaults.merge({
                 "data-change" => changer("boolean"),
                 "id"          => sanitize_to_id(attribute_name),
+                "data-initial-value"  => attribute_value
               }).merge(options)
             )
           ].join("\n")
@@ -192,7 +193,7 @@ module Dsl
           # a template lookup for handlebarsjs
           idx = attribute.index "{{@index}}"
           if idx
-            return wrap_around(attribute.slice(idx+1, attribute.length).join("."), "{{", "}}")
+            return wrap_around(attribute.slice(idx+1, attribute.length).join("."), "{{toString ", "}}")
           end
 
           result = attrs


### PR DESCRIPTION
This was done in 02ceddb for other selects, but boolean ones were
forgotten.

Note that we need a handlebars helper to properly store "false". See
http://stackoverflow.com/questions/17664323/handlebars-doesnt-render-boolean-variables-when-false
