### PR TITLE
Render 404 on barclamp_index in HTML (bnc#916221)

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -39,7 +39,7 @@ class BarclampController < ApplicationController
   def barclamp_index
     @barclamps = ServiceObject.all
     respond_to do |format|
-      format.html { render :template => 'barclamp/barclamp_index' }
+      format.html { raise ActionController::RoutingError.new('Not Found') }
       format.xml  { render :xml => @barclamps }
       format.json { render :json => @barclamps }
     end

--- a/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
@@ -34,12 +34,10 @@ describe CrowbarController do
   end
 
   describe "GET barclamp_index" do
-    it "renders list of all barclamps" do
-      skip("FIXME")
-
-      get :barclamp_index
-      response.should be_success
-      assigns(:barclamps).should include("crowbar")
+    it "renders page not found as html" do
+      expect {
+        get :barclamp_index
+      }.to raise_error(ActionController::RoutingError)
     end
 
     it "returns list of barclamp names as json" do


### PR DESCRIPTION
This action is not rendered in HTML, only as JSON when using the API.

Raise 404 when viewed as HTML, so rails will render it's standard
not-found page, as suggested in the BNC entry.

cc @vmoravec