### PR TITLE
make logging more consistent

### DIFF
--- a/crowbar_framework/barclamp_model/crowbar_framework/app/models/==BC-MODEL==_service.rb
+++ b/crowbar_framework/barclamp_model/crowbar_framework/app/models/==BC-MODEL==_service.rb
@@ -45,7 +45,7 @@ class ==^BC-MODEL==Service < ServiceObject
   end
 
   def apply_role_pre_chef_call(old_role, role, all_nodes)
-    @logger.debug("==*BC-MODEL== apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+    @logger.debug("==*BC-MODEL== #{__method__}: entering #{all_nodes.inspect}")
     return if all_nodes.empty?
 
     # Make sure the bind hosts are in the admin network
@@ -58,14 +58,14 @@ class ==^BC-MODEL==Service < ServiceObject
 
       node.save
     end
-    @logger.debug("==*BC-MODEL== apply_role_pre_chef_call: leaving")
+    @logger.debug("==*BC-MODEL== #{__method__}: leaving")
   end
 
   # Similar to above - delete or uncomment for actions to be run after
   # chef-client runs.
   # def apply_role_post_chef_call(old_role, role, all_nodes)
-  #   @logger.debug("==*BC-MODEL== apply_role_post_chef_call: entering #{all_nodes.inspect}")
-  #   @logger.debug("==*BC-MODEL== apply_role_post_chef_call: leaving")
+  #   @logger.debug("==*BC-MODEL== #{__method__}: entering #{all_nodes.inspect}")
+  #   @logger.debug("==*BC-MODEL== #{__method__}: leaving")
   # end
 
 end


### PR DESCRIPTION
right now logging is a bit inconsistent. 
see for example `AR:` vs `apply_role` as a prefix for the logging output of `service_object.rb`
some time ago i even had to ask what `AR` means, it was not so clear.
one way to generalize it is rubys magic `__method__` which just gives you the name of the method, where the statement is executed.
this would have to be done for the other barclamps as well.