### PR TITLE
Fix changing the platform in bulk view

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -105,11 +105,6 @@ class NodesController < ApplicationController
             dirty = false
             node = NodeObject.find_node_by_name node_name
 
-            if node_attributes["allocate"] and not node.allocated?
-              node.allocate!
-              dirty = true
-            end
-
             unless node.alias == node_attributes["alias"]
               node.force_alias = node_attributes["alias"]
               dirty = true
@@ -130,6 +125,11 @@ class NodesController < ApplicationController
                 node.license_key = node_attributes["license_key"]
                 dirty = true
               end
+            end
+
+            if node_attributes["allocate"] and not node.allocated?
+              node.allocate!
+              dirty = true
             end
 
             unless node.intended_role == node_attributes["intended_role"]


### PR DESCRIPTION
Selecting a non-default target platform for nodes in the bulk view didn't have
any effect if "allocate" was marked at the same time. Handling the target
platform attribute before the allocate attribute should fix the problem.