### PR TITLE
Include form helper

### DIFF
--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -204,7 +204,7 @@ module Dsl
       end
 
       def method_missing(method_name, *arguments, &block)
-        if view.respond_to? method_name
+        if view.respond_to?(method_name, true)
           view.send(method_name, *arguments, &block)
         else
           super

--- a/crowbar_framework/lib/dsl/proposal/attribute.rb
+++ b/crowbar_framework/lib/dsl/proposal/attribute.rb
@@ -235,7 +235,7 @@ module Dsl
           else
             result
           end
-        rescue
+        rescue TypeError => e
           Rails.logger.debug "Failed to find the attribute for `#{attribute.join(", ")}`"
           ""
         end


### PR DESCRIPTION
The cinder backend UI uses a hack to workaround handlebars substituted
values and calls wrap_around. However, this is a method defined in form
helper. The helpers possibly might have been accessible from the DSL in rails 2,
but this is no longer the case in rails 4.