### PR TITLE
add .sass-cache dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *~
-
+.sass-cache
 erl_crash.dump
 trace_*.txt
 *.beam


### PR DESCRIPTION
A lot of files are generated in this directory when running the tests locally.
These can be ignored.
