### PR TITLE
Add some states to list of valid transition states

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -521,6 +521,8 @@ class BarclampController < ApplicationController
       "applying", "discovered", "discovering", "hardware-installed",
       "hardware-installing", "hardware-updated", "hardware-updating",
       "installed", "installing", "ready", "readying", "recovering",
+      # used by sledgehammer / crowbar_join
+      "debug", "problem", "reboot", "shutdown"
     ]
   end
 


### PR DESCRIPTION
sledgehammer and crowbar_join need to be able to transition states to:

 - problem: errors on boot
 - reboot: on rebooting
 - shutdown: on shutting down
 - debug: special state for sledgehammer that can be triggered for
   debugging