### PR TITLE
Check that at least 2 disks are selected for raid

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -352,7 +352,7 @@ class NodesController < ApplicationController
 
   def save_node
     if params[:group] and params[:group] != "" and !(params[:group] =~ /^[a-zA-Z][a-zA-Z0-9._:-]+$/)
-      flash[:notice] = @node.name + ": " + t('nodes.list.group_error')
+      flash[:alert] = t('nodes.list.group_error', :node => @node.name)
       return false
     end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -302,7 +302,7 @@ en:
       failed: 'Failed to save the nodes %{failed}'
       duplicate_alias: 'Failed to save the nodes %{failed} because there are duplicate aliases. Nothing got changed!'
       duplicate_public: 'Failed to save the nodes %{failed} because there are duplicate public names. Nothing got changed!'
-      group_error: 'Failed to save the group for %{node}, should start with a letter and only contain letters, digits, -, _, ., or :.'
+      group_error: 'Failed to save %{node}: The group should start with a letter and only contain letters, digits, -, _, ., or :.'
       name: 'Name'
       group: 'Group'
       alias: 'Alias'  


### PR DESCRIPTION
When configuring RAID, 2 disks are at least needed. Otherwise i.e. the
autoyast.xml template gets wrong values and the installation aborts.
