### PR TITLE
Fix alias in bulk edit (bnc#918523)

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -105,18 +105,14 @@ class NodesController < ApplicationController
           begin
             dirty = false
             node = NodeObject.find_node_by_name node_name
+            is_allocated = node.allocated?
 
-            unless node.alias == node_attributes["alias"]
-              node.force_alias = node_attributes["alias"]
+            if node_attributes["allocate"] and not is_allocated
+              node.allocate!
               dirty = true
             end
 
-            unless node.public_name == node_attributes["public_name"]
-              node.force_public_name = node_attributes["public_name"]
-              dirty = true
-            end
-
-            unless node.allocated?
+            unless is_allocated
               unless node.target_platform == node_attributes["target_platform"]
                 node.target_platform = node_attributes["target_platform"]
                 dirty = true
@@ -128,8 +124,13 @@ class NodesController < ApplicationController
               end
             end
 
-            if node_attributes["allocate"] and not node.allocated?
-              node.allocate!
+            unless node.alias == node_attributes["alias"]
+              node.force_alias = node_attributes["alias"]
+              dirty = true
+            end
+
+            unless node.public_name == node_attributes["public_name"]
+              node.force_public_name = node_attributes["public_name"]
               dirty = true
             end
 


### PR DESCRIPTION
If you try to set an alias or public_name on an unallocated node in bulk
edit, and you try to allocate it at the same time crowbar ignores the
alias and public_name you defined. Because of that i have moved the
alias and public_name assignment below the allocation, that way this
information doesn't get lost.

https://bugzilla.suse.com/show_bug.cgi?id=918523