### PR TITLE
Fix barclamp and name methods to work w/ networks

### DIFF
--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -137,12 +137,22 @@ class ProposalObject < ChefObject
 
   def name
     match = @item.name.match(/crowbar_bc-(.*)-(.*)$/)
-    match[1] == 'template' ? match[1] : match[2]
+    if match.nil?
+      match = @item.name.match(/crowbar_(.*)_network$/)
+      match.nil? ? "" : match[1]
+    else
+      match[1] == 'template' ? match[1] : match[2]
+    end
   end
 
   def barclamp
     match = @item.name.match(/crowbar_bc-(.*)-(.*)$/)
-    match[1] == 'template' ? match[2] : match[1]
+    if match.nil?
+      match = @item.name.match(/crowbar_(.*)_network$/)
+      match.nil? ? "" : "network"
+    else
+      match[1] == 'template' ? match[2] : match[1]
+    end
   end
 
   def prop

--- a/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-admin_network.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-admin_network.json
@@ -1,0 +1,52 @@
+{"name":"data_bag_item_crowbar_admin_network","data_bag":"crowbar","chef_type":"data_bag_item","json_class":"Chef::DataBagItem","raw_data":{ 
+  "allocated": {
+    "192.168.124.10": {
+      "address": "192.168.124.10",
+      "machine": "crowbar.site",
+      "interface": "intf0"
+    }
+  },
+  "id": "admin_network",
+  "network": {
+    "broadcast": "192.168.124.255",
+    "subnet": "192.168.124.0",
+    "add_bridge": false,
+    "conduit": "intf0",
+    "ranges": {
+      "switch": {
+        "start": "192.168.124.241",
+        "end": "192.168.124.250"
+      },
+      "admin": {
+        "start": "192.168.124.10",
+        "end": "192.168.124.11"
+      },
+      "dhcp": {
+        "start": "192.168.124.21",
+        "end": "192.168.124.80"
+      },
+      "host": {
+        "start": "192.168.124.81",
+        "end": "192.168.124.160"
+      }
+    },
+    "netmask": "255.255.255.0",
+    "vlan": 100,
+    "use_vlan": false,
+    "router": "192.168.124.1",
+    "router_pref": 10
+  },
+  "allocated_by_name": {
+    "crowbar.site": {
+      "address": "192.168.124.10",
+      "machine": "crowbar.site",
+      "interface": "intf0"
+    }
+  },
+  "deployment": {
+    "network": {
+      "crowbar-revision": 1,
+      "crowbar-applied": false
+    }
+  }
+}}

--- a/crowbar_framework/spec/models/proposal_object_spec.rb
+++ b/crowbar_framework/spec/models/proposal_object_spec.rb
@@ -28,6 +28,11 @@ describe ProposalObject do
       proposal = ProposalObject.find_barclamp("crowbar")
       proposal.barclamp.should == 'crowbar'
     end
+
+    it "returns network for networks" do
+      proposal = ProposalObject.find_proposal_by_id("admin_network")
+      proposal.barclamp.should == 'network'
+    end
   end
 
   describe "name" do
@@ -39,6 +44,11 @@ describe ProposalObject do
     it "returns name for templates" do
       proposal = ProposalObject.find_barclamp("crowbar")
       proposal.name.should == 'template'
+    end
+
+    it "returns name for networks" do
+      proposal = ProposalObject.find_proposal_by_id("admin_network")
+      proposal.name.should == 'admin'
     end
   end
 


### PR DESCRIPTION
ProposalObject is (ab)used to also write data bags that contain network
information (and not proposals).

Commit 5614efd broke this because the regular expressions were not
matching at all.

This is only really visible when the network barclamp is applied, which
is usually on install.

(This is https://github.com/crowbar/barclamp-crowbar/pull/1020 for master)
