### PR TITLE
Changed rubygems to HTTP

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-source "https://rubygems.org"
+source "http://rubygems.org"
 
 gem "rails", "~> 4.1"
 gem "haml-rails", "~> 0.5"


### PR DESCRIPTION
While development based on the gemfile i realized that a communication
throught HTTPS does not work for our bundler. It fails with
'NoMethodError: undefined method `extensions' for nil:NilClass'. With
this change it simply works again without any error.