### PR TITLE
Add array-comma-string for better parsing attributes

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/jsonAttribute.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/jsonAttribute.js
@@ -51,9 +51,20 @@
         value = parseFloat(value);
         break;
       case 'array-string':
+        value = this.replaceSpace(this.splitString(value));
+        break;
+      case 'array-comma-string':
         value = this.splitString(value);
         break;
       case 'array-boolean':
+        var index;
+        value = this.replaceSpace(this.splitString(value));
+
+        for (index in value) {
+          value[index] = value[index].toLowerCase() == 'true'
+        }
+        break;
+      case 'array-comma-boolean':
         var index;
         value = this.splitString(value);
 
@@ -63,6 +74,14 @@
         break;
       case 'array-integer':
         var index;
+        value = this.replaceSpace(this.splitString(value));
+
+        for (index in value) {
+          value[index] = parseInt(value[index]);
+        }
+        break;
+      case 'array-comma-integer':
+        var index;
         value = this.splitString(value);
 
         for (index in value) {
@@ -70,6 +89,14 @@
         }
         break;
       case 'array-float':
+        var index;
+        value = this.replaceSpace(this.splitString(value));
+
+        for (index in value) {
+          value[index] = parseFloat(value[index]);
+        }
+        break;
+      case 'array-comma-float':
         var index;
         value = this.splitString(value);
 
@@ -164,8 +191,15 @@
     this.writeJson();
   };
 
+  JsonAttribute.prototype.replaceSpace = function(value) {
+    return value.replace(/ /g, ',');
+  };
+
   JsonAttribute.prototype.splitString = function(value) {
-    return value.replace(/ /g, ',').replace(/,+/g, ',').split(',');
+    return $.map(
+      value.split(','),
+      $.trim
+    );
   };
 
   $.fn.readJsonAttribute = function(key, value, type) {

--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -133,19 +133,43 @@ module Dsl
       end
 
       def array_string_field(attribute, options = {})
-        input attribute, :text_field_tag, "array-string", options
+        type = if options.delete(:only_comma)
+          "array-comma-string"
+        else
+          "array-string"
+        end
+
+        input attribute, :text_field_tag, type, options
       end
 
       def array_boolean_field(attribute, options = {})
-        input attribute, :text_field_tag, "array-boolean", options
+        type = if options.delete(:only_comma)
+          "array-comma-boolean"
+        else
+          "array-boolean"
+        end
+
+        input attribute, :text_field_tag, type, options
       end
 
       def array_integer_field(attribute, options = {})
-        input attribute, :text_field_tag, "array-integer", options
+        type = if options.delete(:only_comma)
+          "array-comma-integer"
+        else
+          "array-integer"
+        end
+
+        input attribute, :text_field_tag, type, options
       end
 
       def array_float_field(attribute, options = {})
-        input attribute, :text_field_tag, "array-float", options
+        type = if options.delete(:only_comma)
+          "array-comma-float"
+        else
+          "array-float"
+        end
+
+        input attribute, :text_field_tag, type, options
       end
 
       def instance_field(attribute, options = {})


### PR DESCRIPTION
This is fix for bnc#903674
Crowbar and/or nova cannot cope with vCenter cluster names containing spaces
https://bugzilla.suse.com/show_bug.cgi?id=903674
