### PR TITLE
Show asset tag if set on the node

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -563,7 +563,12 @@ class NodeObject < ChefObject
     if virtual?
       "vm-#{mac.gsub(':',"-")}"
     else
-      @node[:dmi]["chassis"]["serial_number"] rescue nil
+      asset = @node[:dmi]["chassis"]["serial_number"] rescue nil
+      if @node[:dmi]["chassis"].has_key?("asset_tag") && !@node[:dmi]["chassis"]["asset_tag"].empty?
+        "#{asset} (#{@node[:dmi]["chassis"]["asset_tag"]})"
+      else
+        asset
+      end
     end
   end
 


### PR DESCRIPTION
The asset tag is a manually configurable label for the node and
can be helpful in identifying the particular machine that
we're looking for.