### PR TITLE
Update rspec rails to 3.1 compatible with rails 4

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -58,7 +58,7 @@ gem "rack-mini-profiler", "~> 0.9",
 
 group :development, :test do
   gem "brakeman", "~> 2.6"
-  gem "rspec-rails", "~> 2.14"
+  gem "rspec-rails", "~> 3.1"
 end
 
 group :test do


### PR DESCRIPTION
This prevents

`named_routes.helpers` is deprecated, please use `route_defined?

deprecation warningis.