### PR TITLE
Only run travis against Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
   - 2.1.0
-  - 1.9.3
-  - 1.8.7
 
 gemfile: crowbar_framework/Gemfile
 


### PR DESCRIPTION
Older versions won't work anymore since we broke compatibility.