### PR TITLE
Display better error for invalid groups

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -75,7 +75,8 @@ class NodesController < ApplicationController
       :success => [],
       :failed => [],
       :duplicate_public => false,
-      :duplicate_alias => false
+      :duplicate_alias => false,
+      :group_error => false,
     }.tap do |report|
       node_values = params[:node] || {}
 
@@ -149,6 +150,7 @@ class NodesController < ApplicationController
 
             unless node.group == node_attributes["group"]
               unless node_attributes["group"].blank? or node_attributes["group"] =~ /^[a-zA-Z][a-zA-Z0-9._:-]+$/
+                report[:group_error] = true
                 raise I18n.t("nodes.list.group_error", :node => node.name)
               end
 
@@ -178,6 +180,8 @@ class NodesController < ApplicationController
         "nodes.list.duplicate_alias"
       when @report[:duplicate_publics]
         "nodes.list.duplicate_public"
+      when @report[:group_error]
+        "nodes.list.group_error"
       else
         "nodes.list.failed"
       end

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -151,7 +151,7 @@ class NodesController < ApplicationController
             unless node.group == node_attributes["group"]
               unless node_attributes["group"].blank? or node_attributes["group"] =~ /^[a-zA-Z][a-zA-Z0-9._:-]+$/
                 report[:group_error] = true
-                raise I18n.t("nodes.list.group_error", :node => node.name)
+                raise I18n.t("nodes.list.group_error", :failed => node.name)
               end
 
               node.group = node_attributes["group"]
@@ -368,7 +368,7 @@ class NodesController < ApplicationController
 
   def save_node
     if params[:group] and params[:group] != "" and !(params[:group] =~ /^[a-zA-Z][a-zA-Z0-9._:-]+$/)
-      flash[:alert] = t('nodes.list.group_error', :node => @node.name)
+      flash[:alert] = t('nodes.list.group_error', :failed => @node.name)
       return false
     end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -342,7 +342,7 @@ en:
       failed: 'Failed to save the nodes %{failed}'
       duplicate_alias: 'Failed to save the nodes %{failed} because there are duplicate aliases. Nothing got changed!'
       duplicate_public: 'Failed to save the nodes %{failed} because there are duplicate public names. Nothing got changed!'
-      group_error: 'Failed to save %{node}: The group should start with a letter and only contain letters, digits, -, _, ., or :.'
+      group_error: 'Failed to save %{failed}: The group should start with a letter and only contain letters, digits, -, _, ., or :.'
       name: 'Name'
       group: 'Group'
       alias: 'Alias'


### PR DESCRIPTION
When bulk editing nodes, currently the default error message is
displayed, when the group contains invalid characters.

 'Failed to save the nodes X.'

This patch adds correct handling of such case and the UI will
display a more informative message:

 'The group should start ...'

cc @tboerger @vuntz 