### PR TITLE
Do not use node handle as fallback for switch name (bnc#918785)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1020,7 +1020,7 @@ class NodeObject < ChefObject
 
   def switch
     if switch_name.nil?
-      self.handle[0..8]
+      "unknown"
     elsif switch_unit.nil?
       switch_name
     else


### PR DESCRIPTION
This is just wrong: if we don't know the switch info, then let's not
pretend it's something else.

This fixes nodes appearing in different groups by default when there's
no switch info.

https://bugzilla.suse.com/show_bug.cgi?id=918785