### PR TITLE
Fix uniq validation for node alias (bnc#915406)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -330,7 +330,7 @@ class NodeObject < ChefObject
     if unique_check
       node = NodeObject.find_node_by_alias value
 
-      if node and !node.handle == handle
+      if node and node.handle != handle
         Rails.logger.warn "Alias #{value} not saved because #{node.name} already has the same alias."
         raise I18n.t('duplicate_alias', :scope => 'model.node') + ": " + node.name
       end

--- a/crowbar_framework/spec/models/node_object_spec.rb
+++ b/crowbar_framework/spec/models/node_object_spec.rb
@@ -87,4 +87,18 @@ describe NodeObject do
       end
     end
   end
+
+  describe "alias" do
+    let(:testing_node) { NodeObject.find_node_by_name("testing") }
+    let(:admin_node) { NodeObject.find_node_by_name("admin") }
+
+    it "doesnt allow duplicates" do
+      # Stub out chef call
+      NodeObject.any_instance.stubs(:update_alias).returns(true)
+
+      expect {
+        testing_node.alias = "admin"
+      }.to raise_error(RuntimeError)
+    end
+  end
 end


### PR DESCRIPTION
A simple typo fix + test case.

!node.handle was always false, so the comparison with the new handle was
also false, and the dupe check error was never raised.

cc @tboerger @vuntz

https://bugzilla.suse.com/show_bug.cgi?id=915406