### PR TITLE
Fix for link_to_device on SLE12 for virtio disks, (bnc#919469)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1351,7 +1351,7 @@ class NodeObject < ChefObject
     return true if device == linkname
     lookup_and_name = linkname.gsub(/^\/dev\/disk\//, '').split(File::SEPARATOR, 2)
     linked_devs = @node[:block_device][device][:disks][lookup_and_name[0]] rescue []
-    linked_devs.include?(lookup_and_name[1])
+    linked_devs.include?(lookup_and_name[1]) rescue false
   end
 
   # IMPORTANT: keep these paths in sync with


### PR DESCRIPTION
Bug https://bugzilla.suse.com/show_bug.cgi?id=919469

This is fix when virtio disk and the target platform is one that might not have the "by-path" links (e.g. SLES 12). Avoid using "by-path".

This can occur for `{"/dev/vda"=>{"owner"=>"Boot"}}`