### PR TITLE
Add ability to change intended role on CLI

### DIFF
--- a/bin/crowbar_machines
+++ b/bin/crowbar_machines
@@ -68,6 +68,7 @@ require "utils/extended_hash"
   "reinstall" => [ "action \"reinstall\", ARGV.shift", "reinstall <name or alias> - Reinstall a node" ],
   "update" => [ "action \"update\", ARGV.shift", "update <name or alias> - Hardware update a node" ],
   "rename" => [ "rename ARGV.shift, ARGV.shift", "rename <name or alias> <new_alias> - Rename a node alias" ],
+  "role" => [ "role ARGV.shift, ARGV.shift", "role <name or alias> <intended role> - Assign an intended role" ],
   "api_help" => [ "api_help", "api_help - Crowbar API help for this barclamp" ]
 }
 
@@ -308,6 +309,26 @@ def rename(name, update)
   usage(-1) if update.nil? or update.empty?
 
   action("rename", name, { :alias => update})
+end
+
+def role(name, update)
+  usage(-1) if name.nil? or name.empty?
+  usage(-1) if update.nil? or update.empty?
+
+  available_roles = %w(
+    no_role
+    controller
+    compute
+    network
+    storage
+  )
+
+  unless available_roles.include? update
+    puts "The role have to be one of #{available_roles.join(", ")}"
+    exit 1
+  end
+
+  action("role", name, { :role => update})
 end
 
 def api_help

--- a/crowbar_framework/app/controllers/machines_controller.rb
+++ b/crowbar_framework/app/controllers/machines_controller.rb
@@ -23,6 +23,7 @@ class MachinesController < BarclampController
   before_filter :load_machine_or_render_not_found,
     :only => [
       :show,
+      :role,
       :rename,
       :identify,
       :delete,
@@ -62,6 +63,16 @@ class MachinesController < BarclampController
   def show
     respond_to do |format|
       format.json { render :json => @machine.to_hash }
+    end
+  end
+
+  add_help(:role, [:id])
+  def role
+    @machine.intended_role = params[:role]
+    @machine.save
+
+    respond_to do |format|
+      format.json { head :ok }
     end
   end
 

--- a/crowbar_framework/app/helpers/form_helper.rb
+++ b/crowbar_framework/app/helpers/form_helper.rb
@@ -26,6 +26,8 @@ module FormHelper
   def roles_for_select(selected)
     options_for_select(
       [
+        # These roles have to stay in sync
+        # with machines role command
         [t(".no_role"), "no_role"], 
         [t(".controller"), "controller"], 
         [t(".compute"), "compute"], 


### PR DESCRIPTION
In order to change the intended role from the command line i have
integrated an API endpoint and added the crowbar_machines implementation
as well. Now an admin can manipulate the intended role from the CLI
pretty easy.
