### PR TITLE
Install uglifier, not closure-compiler

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -54,7 +54,6 @@ when "suse"
     ruby2.1-rubygem-activerecord-session_store
     ruby2.1-rubygem-activeresource
     ruby2.1-rubygem-chef
-    ruby2.1-rubygem-closure-compiler
     ruby2.1-rubygem-dotenv
     ruby2.1-rubygem-dotenv-deployment
     ruby2.1-rubygem-haml-rails
@@ -65,6 +64,7 @@ when "suse"
     ruby2.1-rubygem-mixlib-shellout
     ruby2.1-rubygem-ohai-6
     ruby2.1-rubygem-rails-4_1
+    ruby2.1-rubygem-rainbows-rails
     ruby2.1-rubygem-redcarpet
     ruby2.1-rubygem-ruby-shadow
     ruby2.1-rubygem-sass-rails
@@ -72,7 +72,7 @@ when "suse"
     ruby2.1-rubygem-simple_navigation_renderers
     ruby2.1-rubygem-sqlite3
     ruby2.1-rubygem-syslogger
-    ruby2.1-rubygem-rainbows-rails
+    ruby2.1-rubygem-uglifier-2_2
   )
 end
 


### PR DESCRIPTION
We use sprockets with uglifier, there is no point in installing
closure-compiler