### PR TITLE
Fix NodeObject.switch_find_info

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -993,8 +993,10 @@ class NodeObject < ChefObject
     res = nil
     begin
       sort_ifs.each do |intf|
-        info = self.crowbar_ohai["switch_config"][intf]["switch_"+type]
-        next if info == -1  # try next interface in case this is not in use
+        switch_config_intf = self.crowbar_ohai["switch_config"][intf]
+        # try next interface in case this is one is missing data
+        next if [switch_config_intf["switch_name"], switch_config_intf["switch_unit"], switch_config_intf["switch_port"]].include? -1
+        info = switch_config_intf["switch_"+type]
         res = info.to_s.gsub(':', '-')
         break  # if we got this far then we are done
       end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -990,18 +990,18 @@ class NodeObject < ChefObject
 
   # DRY version of the switch name/unit/port code
   def switch_find_info(type)
-    info = nil
+    res = nil
     begin
       sort_ifs.each do |intf|
         info = self.crowbar_ohai["switch_config"][intf]["switch_"+type]
         next if info == -1  # try next interface in case this is not in use
-        info = info.name = name.to_s.gsub(':', '-')
+        res = info.to_s.gsub(':', '-')
         break  # if we got this far then we are done
       end
     rescue
       Rails.logger.warn("Switch #{type} Error: #{@node.name}: Switch config not detected during discovery")
     end
-    info
+    res
   end
 
   # used to determine if display information has been set or if defaults should be used


### PR DESCRIPTION
The code was totally broken, setting the result variable to a value that
is not something we want to return yet, and with some totally broken
code raising an exception (info = info.name = foo, where info.name just
doesn't exist)