### PR TITLE
Remove running brakeman from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ install:
   - cp config/catalog.yml.example config/catalog.yml
 script:
   - bundle exec rake spec
-  - bundle exec rake brakeman:run


### PR DESCRIPTION
Remove brakeman from the script section. It seems that having two scripts breaks the travis.yml, although it is valid according to the validator.

Please do not merge until the travis runs fine on this PR.
