### PR TITLE
Do not write port config for apache twice (bnc#897996)

### DIFF
--- a/chef/cookbooks/apache2/recipes/mod_ssl.rb
+++ b/chef/cookbooks/apache2/recipes/mod_ssl.rb
@@ -35,13 +35,11 @@ if node.platform == "suse"
   end
 end
 
-ports = node[:apache][:listen_ports].include?("443") ? node[:apache][:listen_ports] : [node[:apache][:listen_ports], "443"].flatten
-
-template "#{node[:apache][:dir]}/ports.conf" do
-  source "ports.conf.erb"
-  variables :apache_listen_ports => ports
-  notifies :reload, resources(:service => "apache2")
-  mode 0644
+unless node[:apache][:listen_ports].include?("443")
+  # override the resource defined in default.rb; we don't want to create the
+  # resource again, otherwise we will write the file twice
+  resource = resources(:template => "#{node[:apache][:dir]}/ports.conf")
+  resource.variables({:apache_listen_ports => [node[:apache][:listen_ports], "443"].flatten})
 end
 
 apache_module "ssl" do


### PR DESCRIPTION
We were defining the template twice, which resulted in the file being
written twice, including once with some non-valid config.

Instead, just override the variable we need in the template the second
time.

https://bugzilla.suse.com/show_bug.cgi?id=897996
