### PR TITLE
Do not use deep munge

### DIFF
--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -27,6 +27,8 @@ module Crowbar
 
     config.time_zone = "UTC"
 
+    config.action_dispatch.perform_deep_munge = false
+
     config.i18n.enforce_available_locales = true
     config.i18n.default_locale = :en
 


### PR DESCRIPTION
This is breaking the JSON parsing for empty arrays, which we use with
the magic crowbar-deep-merge-template feature when creating the initial
crowbar proposal.

With deep munge enabled, we cannot remove the nagios proposal, which
results in failures when nagios barclamp is not available.

See:
https://github.com/rails/rails/issues/8832
https://github.com/rails/rails/issues/13420

We can revert this once switching to rails 5 (see comments in second
issue).