### PR TITLE
Fix hideShowClusterConf.js when a cluster is assigned to role on load

### DIFF
--- a/crowbar_framework/app/assets/javascripts/jquery/hideShowClusterConf.js
+++ b/crowbar_framework/app/assets/javascripts/jquery/hideShowClusterConf.js
@@ -24,10 +24,10 @@
   HideShowClusterConf.prototype.initialize = function() {
     var self = this;
 
-    var clusters = $.grep($(this.options.deployment_storage).readJsonAttribute(this.options.deployment_path), this.isCluster);
-    this.clusters_allocated = clusters.length;
-
-    if (this.clusters_allocated == 0) { this.root.hide(); }
+    // if a cluster is already in use, then we'll get the nodeListNodeAllocated
+    // event on page load
+    this.clusters_allocated = 0;
+    this.root.hide();
 
     $(document).on('nodeListNodeAllocated', function(evt, data) {
       if (self.isCluster(data.id)) {


### PR DESCRIPTION
We were counting the same cluster twice: once by looking at the
attributes, and once due to the nodeListNodeAllocated event that happens
on page load.