### PR TITLE
Fix crash when we have a role that we can't match to a barclamp

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -453,11 +453,15 @@ module NodesHelper
             barclamp.include? object.barclamp
           end.first
 
-          proposal = all_proposals.find { |p| p.id == role_to_proposal_name(barclamp) }
+          if barclamp.nil?
+            proposal = nil
+          else
+            proposal = all_proposals.find { |p| p.id == role_to_proposal_name(barclamp) }
+          end
 
           if proposal.nil?
             listing[object.category] ||= []
-            listing[object.category].push role
+            listing[object.category].push role.titleize
           else
             route = proposal_barclamp_path(
               :controller => proposal.barclamp,


### PR DESCRIPTION
This should really not happen, but when it happens, we should not
totally fail, and instead keep working so we can provide more
information on what is wrong.

```
ActionView::TemplateError (private method `split' called for nil:NilClass) on line #5 of app/views/nodes/_show_roles.html.haml:
2:   %th
3:     = t("model.attributes.node.roles")
4:   %td{ :colspan => 3 }
5:     = node_role_list(@node)

    app/helpers/nodes_helper.rb:565:in `role_to_proposal_name'
    app/helpers/nodes_helper.rb:456:in `node_role_list'
    /usr/lib64/ruby/1.8/net/protocol.rb:135:in `find'
    app/helpers/nodes_helper.rb:456:in `each'
    app/helpers/nodes_helper.rb:456:in `find'
    app/helpers/nodes_helper.rb:456:in `node_role_list'
    app/helpers/nodes_helper.rb:443:in `map'
    app/helpers/nodes_helper.rb:443:in `node_role_list'
    app/helpers/nodes_helper.rb:442:in `tap'
    app/helpers/nodes_helper.rb:442:in `node_role_list'
```
