### PR TITLE
Implement a proper comparison for versions.

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/nodeList.js
@@ -417,29 +417,40 @@
       return [0, 0, 0];
     };
 
-    var cmp = function(op, version1, version2) {
-      var as_version1 = to_version(version1);
-      var as_version2 = to_version(version2);
-      var result = as_version1.map(function(v1, i) {
-        switch (op) {
-          case ">=":
-            return v1 >= as_version2[i];
-          case ">":
-            return v1 > as_version2[i];
-          case "<=":
-            return v1 <= as_version2[i];
-          case "<":
-            return v1 < as_version2[i];
-          case "==":
-            return v1 == as_version2[i];
-          default:
-            return false;
+    var cmp = function(version1, version2) {
+      var ans = 0;
+      // version1 and version2 are arrays of the same length.  At this
+      // point this assertion is true:
+      // assert(version1.length == version2.length)
+      for (var i=0; i<version1.length; i++) {
+        if (version1[i] < version2[i]) {
+          ans = -1;
+        } else if (version1[i] > version2[i]) {
+          ans = 1;
         }
-      });
+        if (ans != 0) {
+          return ans;
+        }
+      }
+      return 0;
+    };
 
-      return result.every(function(element, index, array) {
-        return element;
-      });
+    var oper = function(op, version1, version2) {
+      var ans = cmp(to_version(version1), to_version(version2)); 
+      switch (op) {
+        case ">":
+          return ans === 1;
+        case ">=":
+          return ans === 1 || ans === 0;
+        case "<":
+          return ans === -1;
+        case "<=":
+          return ans === -1 || ans === 0;
+        case "==":
+          return ans === 0;
+        default:
+          return false;
+      }
     };
 
     // First group contains the RegExp without pre and post '/'
@@ -451,9 +462,9 @@
 
     var op_value = /^(>=?|<=?)\s*([.\d]+)$/.exec(maybe_regexp);
     if (op_value) {
-      return cmp(op_value[1], value, op_value[2]);
+      return oper(op_value[1], value, op_value[2]);
     } else {
-      return cmp('==', value, maybe_regexp);
+      return oper('==', value, maybe_regexp);
     }
   };
 

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1631,9 +1631,29 @@ class ServiceObject
       end
     end
 
-    cmp = lambda do |op, version|
-      (to_version.call(value).zip to_version.call(version)).all? do |v1, v2|
-        v1.send(op, v2)
+    cmp = lambda do |version1, version2|
+      version1.zip(version2).each do |v|
+        ans = v[0] <=> v[1]
+        return ans if ans != 0
+      end
+      0
+    end
+
+    oper = lambda do |op, value1, value2|
+      ans = cmp.call(to_version.call(value1), to_version.call(value2))
+      case op
+      when '>'
+        ans == 1
+      when '>='
+        ans == 1 || ans == 0
+      when '<'
+        ans == -1
+      when '<='
+        ans == -1 || ans == 0
+      when '=='
+        ans == 0
+      else
+        false
       end
     end
 
@@ -1642,9 +1662,11 @@ class ServiceObject
     if maybe_regexp.start_with?('/') && maybe_regexp.end_with?('/')
       Regexp.new(maybe_regexp[1..-2]).match(value)
     elsif op_value.length > 0
-      cmp.call(op_value.first.first, op_value.first.last)
+      op_tmp = op_value.first.first
+      value_tmp = op_value.first.last
+      oper.call(op_tmp, value, value_tmp)
     else
-      cmp.call('==', maybe_regexp)
+      oper.call('==', value, maybe_regexp)
     end
   end
 end

--- a/crowbar_framework/spec/models/service_object_spec.rb
+++ b/crowbar_framework/spec/models/service_object_spec.rb
@@ -133,16 +133,100 @@ describe ServiceObject do
     end
 
     describe "platform" do
-      it "allows nodes of matched platform using operators" do
+      it "allows nodes of matched platform using operator >=" do
         dns_service.stubs(:role_constraints).returns(
           {
             "dns-client" => {
               "admin" => true ,
-              "platform" => { "ubuntu" => ">= 10" }
+              "platform" => { "ubuntu" => ">= 10.10" }
             }
           })
         dns_service.validate_proposal_constraints(dns_proposal)
         dns_service.validation_errors.length.should be == 0
+      end
+
+      it "does not allow nodes of matched platform using operator >=" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => ">= 10.10.1" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 1
+      end
+
+      it "allows nodes of matched platform using operator >" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "> 10.09" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "does not allow nodes of matched platform using operator >" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => ">= 10.10.1" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 1
+      end
+
+      it "allows nodes of matched platform using operator <=" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "<= 10.10.1" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "does not allow nodes of matched platform using operator <=" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "<= 10.09" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 1
+      end
+
+      it "allows nodes of matched platform using operator ==" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "10.10" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 0
+      end
+
+      it "does not allow nodes of matched platform using operator ==" do
+        dns_service.stubs(:role_constraints).returns(
+          {
+            "dns-client" => {
+              "admin" => true ,
+              "platform" => { "ubuntu" => "10.10.1" }
+            }
+          })
+        dns_service.validate_proposal_constraints(dns_proposal)
+        dns_service.validation_errors.length.should be == 1
       end
 
       it "allows nodes of matched platform with fancy versioning" do


### PR DESCRIPTION
In crowbar/barclamp-crowbar#1175 I introduced a wrong comparison
algorithm after missunderstanding how <=> works on Ruby.

This commit fix the issue and 8+ test cases to cover all operators.