### PR TITLE
Change recovering and reinstall states to match the unready status

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -392,13 +392,13 @@ class NodeObject < ChefObject
       "ready"     #green
     when "discovered", "wait", "waiting", "user", "hold", "pending", "input"
       "pending"   #flashing yellow
-    when "discovering", "reset", "delete", "shutdown", "reboot", "poweron", "noupdate"
+    when "discovering", "reset", "delete", "shutdown", "poweron", "noupdate"
       "unknown"   #grey
     when "problem", "issue", "error", "failed", "fail", "warn", "warning", "fubar", "alert"
       "failed"    #flashing red
     when "hardware-installing", "hardware-install", "hardware-installed", "hardware-updated", "hardware-updating"
       "building"  #yellow
-    else # including: installing, installed, reinstall, recovering, readying, applying
+    else # including: installing, installed, reinstall, reboot, recovering, readying, applying
       "unready"   #spinner
     end
   end


### PR DESCRIPTION
Recovering was matching failed (red led) and reinstall was matching
unknown (grey led), but these states are similar to other states that
are in unready (spinner led).
