### PR TITLE
Fix active roles dashboard

### DIFF
--- a/crowbar_framework/app/controllers/dashboard_controller.rb
+++ b/crowbar_framework/app/controllers/dashboard_controller.rb
@@ -6,7 +6,13 @@ class DashboardController < ApplicationController
   end
 
   def active_roles
-    @assigned_roles = RoleObject.assigned(@roles).reject { |r| r.proposal? || r.core_role? || r.ha? }.sort_by(&:name)
+    @assigned_roles = RoleObject.assigned(@roles).reject do |r|
+      r.proposal? || r.core_role? || r.ha?
+    end.group_by do |r|
+      r.barclamp
+    end.sort_by do |barclamp, roles|
+      barclamp
+    end
   end
 
   private

--- a/crowbar_framework/app/views/dashboard/_role.html.haml
+++ b/crowbar_framework/app/views/dashboard/_role.html.haml
@@ -1,26 +1,18 @@
-.panel.panel-default
-  .panel-heading
-    %h2
-      = display_name_for(role.barclamp)
+.row
+  .col-xs-12
+    %h3
+      = role.name
 
-  .panel-body
-    .row
-      .col-xs-12
-        %h3
-          = t(".nodes")
+.row
+  .col-xs-12
+    - elements.select { |e| e.cluster }.each do |cluster|
+      %span
+        = render :partial => "link_cluster", :locals => { :status => ServiceObject.cluster_status(cluster.nodes), :name => cluster.name }
+        (
+        - cluster.nodes.each do |node|
+          = render :partial => "link_node", :locals => { :node => node }
+        )
 
-    .row
-      .col-xs-12
-        - elements.select { |e| e.cluster }.each do |cluster|
-          %span
-            = render :partial => "link_cluster", :locals => { :status => ServiceObject.cluster_status(cluster.nodes), :name => cluster.name }
-            (
-            - cluster.nodes.each do |node|
-              = render :partial => "link_node", :locals => { :node => node }
-            )
-
-        - elements.select { |e| !e.cluster }.each do |node|
-          %span
-            = render :partial => "link_node", :locals => { :node => node.node }
-
-  .panel-footer
+    - elements.select { |e| !e.cluster }.each do |node|
+      %span
+        = render :partial => "link_node", :locals => { :node => node.node }

--- a/crowbar_framework/app/views/dashboard/active_roles.html.haml
+++ b/crowbar_framework/app/views/dashboard/active_roles.html.haml
@@ -5,7 +5,13 @@
 
 .row
   .col-xs-12
-    - @assigned_roles.each do |role|
-      .row
-        .col-xs-12
-          = render :partial => "role", :locals => { :role => role, :elements => role.element_nodes(@roles, @nodes) }
+    - @assigned_roles.each do |barclamp, roles|
+      .panel.panel-default
+        .panel-heading
+          %h2
+            = display_name_for(barclamp)
+        .panel-body
+          - roles.map { |role| { :role => role, :elements => role.element_nodes(@roles, @nodes) } }.each do |locals|
+            - unless locals[:elements].empty?
+              = render :partial => "role", :locals => locals
+        .panel-footer


### PR DESCRIPTION
1) Roles without assigned nodes are not displayed
2) Roles are grouped under a barclamp name.

This fixes the duplicated roles issue. In fact, they were
different roles belonging to the same barclamp and only that barclamp's
name was displayed, giving the impression of duplicates.
