### PR TITLE
Fix typo in variable name

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1266,7 +1266,7 @@ class NodeObject < ChefObject
           centos-6.4
           suse-11.3
         )
-        unless virtio_by_path_platform.include?(@node[:target_platform])
+        unless virtio_by_path_platforms.include?(@node[:target_platform])
           disk_lookups = []
         end
       end


### PR DESCRIPTION
undefined local variable or method `virtio_by_path_platform'
