### PR TITLE
Revert "Preload app code on rainbows startup"

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/rainbows.cfg.erb
+++ b/chef/cookbooks/crowbar/templates/default/rainbows.cfg.erb
@@ -5,7 +5,6 @@ end
 
 timeout 3600
 worker_processes 4
-preload_app true
 listen "<%= @web_host %>:<%= @web_port %>"
 user("<%= @user %>","<%= @group || nil %>")
 <% if node[:platform]=="suse" -%>
@@ -14,13 +13,3 @@ pid("/var/run/crowbar/crowbar.pid")
 stderr_path "<%= "#{@logdir}/#{@logname}.out" %>"
 stdout_path "<%= "#{@logdir}/#{@logname}.out" %>"
 working_directory "<%= @app_location %>"
-
-before_fork do |server, worker|
-  defined?(ActiveRecord::Base) and
-    ActiveRecord::Base.connection.disconnect!
-end
-
-after_fork do |server, worker|
-  defined?(ActiveRecord::Base) and
-    ActiveRecord::Base.establish_connection
-end


### PR DESCRIPTION
This reverts commit 93a7e299ba41e3c59d444eafe8371ac7fc89bac3.

Our deployment scripts assume that force-reload is in fact equivalent to
restart (i.e. reloads the code), which is not the case if we preload the
app.