### PR TITLE
BNC#889444 Fix unsetting the applied proposal flag

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1383,7 +1383,7 @@ class ServiceObject
     unless prop["deployment"][barclamp]["elements"][newrole].include?(node.name)
       @logger.debug("ARTOI: updating proposal with node #{node.name}, role #{newrole} for deployment of #{barclamp}")
       prop["deployment"][barclamp]["elements"][newrole] << node.name
-      prop.save
+      prop.save(:applied => prop.latest_applied?)
     else
       @logger.debug("ARTOI: node #{node.name} already in proposal: role #{newrole} for #{barclamp}")
     end


### PR DESCRIPTION
On a fresh install, the proposals were marked as not having the latest
version applied. This was due to nodes being added to the proposal after
it was committed.

Keep the flag set when saving in add_role_to_instance_and_node.

Fixes https://bugzilla.novell.com/show_bug.cgi?id=889444.
