### PR TITLE
Refactor platform version requirements check

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -889,7 +889,7 @@ class ServiceObject
         node = NodeObject.find_node_by_name(element)
 
         return true if !constraints.any? do |platform, version|
-          node[:platform] == platform && equal_or_match_version(node[:platform_version], version)
+          node[:platform] == platform && PlatformRequirement.new(version).satisfied_by?(node[:platform_version])
         end
       end
     end
@@ -904,7 +904,7 @@ class ServiceObject
         node = NodeObject.find_node_by_name(element)
 
         return true if constraints.any? do |platform, version|
-          node[:platform] == platform && equal_or_match_version(node[:platform_version], version)
+          node[:platform] == platform && PlatformRequirement.new(version).satisfied_by?(node[:platform_version])
         end
       end
     end
@@ -1640,59 +1640,6 @@ class ServiceObject
       Rack::MiniProfiler.step(name, &block)
     else
       block.call
-    end
-  end
-
-  def equal_or_match_version(value, maybe_regexp)
-    to_version = lambda do |version|
-      case version.to_s
-      when /^(\d+)\.(\d+)\.(\d+)$/
-        [ $1.to_i, $2.to_i, $3.to_i ]
-      when /^(\d+)\.(\d+)$/
-        [ $1.to_i, $2.to_i, 0 ]
-      when /^(\d+)$/
-        [ $1.to_i, 0, 0 ]
-      else
-        [0, 0, 0]
-      end
-    end
-
-    cmp = lambda do |version1, version2|
-      version1.zip(version2).each do |v|
-        ans = v[0] <=> v[1]
-        return ans if ans != 0
-      end
-      0
-    end
-
-    oper = lambda do |op, value1, value2|
-      ans = cmp.call(to_version.call(value1), to_version.call(value2))
-      case op
-      when '>'
-        ans == 1
-      when '>='
-        ans == 1 || ans == 0
-      when '<'
-        ans == -1
-      when '<='
-        ans == -1 || ans == 0
-      when '=='
-        ans == 0
-      else
-        false
-      end
-    end
-
-    op_value = maybe_regexp.scan(/^(>=?|<=?)\s*([.\d]+)$/)
-
-    if maybe_regexp.start_with?('/') && maybe_regexp.end_with?('/')
-      Regexp.new(maybe_regexp[1..-2]).match(value)
-    elsif op_value.length > 0
-      op_tmp = op_value.first.first
-      value_tmp = op_value.first.last
-      oper.call(op_tmp, value, value_tmp)
-    else
-      oper.call('==', value, maybe_regexp)
     end
   end
 end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -889,7 +889,7 @@ class ServiceObject
         node = NodeObject.find_node_by_name(element)
 
         return true if !constraints.any? do |platform, version|
-          node[:platform] == platform && PlatformRequirement.new(version).satisfied_by?(node[:platform_version])
+          PlatformRequirement.new(platform, version).satisfied_by?(node[:platform], node[:platform_version])
         end
       end
     end
@@ -904,7 +904,7 @@ class ServiceObject
         node = NodeObject.find_node_by_name(element)
 
         return true if constraints.any? do |platform, version|
-          node[:platform] == platform && PlatformRequirement.new(version).satisfied_by?(node[:platform_version])
+          PlatformRequirement.new(platform, version).satisfied_by?(node[:platform], node[:platform_version])
         end
       end
     end

--- a/crowbar_framework/lib/platform_requirement.rb
+++ b/crowbar_framework/lib/platform_requirement.rb
@@ -1,22 +1,27 @@
 class PlatformRequirement
-  attr_reader :as_string
+  attr_reader :required_version, :required_platform
 
   attr_reader :cmp_operator, :required_version_string
 
-  def initialize(string)
-    @as_string = string
+  def initialize(required_platform, required_version)
+    @required_version  = required_version
+    @required_platform = required_platform
 
-    @cmp_operator, @required_version_string = parse(string)
+    @cmp_operator, @required_version_string = parse(required_version)
 
     @cmp_operator ||= "=="
-    @required_version_string ||= string
+    @required_version_string ||= required_version
   end
 
-  def satisfied_by?(version)
-    if is_regexp?
-      regexp_compare(version)
+  def satisfied_by?(platform, version)
+    if required_platform == platform
+      if is_regexp?
+        regexp_compare(version)
+      else
+        version_compare(version)
+      end
     else
-      version_compare(version)
+      false
     end
   end
 
@@ -47,11 +52,11 @@ class PlatformRequirement
   end
 
   def regexp_body
-    as_string[1..-2]
+    required_version[1..-2]
   end
 
   def is_regexp?
-    as_string.start_with?('/') && as_string.end_with?('/')
+    required_version.start_with?('/') && required_version.end_with?('/')
   end
 end
 

--- a/crowbar_framework/lib/platform_requirement.rb
+++ b/crowbar_framework/lib/platform_requirement.rb
@@ -1,0 +1,57 @@
+class PlatformRequirement
+  attr_reader :as_string
+
+  attr_reader :cmp_operator, :required_version_string
+
+  def initialize(string)
+    @as_string = string
+
+    @cmp_operator, @required_version_string = parse(string)
+
+    @cmp_operator ||= "=="
+    @required_version_string ||= string
+  end
+
+  def satisfied_by?(version)
+    if is_regexp?
+      regexp_compare(version)
+    else
+      version_compare(version)
+    end
+  end
+
+  private
+
+  def version_compare(version)
+    passed   = PlatformVersion.new(version.to_s)
+    required = PlatformVersion.new(required_version_string)
+
+    if passed.respond_to?(cmp_operator.to_sym)
+      passed.send(cmp_operator.to_sym, required)
+    else
+      false
+    end
+  end
+
+  def regexp_compare(version)
+    Regexp.new(regexp_body).match(version.to_s)
+  end
+
+  def parse(string)
+    captures = string.scan(/^(>=?|<=?)\s*([.\d]+)$/)
+    if captures.length > 0
+      captures.first
+    else
+      []
+    end
+  end
+
+  def regexp_body
+    as_string[1..-2]
+  end
+
+  def is_regexp?
+    as_string.start_with?('/') && as_string.end_with?('/')
+  end
+end
+

--- a/crowbar_framework/lib/platform_version.rb
+++ b/crowbar_framework/lib/platform_version.rb
@@ -1,0 +1,40 @@
+class PlatformVersion
+  include Comparable
+
+  attr_reader :as_array, :as_string
+
+  def initialize(version)
+    @as_string = version
+    @as_array  = parse(version)
+  end
+
+  def to_s
+    as_string
+  end
+
+  def to_a
+    as_array
+  end
+
+  def <=>(other)
+    pairwise_comparisons = to_a.zip(other.to_a).map do |v1_part, v2_part|
+      v1_part <=> v2_part
+    end
+    pairwise_comparisons.find { |cmp| cmp != 0 } || 0
+  end
+
+  private
+
+  def parse(version)
+    case version.to_s
+    when /^(\d+)\.(\d+)\.(\d+)$/
+      [ $1.to_i, $2.to_i, $3.to_i ]
+    when /^(\d+)\.(\d+)$/
+      [ $1.to_i, $2.to_i, 0 ]
+    when /^(\d+)$/
+      [ $1.to_i, 0, 0 ]
+    else
+      [0, 0, 0]
+    end
+  end
+end

--- a/crowbar_framework/spec/lib/platform_requirement_spec.rb
+++ b/crowbar_framework/spec/lib/platform_requirement_spec.rb
@@ -2,40 +2,40 @@ require 'spec_helper'
 
 describe PlatformRequirement do
   it "works when specified as regexp" do
-    req = PlatformRequirement.new("/1.2.1/")
+    req = PlatformRequirement.new("ubuntu", "/1.2.1/")
 
-    expect(req).to be_satisfied_by("1.2.1")
-    expect(req).to_not be_satisfied_by("1.3.1")
+    expect(req).to be_satisfied_by("ubuntu", "1.2.1")
+    expect(req).to_not be_satisfied_by("ubuntu", "1.3.1")
   end
 
   it "works when specified as string" do
-    req = PlatformRequirement.new("1.2.1")
+    req = PlatformRequirement.new("ubuntu", "1.2.1")
 
-    expect(req).to be_satisfied_by("1.2.1")
-    expect(req).to_not be_satisfied_by("1.3.1")
+    expect(req).to be_satisfied_by("ubuntu", "1.2.1")
+    expect(req).to_not be_satisfied_by("ubuntu", "1.3.1")
 
-    req = PlatformRequirement.new("10.10.0")
+    req = PlatformRequirement.new("ubuntu", "10.10.0")
 
-    expect(req).to be_satisfied_by("10.10.0")
-    expect(req).to_not be_satisfied_by("1.3.1")
+    expect(req).to be_satisfied_by("ubuntu", "10.10.0")
+    expect(req).to_not be_satisfied_by("ubuntu", "1.3.1")
   end
 
   it "works when specified using an operator" do
-    req = PlatformRequirement.new(">= 1.2.1")
+    req = PlatformRequirement.new("ubuntu", ">= 1.2.1")
 
-    expect(req).to be_satisfied_by("1.2.1")
-    expect(req).to be_satisfied_by("1.3.1")
-    expect(req).to_not be_satisfied_by("0.9.0")
-    expect(req).to_not be_satisfied_by("1.2.0")
+    expect(req).to be_satisfied_by("ubuntu", "1.2.1")
+    expect(req).to be_satisfied_by("ubuntu", "1.3.1")
+    expect(req).to_not be_satisfied_by("ubuntu", "0.9.0")
+    expect(req).to_not be_satisfied_by("ubuntu", "1.2.0")
   end
 
   it "returns false for incorrect input" do
-    req = PlatformRequirement.new(">= 1.2.1")
+    req = PlatformRequirement.new("ubuntu", ">= 1.2.1")
 
-    expect(req).to_not be_satisfied_by("sdfsdf")
+    expect(req).to_not be_satisfied_by("ubuntu", "sdfsdf")
 
-    req = PlatformRequirement.new("sdfsdf")
+    req = PlatformRequirement.new("ubuntu", "sdfsdf")
 
-    expect(req).to_not be_satisfied_by("1.2.1")
+    expect(req).to_not be_satisfied_by("ubuntu", "1.2.1")
   end
 end

--- a/crowbar_framework/spec/lib/platform_requirement_spec.rb
+++ b/crowbar_framework/spec/lib/platform_requirement_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe PlatformRequirement do
+  it "works when specified as regexp" do
+    req = PlatformRequirement.new("/1.2.1/")
+
+    expect(req).to be_satisfied_by("1.2.1")
+    expect(req).to_not be_satisfied_by("1.3.1")
+  end
+
+  it "works when specified as string" do
+    req = PlatformRequirement.new("1.2.1")
+
+    expect(req).to be_satisfied_by("1.2.1")
+    expect(req).to_not be_satisfied_by("1.3.1")
+
+    req = PlatformRequirement.new("10.10.0")
+
+    expect(req).to be_satisfied_by("10.10.0")
+    expect(req).to_not be_satisfied_by("1.3.1")
+  end
+
+  it "works when specified using an operator" do
+    req = PlatformRequirement.new(">= 1.2.1")
+
+    expect(req).to be_satisfied_by("1.2.1")
+    expect(req).to be_satisfied_by("1.3.1")
+    expect(req).to_not be_satisfied_by("0.9.0")
+    expect(req).to_not be_satisfied_by("1.2.0")
+  end
+
+  it "returns false for incorrect input" do
+    req = PlatformRequirement.new(">= 1.2.1")
+
+    expect(req).to_not be_satisfied_by("sdfsdf")
+
+    req = PlatformRequirement.new("sdfsdf")
+
+    expect(req).to_not be_satisfied_by("1.2.1")
+  end
+end

--- a/crowbar_framework/spec/lib/platform_version_spec.rb
+++ b/crowbar_framework/spec/lib/platform_version_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe PlatformVersion do
+  it "correctly implements ordering" do
+    cases = {
+      ["1.2.0", "1.1.1"] => ["1.1.1", "1.2.0"],
+      ["0.0.1", "0.1.0"] => ["0.0.1", "0.1.0"],
+      ["1.0.0", "0.9.9"] => ["0.9.9", "1.0.0"],
+    }
+
+    cases.each do |versions, sorted|
+      sorted_versions = versions.map { |v| PlatformVersion.new(v) }.sort.map(&:to_s)
+      expect(sorted_versions).to eq(sorted)
+    end
+  end
+
+  it "responds to other ops" do
+    ver = PlatformVersion.new("1.2.1")
+    expect(ver).to respond_to(:>)
+  end
+end


### PR DESCRIPTION
As the service object is already too bloated, this set of patches moves the node platform version checks into a separate classes.

It also simplifies the code a bit by not using lambdas, but having the methods as a part of (private) interface.

cc @aplanas 