### PR TITLE
Fix linkname check

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1346,9 +1346,9 @@ class NodeObject < ChefObject
   # that means that the given linkname can be found in the array
   # @node[:block_device][device][by-{id,path,uuid}]
   def link_to_device?(device, linkname)
-    # device is i.e. "/dev/sda", "/dev/vda", ...
+    # device is i.e. "sda", "vda", ...
     # linkname is i.e. "/dev/disk/by-path/pci-0000:00:04.0-virtio-pci-virtio1"
-    return true if device == linkname
+    return true if File.join("", "dev", device) == linkname
     lookup_and_name = linkname.gsub(/^\/dev\/disk\//, '').split(File::SEPARATOR, 2)
     linked_devs = @node[:block_device][device][:disks][lookup_and_name[0]] rescue []
     linked_devs.include?(lookup_and_name[1])


### PR DESCRIPTION
Commit 2ad06ccf3f89e36697581621418dc3f545277679 was wrong. The "device"
parameter given to link_to_device?() is for instance "vda" (without a
trailing "/dev"). But the linkname is the full path in the case where
linkname is the device name.