### PR TITLE
Avoid temporary service outage with error 503

### DIFF
--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -197,7 +197,6 @@ template "#{node[:apache][:dir]}/ports.conf" do
   owner "root"
   variables :apache_listen_ports => node[:apache][:listen_ports]
   mode 0644
-  notifies :reload, resources(:service => "apache2")
 end
 
 # leave the default module list untouched for now on SUSE
@@ -224,6 +223,6 @@ end
 #apache_site "default" if platform?("centos", "redhat", "fedora")
 
 service "apache2" do
-  action :start
+  action [ :start, :reload ]
   ignore_failure true
 end


### PR DESCRIPTION
When horizon is deploed in a HA setup, haproxy is used. In every chef run, the
ports the apache server is listening to are first set to the default values,
and in a later cookbook to the haproxy values. When checking from the beginning
if the haproxy values are needed, we avoid unnecessary changes to the config
file causing apache2 restarts that result in a temporary service outage with
error 503.

See also https://bugzilla.novell.com/show_bug.cgi?id=897996
