### PR TITLE
Add two new validation constraints.

### DIFF
--- a/crowbar_framework/app/assets/javascripts/misc/stringLocalize.js
+++ b/crowbar_framework/app/assets/javascripts/misc/stringLocalize.js
@@ -29,6 +29,8 @@ if (!String.prototype.localize) {
       'barclamp.node_selector.unique': 'Failed to assign {0} to {1}, it\'s already assigned to another role',
       'barclamp.node_selector.zero': 'Failed to assign {0} to {1}, no assignment allowed',
       'barclamp.node_selector.max_count': 'Failed to assign {0} to {1}, maximum of allowed nodes/clusters reached',
+      'barclamp.node_selector.platform': 'Failed to assign {0} to {1}, this platform is not allowed',
+      'barclamp.node_selector.exclude_platform': 'Failed to assign {0} to {1}, this platform is excluded',
       'barclamp.node_selector.conflicting_roles': 'Node {0} cannot be assigned to both {1} and any of these roles: {2}'
     };
 

--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -94,6 +94,8 @@ module NodesHelper
             :title => node.description(false, true),
             :admin => node.admin?,
             :group => node.group,
+            :platform => node[:platform],
+            :platform_version => node[:platform_version],
             :cluster => false
           } if node.group == group or group.nil?
         end

--- a/crowbar_framework/app/views/barclamp/_node_selector.html.haml
+++ b/crowbar_framework/app/views/barclamp/_node_selector.html.haml
@@ -49,7 +49,7 @@
         .form-group
           %ul.nodes
             - nodes_hash.each do |n, detail|
-              %li.form-control.input-sm.available{ "data-draggable" => "true", "data-id" => n, "data-alias" => detail[:alias], "data-cluster" => "false", "data-admin" => detail[:admin].to_s, :title => (detail[:title] || t("not_set")) }
+              %li.form-control.input-sm.available{ "data-draggable" => "true", "data-id" => n, "data-alias" => detail[:alias], "data-cluster" => "false", "data-admin" => detail[:admin].to_s, "data-platform" => detail[:platform], "data-platform-version" => detail[:platform_version], :title => (detail[:title] || t("not_set")) }
                 = icon_tag :hdd
                 = detail[:alias]
                 = link_to icon_tag("link"), node_path(detail[:handle]), :title => t(".node_link", :alias => detail[:alias]), :class => "pull-right"

--- a/crowbar_framework/spec/models/service_object_spec.rb
+++ b/crowbar_framework/spec/models/service_object_spec.rb
@@ -131,5 +131,91 @@ describe ServiceObject do
         dns_service.validation_errors.first.should match(/cannot be assigned to both role/)
       end
     end
+
+    describe "platform" do
+      it "allows nodes of matched platform using operators" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => ">= 10" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "allows nodes of matched platform with fancy versioning" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "10.10.0" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "allows nodes of matched platform using regular expressions" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "/10.*/" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "allows nodes of matched platform using regular expressions (multiple platforms)" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "suse" => "12.0", "ubuntu" => "/10.*/" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "does not allow nodes of a different platform" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "suse" => "12.0" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.first.should match(/can be used only for suse 12.0/)
+      end
+
+      it "does not allow nodes of a different platform (multiple parforms)" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "suse" => "12.0", "redhat" => "/.*/" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.first.should match(/can be used only for suse 12.0/)
+      end
+
+      it "does not allow nodes of a Ubuntu" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "exclude_platform" => { "ubuntu" => "/.*/" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.first.should match(/can't be used for ubuntu/)
+      end
+    end
   end
 end


### PR DESCRIPTION
* Add "platform" constraint:

  "platform" => ['suse', /12.(0|1)/]

  This will expect that the service have a platform equal to 'suse'
  and a platform_version of 12.0 or 12.1

* Add "exclude_platform" constraint:

  "exclude_platform" => [/suse/, '11.3']

  If the platform is a SLES11 SP3, the service will not be installed.