### PR TITLE
Redirect to raw after raw editing (bnc#885223)

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -426,7 +426,16 @@ class BarclampController < ApplicationController
         Rails.logger.warn "Invalid action #{params[:submit]} for #{params[:id]}"
         flash[:alert] = "Invalid action #{params[:submit]}"
       end
-      redirect_to proposal_barclamp_path(:controller => params[:barclamp], :id => params[:name])
+
+      redirect_params = {
+        :controller => params[:barclamp],
+        :id => params[:name]
+      }
+
+      redirect_params[:dep_raw] = params[:dep_raw] if params[:dep_raw] == "true"
+      redirect_params[:attr_raw] = params[:attr_raw] if params[:attr_raw] == "true"
+
+      redirect_to proposal_barclamp_path(redirect_params)
     end
   end
 

--- a/crowbar_framework/app/views/barclamp/_edit_attributes_raw.html.haml
+++ b/crowbar_framework/app/views/barclamp/_edit_attributes_raw.html.haml
@@ -8,6 +8,9 @@
 
 .panel-body
   .form-group
+    %input{ :type => "hidden", :name => "dep_raw", :value => @dep_raw }
+    %input{ :type => "hidden", :name => "attr_raw", :value => @attr_raw }
+
     - if request.env['HTTP_USER_AGENT'].downcase.index('msie 7')
       %textarea#proposal_attributes{ :name => "proposal_attributes", :rows => 30, :cols => 80, :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
         = @proposal.pretty_attributes_json

--- a/crowbar_framework/app/views/barclamp/_edit_deployment_raw.html.haml
+++ b/crowbar_framework/app/views/barclamp/_edit_deployment_raw.html.haml
@@ -8,6 +8,9 @@
 
 .panel-body
   .form-group
+    %input{ :type => "hidden", :name => "dep_raw", :value => @dep_raw }
+    %input{ :type => "hidden", :name => "attr_raw", :value => @attr_raw }
+
     - if request.env['HTTP_USER_AGENT'].downcase.index('msie 7')
       %textarea#proposal_deployment{ :name => "proposal_deployment", :rows => 30, :cols => 80, :data => { "changed-state" => t("proposal.failures.unsaved_changes") } }
         = @proposal.pretty_deployment_json


### PR DESCRIPTION
In order to see directly the raw mode again after editing withuin raw
mode we need to send the dep_raw and attr_raw attributes to detect which
view should be shown after saving the current state.

This fixes https://bugzilla.suse.com/show_bug.cgi?id=885223

(cherry picked from commit 9855ccd76dde2b6c780025d5db1a382cd3ed933d)
