### PR TITLE
Add CrowbarHelper.in_sledgehammer? helper

### DIFF
--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -59,4 +59,9 @@ module CrowbarHelper
     # chef10 so we have to rescue false (see e.g. CHEF-3736)
     !!node["crowbar"].fetch("admin_node", false) rescue false
   end
+
+  def self.in_sledgehammer?(node)
+    states = [ "ready", "readying", "recovering", "applying" ]
+    not states.include?(node[:state])
+  end
 end


### PR DESCRIPTION
We have this code in a few barclamps, and it's not really understandable
at first. So the small helper will make it clearer what it's for, and
avoid copy & paste bugs.