### PR TITLE
Rename serve_static_assets to serve_static_files

### DIFF
--- a/crowbar_framework/config/environments/development.rb
+++ b/crowbar_framework/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.force_ssl = false
   config.autoflush_log = true
 

--- a/crowbar_framework/config/environments/production.rb
+++ b/crowbar_framework/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local = false
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.force_ssl = false
   config.autoflush_log = false
 

--- a/crowbar_framework/config/environments/test.rb
+++ b/crowbar_framework/config/environments/test.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.cache_classes = true
   config.eager_load = false
   config.consider_all_requests_local = true
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.force_ssl = false
   config.autoflush_log = false
 


### PR DESCRIPTION
Rename the serve_static_assets to serve_static_files in the environment
configuration. This prevents

The configuration option `config.serve_static_assets` has been renamed

deprecation warnings (the option will be removed in rails 5).