### PR TITLE
Fix RemoteNode when hostname resolves to multiple addresses (bnc#918270)

### DIFF
--- a/crowbar_framework/lib/remote_node.rb
+++ b/crowbar_framework/lib/remote_node.rb
@@ -82,7 +82,7 @@ module RemoteNode
   # Workaround for similar issue
   # http://projects.puppetlabs.com/issues/2776
   def self.resolve_host(host)
-    `dig +short #{host}`
+    `dig +short #{host} | head -n1`
   end
 
   def self.runlevel_check_cmd(host)


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=918270