### PR TITLE
restrict available subcommands to only crowbar binaries

### DIFF
--- a/bin/crowbar
+++ b/bin/crowbar
@@ -28,7 +28,8 @@ else
   loc = File.expand_path(File.dirname(__FILE__))
 end
 
-@areas = Dir.glob("./crowbar_*").map! { |x| x.gsub("./crowbar_", "") }
+@areas = Dir.glob("./crowbar_*").select {|ex| File.executable?(ex)}
+@areas = @areas.map! { |x| x.gsub("./crowbar_", "") }
 @areas << Dir.glob(File.join(loc,"crowbar_*")).map! { |x| x.gsub(File.join(loc,"crowbar_"), "") }
 @areas = @areas.flatten.select {|a| a !~ /\.sh$/}
 


### PR DESCRIPTION
the crowbar CLI should only match crowbar binaries for his subcommands.
I stumbled upon this, when i had some files laying around on the admin node which were "accidentally" prefixed with `crowbar_`.
```bash
root@crowbar:~ # ls -l crowbar_*
-rw-r--r-- 1 root root  252 Jan 19 19:23 crowbar_batch.log
-rw-r--r-- 1 root root 5769 Jan 19 17:12 crowbar_batch_only_openstack.yml
root@crowbar:~ # crowbar help
Usage: crowbar <area> <subcommand>
  Areas: batch batch.log batch_only_openstack.yml ceilometer ceph cinder crowbar database deployer dns glance heat ipmi keystone logging machines network neutron nfs_client node_state nova nova_dashboard ntp pacemaker provisioner rabbitmq reset reset_nodes reset_proposal suse_manager_client swift tempest trove updater
```

the two files in my working directory were suddenly available as a subcommand.
I could even try to execute them with crowbar...
```bash
root@crowbar:~ # crowbar batch.log
/usr/bin/crowbar:43:in `exec': Permission denied - ./crowbar_batch.log (Errno::EACCES)
	from /usr/bin/crowbar:43:in `<main>'
```

Do you see this as a potential vulnerability? If so, this solution would be not the best. Then we should only match files from `/opt/dell/bin/` and perform some upstream md5 check to ensure their integrity, or sth similar.