### PR TITLE
Fix logging format (bnc#912805)

### DIFF
--- a/crowbar_framework/config/environments/development.rb
+++ b/crowbar_framework/config/environments/development.rb
@@ -52,8 +52,7 @@ Rails.application.configure do
   config.log_tags = []
 
   config.logger = ActiveSupport::TaggedLogging.new(
-    Logger.new Rails.root.join("log", "development.log") # SyslogLogger.new
+    Logger.new(Rails.root.join("log", "development.log"))
   )
-
-  config.log_formatter = ::Logger::Formatter.new
+  config.logger.formatter = ::Crowbar::Logger::Formatter.new
 end

--- a/crowbar_framework/config/environments/production.rb
+++ b/crowbar_framework/config/environments/production.rb
@@ -52,8 +52,7 @@ Rails.application.configure do
   config.log_tags = []
 
   config.logger = ActiveSupport::TaggedLogging.new(
-    Logger.new File.join(ENV["CROWBAR_LOG_DIR"], "production.log") # SyslogLogger.new
+    Logger.new(File.join(ENV["CROWBAR_LOG_DIR"], "production.log"))
   )
-
-  config.log_formatter = ::Logger::Formatter.new
+  config.logger.formatter = ::Crowbar::Logger::Formatter.new
 end

--- a/crowbar_framework/config/environments/test.rb
+++ b/crowbar_framework/config/environments/test.rb
@@ -52,8 +52,7 @@ Rails.application.configure do
   config.log_tags = []
 
   config.logger = ActiveSupport::TaggedLogging.new(
-    Logger.new Rails.root.join("log", "test.log") # SyslogLogger.new
+    Logger.new(Rails.root.join("log", "test.log"))
   )
-
-  config.log_formatter = ::Logger::Formatter.new
+  config.logger.formatter = ::Crowbar::Logger::Formatter.new
 end

--- a/crowbar_framework/lib/crowbar/logger/formatter.rb
+++ b/crowbar_framework/lib/crowbar/logger/formatter.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2014, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Logger
+    class Formatter < ::Logger::Formatter
+      include ActiveSupport::TaggedLogging::Formatter
+
+      def call(severity, timestamp, progname, msg)
+        final_message = if msg.is_a? String
+          msg
+        else
+          msg.inspect
+        end
+
+        super(
+          severity,
+          timestamp,
+          progname,
+          final_message
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
> The config.log_formatter setting does not have any effect on the
> actual log format, if TaggedLogger or AS::Logger is passed via config.logger.
> 
> This might be due to the way the TaggedLogger is initialized [1]. To
> make it work, we would have to first instantiate the logger, then set
> its formatter, then pass it to the tagged logging. This is ugly.
>
> We could also use ActiveSupport::Logger instead, but the
> config.log_formatter does not work there, either (unless we again set
> the formatter as an attribute).

As Thomas correctly pointed out, the config.log_format does not apply if the config.logger is set.

Let's just use simple logger for now, and add tagged logging later. Imho there is no fast and easy way how to keep both tagged logging and old log format (unless we implement a custom formatter that does both).