### PR TITLE
Make NodeObject.group_order return a unique value

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1051,7 +1051,7 @@ class NodeObject < ChefObject
       if switch_port.nil? or switch_port == -1
         self.alias
       else
-        switch_name + "%05d" % switch_unit.to_i + "%05d" % switch_port.to_i
+        switch_name + "%05d" % switch_unit.to_i + "%05d" % switch_port.to_i + self.alias
       end
     rescue
        self.alias


### PR DESCRIPTION
The node dashboard relies on the fact that group_order is different for
each node. This was not the case when two nodes are actually VMWare VMs
that are ultimately plugged in the same switch.

So instead of only relying on the information of where the node is
plugged on the switch, also append to that the alias of the node to
ensure group_order is unique.