### PR TITLE
Removed ember-js dependency

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -21,7 +21,6 @@ gem "rails", "~> 4.1"
 gem "haml-rails", "~> 0.5"
 gem "sass-rails", "~> 4.0"
 gem "rainbows-rails", "~> 1.0"
-gem "ember-rails", "~> 0.15"
 
 gem "activeresource", "~> 4.0"
 gem "dotenv", "~> 1.0"

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -39,9 +39,6 @@ else
   gem "rainbows-rails", version: "~> 1.0"
   require "rainbows-rails"
 
-  gem "ember-rails", version: "~> 1.0"
-  require "ember-rails"
-
   # general stuff
   gem "activerecord-session_store", version: "~> 0.1"
   require "activerecord/session_store"


### PR DESCRIPTION
As we are currently not using ember-js i have removed the dependency for
this release that we don't need to ship dependencies like nodejs.
