### PR TITLE
Hide power actions UI for windows nodes

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1090,6 +1090,11 @@ class NodeObject < ChefObject
   end
 
   def ssh_cmd(cmd)
+    if @node[:platform] == "windows"
+      Rails.logger.warn("ssh command \"#{cmd}\" for #{@node.name} ignored - node is running Windows")
+      return nil
+    end
+
     # Have to redirect stdin, stdout, stderr and background reboot
     # command on the client else ssh never disconnects when client dies
     # `timeout` and '-o ConnectTimeout=10' are there in case anything

--- a/crowbar_framework/app/views/nodes/_buttons_power.html.haml
+++ b/crowbar_framework/app/views/nodes/_buttons_power.html.haml
@@ -2,20 +2,23 @@
   = link_to t(".identify"), hit_node_path(@node.handle, "identify"), class: "btn btn-default", remote: true
 
 - unless @node.admin?
-  %button.btn.btn-default.dropdown-toggle{ type: "button", data: { toggle: "dropdown" } }
-    = t(".actions")
-    %span.caret
+  - if @node[:platform] != 'windows' || @node.bmc_set?
+    %button.btn.btn-default.dropdown-toggle{ type: "button", data: { toggle: "dropdown" } }
+      = t(".actions")
+      %span.caret
 
-  %ul.dropdown-menu{ role: "menu" }
-    %li{ role: "presentation" }
-      = link_to t(".reboot"), hit_node_path(@node.handle, "reboot"), role: "menuitem", remote: true
-    %li{ role: "presentation" }
-      = link_to t(".shutdown"), hit_node_path(@node.handle, "shutdown"), role: "menuitem", remote: true
-    %li.divider{ role: "presentation" }
-    - if @node.bmc_set?
-      %li{ role: "presentation" }
-        = link_to t(".poweron"), hit_node_path(@node.handle, "poweron"), role: "menuitem", remote: true, "data-confirm" => t("are_you_sure")
-    %li{ role: "presentation" }
-      = link_to t(".powercycle"), hit_node_path(@node.handle, "powercycle"), role: "menuitem", remote: true
-    %li{ role: "presentation" }
-      = link_to t(".poweroff"), hit_node_path(@node.handle, "poweroff"), role: "menuitem", remote: true
+    %ul.dropdown-menu{ role: "menu" }
+      - if @node[:platform] != 'windows'
+        %li{ role: "presentation" }
+          = link_to t(".reboot"), hit_node_path(@node.handle, "reboot"), role: "menuitem", remote: true
+        %li{ role: "presentation" }
+          = link_to t(".shutdown"), hit_node_path(@node.handle, "shutdown"), role: "menuitem", remote: true
+        %li.divider{ role: "presentation" }
+      - if @node.bmc_set?
+        %li{ role: "presentation" }
+          = link_to t(".poweron"), hit_node_path(@node.handle, "poweron"), role: "menuitem", remote: true, "data-confirm" => t("are_you_sure")
+      - if @node[:platform] != 'windows' || @node.bmc_set?
+        %li{ role: "presentation" }
+          = link_to t(".powercycle"), hit_node_path(@node.handle, "powercycle"), role: "menuitem", remote: true
+        %li{ role: "presentation" }
+          = link_to t(".poweroff"), hit_node_path(@node.handle, "poweroff"), role: "menuitem", remote: true


### PR DESCRIPTION
All actions that required ssh can't work for windows nodes since there's
no ssh server installed there.

Also add warning when trying to use API requiring ssh for windows nodes