### PR TITLE
Fix crash on node view

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -453,11 +453,13 @@ module NodesHelper
             barclamp.include? object.barclamp
           end.first
 
-          proposal = all_proposals.find { |p| p.id == role_to_proposal_name(barclamp) }
+          unless barclamp.nil?
+            proposal = all_proposals.find { |p| p.id == role_to_proposal_name(barclamp) }
+          end
 
           if proposal.nil?
             listing[object.category] ||= []
-            listing[object.category].push role
+            listing[object.category].push role.titleize
           else
             route = proposal_barclamp_path(
               :controller => proposal.barclamp,


### PR DESCRIPTION
In deallocated node state it is sometimes not possible
to view the node details anymore. Fixes
https://bugzilla.novell.com/show_bug.cgi?id=889834

(cherry picked from commit e1c3d040b53cb6069f837d2f80bb250352e05009)
