### PR TITLE
Bnc863101

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -391,10 +391,16 @@ class BarclampController < ApplicationController
           flash[:notice] = answer[1] if answer[0] >= 300 and answer[0] < 400
           flash[:notice] = t('barclamp.proposal_show.commit_proposal_success') if answer[0] == 200
           if answer[0] == 202
-            flash_msg = answer[1].map { |node_dns|
-                 NodeObject.find_node_by_name(node_dns).alias
-            }.join ", "
-            flash[:notice] = "#{t('barclamp.proposal_show.commit_proposal_queued')}: #{flash_msg}"
+            missing_nodes = answer[1].map { |node_dns| NodeObject.find_node_by_name(node_dns) }
+
+            unready_nodes = missing_nodes.map(&:alias)
+            unallocated_nodes = missing_nodes.reject(&:allocated).map(&:alias)
+
+            flash[:notice] = "#{t('barclamp.proposal_show.commit_proposal_queued')}: #{(unready_nodes - unallocated_nodes).join(", ")}"
+
+            unless unallocated_nodes.empty?
+              flash[:alert]  = "#{t('barclamp.proposal_show.commit_proposal_queued_unallocated')}: #{unallocated_nodes.join(", ")}"
+            end
           end
         rescue StandardError => e
           flash_and_log_exception(e)

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -219,8 +219,8 @@ class ServiceObject
           next if node.nil?
           pre_cached_nodes[node_name] = node
 
-          # Make sure the node is allocated
-          node.allocate!
+          # Mark node as pending. User will be informed about node needing
+          # manual allocation if not allocated.
           node.crowbar["crowbar"]["pending"] = {} if node.crowbar["crowbar"]["pending"].nil?
           node.crowbar["crowbar"]["pending"]["#{bc}-#{inst}"] = val
           node.save

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -98,6 +98,7 @@ en:
       commit_proposal: 'Apply'
       commit_proposal_success: 'Successfully applied the proposal'
       commit_proposal_queued: 'Successfully queued the proposal until the following become ready'
+      commit_proposal_queued_unallocated: 'The proposal requires manual allocation of these nodes'
       save_proposal: 'Save'
       save_proposal_success: 'Successfully saved changes to the proposal'
       dequeue_proposal: 'Dequeue'


### PR DESCRIPTION
A fix for  https://bugzilla.suse.com/show_bug.cgi?id=863101

Applying a barclamp allocates (i.e. re-installs) a node.  This could be
problematic e.g. if the node contains a previously installed OS, or user
data.

This patch changes the policy to not allocate the nodes automatically on
barclamp apply.

This is preferrable to not offering the non-allocated nodes in the UI as
it works also for the API. User will be informed about the need to
allocate the nodes manually.