### PR TITLE
Totally ignore nodes that were never discovered by crowbar (bnc#900216)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -39,13 +39,8 @@ class NodeObject < ChefObject
         end
       end
       answer.compact!
-      answer.delete_if { |x| !x.has_chef_server_roles? }
     end
     return answer
-  end
-
-  def has_chef_server_roles?
-      return !@role.nil?
   end
 
   def self.find_all_nodes


### PR DESCRIPTION
If chef-client is run on a node, but that node never went through the
discovered state, then crowbar never created the role for that node
(crowbar-$node).

This will result in failures when we list nodes because chef knows about
the node, and crowbar thinks it should know about it too.

Instead, if we see that the node role doesn't exist, then we pretend the
node just doesn't even exist.

https://bugzilla.suse.com/show_bug.cgi?id=900216