### PR TITLE
Support finding crowbar subcommands when the executable is a symlink

### DIFF
--- a/bin/crowbar
+++ b/bin/crowbar
@@ -16,11 +16,16 @@
 # limitations under the License.
 #
 
-loc=File.expand_path(File.dirname(__FILE__))
 def usage (rc)
   puts "Usage: crowbar <area> <subcommand>"
   puts "  Areas: #{@areas.sort.join(" ")}"
   exit rc
+end
+
+if File.symlink?(__FILE__)
+  loc = File.expand_path(File.dirname(File.readlink(__FILE__)))
+else
+  loc = File.expand_path(File.dirname(__FILE__))
 end
 
 @areas = Dir.glob("./crowbar_*").map! { |x| x.gsub("./crowbar_", "") }


### PR DESCRIPTION
Right now, the crowbar tool only looks for subcommands in the current
directory and in the directory of the executable. We change the latter
to look for subcommand in the directory of the symlink target if the
executable is a symlink.

This allows having a /usr/bin/crowbar symlink pointing to
/opt/dell/bin/crowbar.
