### PR TITLE
Disable root element in API JSONs (bnc#912309)

### DIFF
--- a/crowbar_framework/config/initializers/serializer.rb
+++ b/crowbar_framework/config/initializers/serializer.rb
@@ -1,3 +1,19 @@
+#
+# Copyright 2014, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Disable root element in the JSON responses for POROs,
 # i.e. keep the behavior the same as in cloud 4
 ActiveModel::Serializer.root = false

--- a/crowbar_framework/config/initializers/serializer.rb
+++ b/crowbar_framework/config/initializers/serializer.rb
@@ -1,0 +1,4 @@
+# Disable root element in the JSON responses for POROs,
+# i.e. keep the behavior the same as in cloud 4
+ActiveModel::Serializer.root = false
+ActiveModel::ArraySerializer.root = false


### PR DESCRIPTION
This supersedes https://github.com/crowbar/barclamp-crowbar/pull/1171

Configure the ActiveModel::Serializers gem to not use root element in
the rendered JSON responses.

This keeps our API JSON responses consistent between cloud releases.