### PR TITLE
Fix mixlib-shellout version in Gemfile

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -38,6 +38,7 @@ gem "tilt", "1.3.3"
 gem "mime-types", "1.18", :require => "mime/types"
 
 gem "chef", "~> 10.24.0"
+gem "mixlib-shellout", "~> 1.1.0"
 gem "ohai", "~> 6.14.0"
 
 group :development do


### PR DESCRIPTION
Newer versions do not support ruby 1.8 and thus, travis builds break.

Fix the lib version to the one used by our packages.
