### PR TITLE
Add apache version attribute; solve mod_deflate issues the upstream way

### DIFF
--- a/chef/cookbooks/apache2/attributes/default.rb
+++ b/chef/cookbooks/apache2/attributes/default.rb
@@ -17,6 +17,27 @@
 # limitations under the License.
 #
 
+if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 13.10
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'debian' && node['platform_version'].to_f >= 8.0
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'redhat' && node['platform_version'].to_f >= 7.0
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'centos' && node['platform_version'].to_f >= 7.0
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'fedora' && node['platform_version'].to_f >= 18
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'opensuse' && node['platform_version'].to_f >= 13.1
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'suse' && node['platform_version'].to_f >= 12
+  default['apache']['version'] = '2.4'
+elsif node['platform'] == 'freebsd' && node['platform_version'].to_f >= 10.0
+  default['apache']['version'] = '2.4'
+else
+  default['apache']['version'] = '2.2'
+end
+
+
 # Where the various parts of apache are
 case platform
 when "redhat","centos","fedora"

--- a/chef/cookbooks/apache2/definitions/web_app.rb
+++ b/chef/cookbooks/apache2/definitions/web_app.rb
@@ -25,7 +25,6 @@ define :web_app, :template => "web_app.conf.erb" do
   include_recipe "apache2::mod_rewrite"
   include_recipe "apache2::mod_deflate"
   include_recipe "apache2::mod_headers"
-  include_recipe "apache2::mod_filter"
 
   if node.platform == "suse"
     vhost_conf = "#{node[:apache][:dir]}/vhosts.d/#{application_name}.conf"

--- a/chef/cookbooks/apache2/templates/default/mods/deflate.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/mods/deflate.conf.erb
@@ -1,16 +1,18 @@
 <IfModule mod_deflate.c>
-          AddOutputFilterByType DEFLATE text/html
-          AddOutputFilterByType DEFLATE text/css
-          AddOutputFilterByType DEFLATE text/plain
-          AddOutputFilterByType DEFLATE text/xml
-          AddOutputFilterByType DEFLATE application/xhtml+xml
-          AddOutputFilterByType DEFLATE application/xml
-          AddOutputFilterByType DEFLATE image/svg+xml
-          AddOutputFilterByType DEFLATE application/rss+xml
-          AddOutputFilterByType DEFLATE application/atom_xml
-          AddOutputFilterByType DEFLATE application/javascript
-          AddOutputFilterByType DEFLATE application/x-javascript
-          AddOutputFilterByType DEFLATE application/x-httpd-php
-          AddOutputFilterByType DEFLATE application/x-httpd-fastphp
-          AddOutputFilterByType DEFLATE application/x-httpd-eruby
+  <IfModule mod_filter.c>
+     # these are known to be safe with MSIE 6
+     AddOutputFilterByType DEFLATE text/html text/plain text/xml
+
+     # everything else may cause problems with MSIE 6
+     AddOutputFilterByType DEFLATE text/css
+     AddOutputFilterByType DEFLATE application/x-javascript application/javascript application/ecmascript
+     AddOutputFilterByType DEFLATE application/rss+xml
+     AddOutputFilterByType DEFLATE application/xml
+     AddOutputFilterByType DEFLATE application/xhtml+xml
+     AddOutputFilterByType DEFLATE image/svg+xml
+     AddOutputFilterByType DEFLATE application/atom_xml
+     AddOutputFilterByType DEFLATE application/x-httpd-php
+     AddOutputFilterByType DEFLATE application/x-httpd-fastphp
+     AddOutputFilterByType DEFLATE application/x-httpd-eruby
+  </IfModule>
 </IfModule>


### PR DESCRIPTION
The block with version attribute is copied from upstream recipe (+ I added SLES12).

Including mod_filter from web_app was my previous solution to 2.4 version upgrade, but the upstream  one (=updating mod_deflate template) seems to be better
