### PR TITLE
upgrade to work with apache 2.4

### DIFF
--- a/chef/cookbooks/apache2/definitions/web_app.rb
+++ b/chef/cookbooks/apache2/definitions/web_app.rb
@@ -25,6 +25,7 @@ define :web_app, :template => "web_app.conf.erb" do
   include_recipe "apache2::mod_rewrite"
   include_recipe "apache2::mod_deflate"
   include_recipe "apache2::mod_headers"
+  include_recipe "apache2::mod_filter"
 
   if node.platform == "suse"
     vhost_conf = "#{node[:apache][:dir]}/vhosts.d/#{application_name}.conf"

--- a/chef/cookbooks/apache2/recipes/mod_filter.rb
+++ b/chef/cookbooks/apache2/recipes/mod_filter.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: apache2
+# Recipe:: filter
+#
+# Copyright 2014 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apache_module "filter" do
+  conf false
+end


### PR DESCRIPTION
after upgrade to apache 2.4 (in SLE12) our /etc/apache2/conf.d/deflate.conf
produces  Invalid command 'AddOutputFilterByType error, which can be fixed
by adding mod_filter

I've seen this while testing radosgw. Might be relevant to dashboard as well. Maybe it could be included for SLE12 only.
