### PR TITLE
Automatically redirect to dashboard start page

### DIFF
--- a/crowbar_framework/index/index.html
+++ b/crowbar_framework/index/index.html
@@ -110,6 +110,7 @@
       for (i = 0; i < links_to_dashboard.length; i++) {
         links_to_dashboard[i].href="http://" + window.location.host + ":3000";
       }
+      window.location.replace("http://" + window.location.host + ":3000");
     </script>
   </body>
 </html>


### PR DESCRIPTION
Instead of showing a stupid error page, try to be helpful
and immediately go to the right page.