### PR TITLE
Use haproxy public name for public URL when using a cluster

### DIFF
--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -14,7 +14,7 @@ module CrowbarHelper
       # loose dependency on the pacemaker cookbook
       cluster_vhostname = CrowbarPacemakerHelper.cluster_vhostname(node)
 
-      public_name = nil
+      public_name = CrowbarPacemakerHelper.cluster_haproxy_vpublic_name(node)
       public_fqdn = "public.#{cluster_vhostname}.#{node[:domain]}"
       public_net_db = Chef::DataBagItem.load('crowbar', 'public_network').raw_data
       public_ip = public_net_db["allocated_by_name"]["#{cluster_vhostname}.#{node[:domain]}"]["address"]


### PR DESCRIPTION
We now have CrowbarPacemakerHelper.cluster_haproxy_vpublic_name, which
enables the operator to avoid using the generated hostnames.

(cherry picked from commit e29245b490e7188196f0fca18675c8030ea24277)