### PR TITLE
schema migration: print script name

### DIFF
--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -111,6 +111,7 @@ module SchemaMigration
       return a, d
     end
 
+    puts "Running migration script #{script} (upgrade: #{is_upgrade})"
     load script
 
     if is_upgrade


### PR DESCRIPTION
During schema migration, print script name and if up- or downgrade is
executed. This is useful while debugging migration problems.