### PR TITLE
Fix indentation of exported YAML

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -516,7 +516,7 @@ def export_proposal(barclamp, template, proposal, alias_by_host)
   end
 
   if added_attrs.empty?
-    puts 'attributes:'
+    puts '  attributes:'
   else
     attrs = { 'attributes' => added_attrs }
     puts to_yaml(attrs).gsub(/^/, '  ')


### PR DESCRIPTION
When exporting a barclamp that only used the default values from the template
(added_attrs.empty?) the "attributes:" key in the generated YAML was not
correctly indented.
