### PR TITLE
avoid bash_completion.sh appearing as an area for crowbar CLI

### DIFF
--- a/bin/crowbar
+++ b/bin/crowbar
@@ -25,7 +25,7 @@ end
 
 @areas = Dir.glob("./crowbar_*").map! { |x| x.gsub("./crowbar_", "") }
 @areas << Dir.glob(File.join(loc,"crowbar_*")).map! { |x| x.gsub(File.join(loc,"crowbar_"), "") }
-@areas = @areas.flatten
+@areas = @areas.flatten.select {|a| a !~ /\.sh$/}
 
 if ARGV.length == 0
   usage -1


### PR DESCRIPTION
bash_completion.sh should not appear in the following usage:

```
cloud4-admin:~ # crowbar
Usage: crowbar <area> <subcommand>
  Areas: ceilometer ceph cinder crowbar database deployer dns glance heat ipmi keystone logging machines network neutron nfs_client node_state node_status nova nova_dashboard ntp pacemaker provisioner rabbitmq reset_nodes reset_proposal suse_manager_client swift trove updater watch_status
```
