### PR TITLE
[WIP] feature/sqlite storage

### DIFF
--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -51,9 +51,9 @@ class ChefObject
     str.gsub("-:") { |c| '\\' + c }
   end
 
-  def export(name = nil)
-    name ||= self.respond_to?(:name) ? self.name : "unknown"
-    file   = Rails.root.join("db", "#{self.chef_type}_#{name}.json")
-    File.open(file, "w") { |f| f.write(self.to_json) }
+  def export(name = nil, obj = self)
+    name ||= obj.respond_to?(:name) ? obj.name : "unknown"
+    file   = Rails.root.join("db", "#{obj.chef_type}_#{name}.json")
+    File.open(file, "w") { |f| f.write(obj.to_json) }
   end
 end

--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -55,9 +55,13 @@ class ChefObject
   # can be exported in a same way as the ProposalObject. When the replacement
   # is completed, remove it and implement the export in the Proposal.
   # Also check the logging barclamp that it did not break.
-  def export(name = nil, obj = self)
+  def self.export(obj, name = nil)
     name ||= obj.respond_to?(:name) ? obj.name : "unknown"
     file   = Rails.root.join("db", "#{obj.chef_type}_#{name}.json")
     File.open(file, "w") { |f| f.write(obj.to_json) }
+  end
+
+  def export(name = nil)
+    self.class.export(self, name)
   end
 end

--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -51,6 +51,10 @@ class ChefObject
     str.gsub("-:") { |c| '\\' + c }
   end
 
+  # FIXME: the second argument was added so that the Proposal model
+  # can be exported in a same way as the ProposalObject. When the replacement
+  # is completed, remove it and implement the export in the Proposal.
+  # Also check the logging barclamp that it did not break.
   def export(name = nil, obj = self)
     name ||= obj.respond_to?(:name) ? obj.name : "unknown"
     file   = Rails.root.join("db", "#{obj.chef_type}_#{name}.json")

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -29,6 +29,30 @@ class Proposal < ActiveRecord::Base
     super
   end
 
+  def self.find_proposals(barclamp)
+    where(:barclamp => barclamp)
+  end
+
+  def self.find_barclamp(barclamp)
+    self.new(:barclamp => barclamp, :name => "template")
+  end
+
+  def self.find_proposal(barclamp, name)
+    where(:barclamp => barclamp, :name => name).first
+  end
+
+  # XXX: the networks will still be backed by ProposalObject for now,
+  # so it is not neccessary to handle them here.
+  # We still need to handle lookups for templates, though.
+  def self.find_proposal_by_id(id)
+    _, barclamp_or_template, name = *id.split("-")
+    if barclamp_or_template == "template"
+      self.new(:barclamp => name, :name => "template")
+    else
+      where(:barclamp => barclamp_or_template, :name => name).first
+    end
+  end
+
   def to_json
     self.properties.to_json
   end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -17,7 +17,7 @@ class Proposal < ActiveRecord::Base
   validate  :name, :name_not_on_blacklist
   validates :name, uniqueness: { scope: :barclamp }
 
-  after_initialize :load_properties_template
+  after_initialize :load_properties_template, :set_default_name
   before_save      :update_proposal_id
 
   # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory
@@ -110,6 +110,10 @@ class Proposal < ActiveRecord::Base
       # XXX: this assumes barclamps are cloned in the same directory
       Rails.root.join("../../barclamp-#{self.barclamp}/chef/data_bags/crowbar/bc-template-#{self.barclamp}.json").expand_path
     end
+  end
+
+  def set_default_name
+    self.name ||= "template"
   end
 
   def update_proposal_id

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -67,7 +67,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def export
-    ChefObject.new.export(self.name, self)
+    ChefObject.export(self)
   end
 
   # FIXME: this is not correct, the item of ProposalObject returns

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -1,3 +1,5 @@
 class Proposal < ActiveRecord::Base
   serialize :properties, JSON
+
+  validates :name, :barclamp, :properties, :presence => true
 end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -11,6 +11,7 @@ class Proposal < ActiveRecord::Base
   validates :name, :uniqueness => { :scope => :barclamp }
 
   after_initialize :load_properties_template
+  before_save      :update_proposal_id
 
   # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory
   # method for creating them. Then the check for barclamp arg would not be needed,
@@ -41,5 +42,9 @@ class Proposal < ActiveRecord::Base
 
   def properties_template_path
     Rails.root.join("../../barclamp-#{self.barclamp}/chef/data_bags/crowbar/bc-template-#{self.barclamp}.json").expand_path
+  end
+
+  def update_proposal_id
+    self.properties["id"] = "bc-#{self.barclamp}-#{self.name}"
   end
 end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -1,0 +1,3 @@
+class Proposal < ActiveRecord::Base
+  serialize :properties, JSON
+end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -3,6 +3,7 @@ class Proposal < ActiveRecord::Base
 
   validates :name, :barclamp, :properties, :presence => true
   validate  :name, :name_not_on_blacklist
+  validates :name, :uniqueness => { :scope => :barclamp }
 
   private
 

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -2,4 +2,15 @@ class Proposal < ActiveRecord::Base
   serialize :properties, JSON
 
   validates :name, :barclamp, :properties, :presence => true
+  validate  :name, :name_not_on_blacklist
+
+  private
+
+  def name_not_on_blacklist
+    forbidden_names = ["template", "nodes", "commit", "status"]
+
+    if forbidden_names.include?(self.name)
+      self.errors.add(:name, "Name cannot be any of #{forbidden_names.to_sentence}.")
+    end
+  end
 end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -70,6 +70,9 @@ class Proposal < ActiveRecord::Base
     ChefObject.new.export(self.name, self)
   end
 
+  # FIXME: this is not correct, the item of ProposalObject returns
+  # couchdb/serialization related attributes. This is equivalent to raw_data
+  # instead.
   def item
     self.properties
   end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -1,7 +1,7 @@
 class Proposal < ActiveRecord::Base
   include Crowbar::ProposalMethods
 
-  # FIXME: remove this
+  # FIXME: remove this when the export is properly implemented
   class_attribute :chef_type
 
   self.chef_type = "data_bag_item"

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -104,7 +104,12 @@ class Proposal < ActiveRecord::Base
   end
 
   def properties_template_path
-    Rails.root.join("../../barclamp-#{self.barclamp}/chef/data_bags/crowbar/bc-template-#{self.barclamp}.json").expand_path
+    if Rails.env.production?
+      Rails.root.join("../chef/data_bags/crowbar/bc-template-#{self.barclamp}.json").expand_path
+    else
+      # XXX: this assumes barclamps are cloned in the same directory
+      Rails.root.join("../../barclamp-#{self.barclamp}/chef/data_bags/crowbar/bc-template-#{self.barclamp}.json").expand_path
+    end
   end
 
   def update_proposal_id

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -6,11 +6,11 @@ class Proposal < ActiveRecord::Base
 
   serialize :properties, JSON
 
-  validates :name, :barclamp, :properties, :presence => true
+  validates :name, :barclamp, :properties, presence: true
   validate  :name, :name_not_on_blacklist
-  validates :name, :uniqueness => { :scope => :barclamp }
+  validates :name, uniqueness: { scope: :barclamp }
 
-  after_initialize :load_properties_template
+  after_initialize :load_properties_template, :set_item_attribute
   before_save      :update_proposal_id
 
   # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -33,6 +33,15 @@ class Proposal < ActiveRecord::Base
     self.properties.to_json
   end
 
+  # FIXME: equivalent to ProposalObject.id
+  def key
+    if name == "template"
+      "bc-#{self.name}-#{self.barclamp}"
+    else
+      "bc-#{self.barclamp}-#{self.name}"
+    end
+  end
+
   def export
     ChefObject.new.export(self.name, self)
   end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -1,9 +1,25 @@
 class Proposal < ActiveRecord::Base
+  # FIXME: add proper i18n to errors
+
+  class TemplateMissing < StandardError; end
+  class TemplateInvalid < StandardError; end
+
   serialize :properties, JSON
 
   validates :name, :barclamp, :properties, :presence => true
   validate  :name, :name_not_on_blacklist
   validates :name, :uniqueness => { :scope => :barclamp }
+
+  after_initialize :load_properties_template
+
+  # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory
+  # method for creating them. Then the check for barclamp arg would not be needed,
+  # as we'd always know the barclamp exists.
+  def initialize(attributes = nil, options = {})
+    raise ArgumentError.new("Barclamp attribute is required") unless attributes && attributes.key?(:barclamp)
+
+    super
+  end
 
   private
 
@@ -13,5 +29,17 @@ class Proposal < ActiveRecord::Base
     if forbidden_names.include?(self.name)
       self.errors.add(:name, "Name cannot be any of #{forbidden_names.to_sentence}.")
     end
+  end
+
+  def load_properties_template
+    self.properties ||= JSON.parse(File.read(properties_template_path))
+  rescue Errno::ENOENT, Errno::EACCES
+    raise TemplateMissing.new("Proposal template is missing or not readable for #{self.barclamp}. Please create #{properties_template_path}.")
+  rescue JSON::ParserError
+    raise TemplateInvalid.new("Please make sure template for #{self.barclamp} in #{properties_template_path} contains valid JSON.")
+  end
+
+  def properties_template_path
+    Rails.root.join("../../barclamp-#{self.barclamp}/chef/data_bags/crowbar/bc-template-#{self.barclamp}.json").expand_path
   end
 end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -17,7 +17,7 @@ class Proposal < ActiveRecord::Base
   validate  :name, :name_not_on_blacklist
   validates :name, uniqueness: { scope: :barclamp }
 
-  after_initialize :load_properties_template, :set_item_attribute
+  after_initialize :load_properties_template
   before_save      :update_proposal_id
 
   # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory
@@ -37,6 +37,18 @@ class Proposal < ActiveRecord::Base
     ChefObject.new.export(self.name, self)
   end
 
+  def item
+    self.properties
+  end
+
+  def raw_data
+    self.properties
+  end
+
+  def raw_data=(value)
+    self.properties = value
+  end
+
   private
 
   def name_not_on_blacklist
@@ -53,12 +65,6 @@ class Proposal < ActiveRecord::Base
     raise TemplateMissing.new("Proposal template is missing or not readable for #{self.barclamp}. Please create #{properties_template_path}.")
   rescue JSON::ParserError
     raise TemplateInvalid.new("Please make sure template for #{self.barclamp} in #{properties_template_path} contains valid JSON.")
-  end
-
-  # FIXME: @item needs to be set to keep compatibility with ProposalObject
-  # and is safe to remove later
-  def set_item_attribute
-    @item = OpenStruct.new(self.properties.merge(raw_data: self.properties))
   end
 
   def properties_template_path

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -126,6 +126,7 @@ class ProposalObject < ChefObject
     increment_crowbar_revision!
     Rails.logger.debug("Saving data bag item: #{@item["id"]} - #{crowbar_revision}")
     @item.save
+    save_proposal_in_sqlite
     Rails.logger.debug("Done saving data bag item: #{@item["id"]} - #{crowbar_revision}")
   end
 
@@ -136,6 +137,13 @@ class ProposalObject < ChefObject
   end
   
   private
+
+  def save_proposal_in_sqlite
+    attrs = { barclamp: self.barclamp, name: self.name }
+
+    prop = Proposal.where(attrs).first_or_initialize(attrs)
+    prop.update(attrs.merge(properties: @item.raw_data))
+  end
 
   def increment_crowbar_revision!
     @item["deployment"] ||= {}

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -89,6 +89,14 @@ class ProposalObject < ChefObject
     @item['id']
   end
 
+  def raw_data
+    item.raw_data
+  end
+
+  def raw_data=(value)
+    item.raw_data = value
+  end
+
   def export
     super("crowbar-bc-#{barclamp}-#{name}")
   end

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -16,6 +16,8 @@
 #
 
 class ProposalObject < ChefObject
+  include Crowbar::ProposalMethods
+
   self.chef_type = "data_bag_item"
 
   BC_PREFIX = 'bc-template-'
@@ -79,60 +81,16 @@ class ProposalObject < ChefObject
     return val.nil? ? nil : ProposalObject.new(val)
   end
 
-  def raw_attributes
-    @raw_attributes ||= begin
-      raw_data["attributes"][barclamp] || {}
-    end
-  end
-
-  def pretty_attributes
-    @pretty_attributes ||= begin
-      Utils::ExtendedHash.new(
-        raw_attributes.dup
-      )
-    end
-  end
-
-  def pretty_attributes_json
-    JSON.pretty_generate(
-      JSON.parse(
-        (raw_data["attributes"][barclamp] || {}).to_json
-      )
-    )
-  end
-
-  def raw_deployment
-    @raw_deployment ||= begin
-      raw_data["deployment"][barclamp] || {}
-    end
-  end
-
-  def pretty_deployment
-    @pretty_deployment ||= begin
-      Utils::ExtendedHash.new(
-        raw_data["deployment"][barclamp].dup
-      )
-    end
-  end
-
-  def pretty_deployment_json
-    JSON.pretty_generate(
-      JSON.parse(
-        (raw_data["deployment"][barclamp] || {}).to_json
-      )
-    )
-  end
-
-  def category
-    @category ||= BarclampCatalog.category(barclamp)
-  end
-
-  def item
-    @item
+  def initialize(x)
+    @item = x
   end
 
   def id
     @item['id']
+  end
+
+  def export
+    super("crowbar-bc-#{barclamp}-#{name}")
   end
 
   def name
@@ -155,118 +113,6 @@ class ProposalObject < ChefObject
     end
   end
 
-  def prop
-    [barclamp, name].join("_")
-  end
-
-  def display_name
-    @display_name ||= BarclampCatalog.display_name(barclamp)
-  end
-
-  def allow_multiple_proposals?
-    ServiceObject.get_service(barclamp).allow_multiple_proposals?
-  end
-
-  #NOTE: Status is NOT accurate if the proposal has been deactivated!  You must check the role.
-  def status
-    bc = @item["deployment"][self.barclamp]
-    if bc.nil?
-      "hold"
-    else
-      return "unready" if bc["crowbar-committing"]
-      return "pending" if bc["crowbar-queued"]
-      return "hold" if !bc.has_key? "crowbar-queued" and !bc.has_key? "crowbar-committing"
-      if !bc.key? "crowbar-status" or bc["crowbar-status"] === "success"
-        "ready"
-      else
-        "failed"
-      end
-    end
-  end
-  
-  # nil if not appliciable, true = if success, false if failed
-  def failed?
-     status === 'failed'
-  end
-
-  # for locationlization, will lookup text before the :  
-  def fail_reason
-     s = if failed?
-       @item["deployment"][self.barclamp]["crowbar-failed"].to_s
-     elsif status === "ready"
-       "Did not fail.  Successfully applied: #{barclamp}-#{name} (status #{status})"
-     else
-       "No success information for proposal: #{barclamp}-#{name} (status #{status})"
-     end
-     out = s.split(":")
-     out[0] = I18n.t out[0], :default=> out[0]
-     return out.join(":").to_s
-  end
-  
-  def description
-    @item['description']
-  end
-  
-  def elements
-    @item.raw_data['deployment'][self.barclamp]["elements"]
-  end
-
-  def all_elements
-    @item.raw_data['deployment'][self.barclamp]["element_order"].flatten.uniq
-  end
-
-  def role
-    RoleObject.find_role_by_name("#{barclamp}-config-#{name}")
-  end
-
-  def crowbar_revision
-    @item["deployment"][barclamp]["crowbar-revision"].to_i rescue 0
-  end
-
-  def latest_applied?
-    @item["deployment"][barclamp]["crowbar-applied"] rescue false
-  end
-
-  def latest_applied=(applied)
-    @item["deployment"] ||= {}
-    @item["deployment"][barclamp] ||= {}
-    @item["deployment"][barclamp]["crowbar-applied"] = applied
-  end
-
-  def active?
-    !role.nil?
-  end
-
-  def raw_data
-    @item.raw_data
-  end
-
-  def raw_data=(value)
-    @item.raw_data = value
-  end
-
-  def [](attrib)
-    @item[attrib]
-  end
-
-  def []=(attrib, value)
-    @item[attrib] = value
-  end
-
-  def initialize(x)
-    @item = x
-  end
-
-  def increment_crowbar_revision!
-    @item["deployment"] ||= {}
-    @item["deployment"][barclamp] ||= {}
-    if @item["deployment"][barclamp]["crowbar-revision"].nil?
-      @item["deployment"][barclamp]["crowbar-revision"] = 0
-    else
-      @item["deployment"][barclamp]["crowbar-revision"] += 1
-    end
-  end
-
   def save(options = {})
     self.latest_applied = !!options[:applied]
     increment_crowbar_revision!
@@ -281,11 +127,18 @@ class ProposalObject < ChefObject
     Rails.logger.debug("Done removal of data bag item: #{@item["id"]} - #{crowbar_revision}")
   end
   
-  def export
-    super("crowbar-bc-#{barclamp}-#{name}")
-  end
-  
   private
+
+  def increment_crowbar_revision!
+    @item["deployment"] ||= {}
+    @item["deployment"][barclamp] ||= {}
+    if @item["deployment"][barclamp]["crowbar-revision"].nil?
+      @item["deployment"][barclamp]["crowbar-revision"] = 0
+    else
+      @item["deployment"][barclamp]["crowbar-revision"] += 1
+    end
+  end
+
   
   # 'array' is the unsorted set of objects
   # 'att_sym' is the symbol of the attribute each object in array, that is represented in index_array

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -150,7 +150,7 @@ class ProposalObject < ChefObject
     attrs = { barclamp: self.barclamp, name: self.name }
 
     prop = Proposal.where(attrs).first_or_initialize(attrs)
-    prop.update(attrs.merge(properties: @item.raw_data))
+    prop.update(attrs.merge(properties: @item.raw_data)) if @item.raw_data != prop.raw_data
   end
 
   def increment_crowbar_revision!

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -133,10 +133,18 @@ class ProposalObject < ChefObject
   def destroy
     Rails.logger.debug("Destroying data bag item: #{@item["id"]} - #{crowbar_revision}")
     @item.destroy(@item.data_bag, @item["id"])
+    delete_proposal_from_sqlite
     Rails.logger.debug("Done removal of data bag item: #{@item["id"]} - #{crowbar_revision}")
   end
   
   private
+
+  def delete_proposal_from_sqlite
+    attrs = { barclamp: self.barclamp, name: self.name }
+
+    prop = Proposal.where(attrs).first
+    prop.destroy if prop
+  end
 
   def save_proposal_in_sqlite
     attrs = { barclamp: self.barclamp, name: self.name }

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -496,6 +496,7 @@ class ServiceObject
 #
 # update proposal status information
 #
+  # FIXME: refactor into Proposal#status=()
   def update_proposal_status(inst, status, message, bc = @bc_name)
     @logger.debug("update_proposal_status: enter #{inst} #{bc} #{status} #{message}")
 
@@ -541,6 +542,7 @@ class ServiceObject
     end
   end
 
+  # FIXME: Move into proposal before_save filter
   def clean_proposal(proposal)
     @logger.debug "clean_proposal"
     proposal.delete("controller")
@@ -576,6 +578,9 @@ class ServiceObject
     end
   end
 
+  # FIXME: these methods operate on a proposal and the controller has access o
+  # bc_name/inst anyway. So it might be better to not pollute the inheritance
+  # chain.
   def elements
     [200, ProposalObject.find_barclamp(@bc_name).all_elements]
   end
@@ -620,6 +625,7 @@ class ServiceObject
   #
   # Utility method to find instances for barclamps we depend on
   #
+  # FIXME: a registry that could be queried for active barclamps
   def find_dep_proposal(bc, optional=false)
     begin
       const_service = self.class.get_service(bc)
@@ -679,12 +685,14 @@ class ServiceObject
   #
   # This can be overridden to provide a better creation proposal
   #
+  # FIXME: check if it is overridden and move to caller
   def create_proposal
     prop = ProposalObject.find_proposal("template", @bc_name)
     raise(I18n.t('model.service.template_missing', :name => @bc_name )) if prop.nil?
     prop.raw_data
   end
 
+  # FIXME: looks like purely controller methods
   def proposal_create(params)
     base_id = params["id"]
     params["id"] = "bc-#{@bc_name}-#{params["id"]}"
@@ -734,6 +742,8 @@ class ServiceObject
     end
   end
 
+  # FIXME: most of these can be validations on the model itself,
+  # preferrably refactored into Validator classes.
   def save_proposal!(prop, options = {})
     options.reverse_merge!(:validate_after_save => true)
     clean_proposal(prop.raw_data)
@@ -743,6 +753,9 @@ class ServiceObject
     validate_proposal_after_save(prop.raw_data) if options[:validate_after_save]
   end
 
+  # XXX: this is where proposal gets copied into a role, scheduling / ops order
+  # is computed (in apply_role) and chef client gets called on the nodes.
+  # Hopefully, this will get moved into a background job.
   def proposal_commit(inst, in_queue = false, validate_after_save = true)
     prop = ProposalObject.find_proposal(@bc_name, inst)
 
@@ -778,6 +791,7 @@ class ServiceObject
   #
   # This can be overridden.  Specific to node validation.
   #
+  # FIXME: move into validator classes
   def validate_proposal_elements proposal_elements
     proposal_elements.each do |role_and_elements|
       role, elements = role_and_elements
@@ -1039,6 +1053,7 @@ class ServiceObject
   # This is a role output function
   # Can take either a RoleObject or a Role.
   #
+  # FIXME: check if it is ever used except for controller
   def self.role_to_proposal(role, bc_name)
     proposal = {}
 

--- a/crowbar_framework/db/migrate/20150312081459_create_proposals.rb
+++ b/crowbar_framework/db/migrate/20150312081459_create_proposals.rb
@@ -1,0 +1,11 @@
+class CreateProposals < ActiveRecord::Migration
+  def change
+    create_table :proposals do |t|
+      t.string :barclamp, :null => false
+      t.string :name, :null => false
+      t.text :properties
+    end
+
+    add_index :proposals, [:barclamp, :name], :unique => true
+  end
+end

--- a/crowbar_framework/db/schema.rb
+++ b/crowbar_framework/db/schema.rb
@@ -11,9 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140526135328) do
+ActiveRecord::Schema.define(version: 20150312081459) do
 
-  create_table "sessions", force: true do |t|
+  create_table "proposals", force: :cascade do |t|
+    t.string "barclamp",   null: false
+    t.string "name",       null: false
+    t.text   "properties"
+  end
+
+  add_index "proposals", ["barclamp", "name"], name: "index_proposals_on_barclamp_and_name", unique: true
+
+  create_table "sessions", force: :cascade do |t|
     t.string   "session_id", null: false
     t.text     "data"
     t.datetime "created_at"

--- a/crowbar_framework/lib/crowbar/proposal_methods.rb
+++ b/crowbar_framework/lib/crowbar/proposal_methods.rb
@@ -81,12 +81,12 @@ module Crowbar
       end
     end
     
-    # nil if not appliciable, true = if success, false if failed
+    # nil if not applicable, true = if success, false if failed
     def failed?
        status === 'failed'
     end
 
-    # for locationlization, will lookup text before the :  
+    # for localization, will lookup text before the :  
     def fail_reason
        s = if failed?
          item["deployment"][self.barclamp]["crowbar-failed"].to_s

--- a/crowbar_framework/lib/crowbar/proposal_methods.rb
+++ b/crowbar_framework/lib/crowbar/proposal_methods.rb
@@ -105,11 +105,11 @@ module Crowbar
     end
     
     def elements
-      item.raw_data['deployment'][self.barclamp]["elements"]
+      raw_data['deployment'][self.barclamp]["elements"]
     end
 
     def all_elements
-      item.raw_data['deployment'][self.barclamp]["element_order"].flatten.uniq
+      raw_data['deployment'][self.barclamp]["element_order"].flatten.uniq
     end
 
     def role
@@ -132,14 +132,6 @@ module Crowbar
 
     def active?
       !role.nil?
-    end
-
-    def raw_data
-      item.raw_data
-    end
-
-    def raw_data=(value)
-      item.raw_data = value
     end
 
     def [](attrib)

--- a/crowbar_framework/lib/crowbar/proposal_methods.rb
+++ b/crowbar_framework/lib/crowbar/proposal_methods.rb
@@ -66,7 +66,7 @@ module Crowbar
 
     #NOTE: Status is NOT accurate if the proposal has been deactivated!  You must check the role.
     def status
-      bc = @item["deployment"][self.barclamp]
+      bc = item["deployment"][self.barclamp]
       if bc.nil?
         "hold"
       else
@@ -89,7 +89,7 @@ module Crowbar
     # for locationlization, will lookup text before the :  
     def fail_reason
        s = if failed?
-         @item["deployment"][self.barclamp]["crowbar-failed"].to_s
+         item["deployment"][self.barclamp]["crowbar-failed"].to_s
        elsif status === "ready"
          "Did not fail.  Successfully applied: #{barclamp}-#{name} (status #{status})"
        else
@@ -101,15 +101,15 @@ module Crowbar
     end
     
     def description
-      @item['description']
+      item['description']
     end
     
     def elements
-      @item.raw_data['deployment'][self.barclamp]["elements"]
+      item.raw_data['deployment'][self.barclamp]["elements"]
     end
 
     def all_elements
-      @item.raw_data['deployment'][self.barclamp]["element_order"].flatten.uniq
+      item.raw_data['deployment'][self.barclamp]["element_order"].flatten.uniq
     end
 
     def role
@@ -117,17 +117,17 @@ module Crowbar
     end
 
     def crowbar_revision
-      @item["deployment"][barclamp]["crowbar-revision"].to_i rescue 0
+      item["deployment"][barclamp]["crowbar-revision"].to_i rescue 0
     end
 
     def latest_applied?
-      @item["deployment"][barclamp]["crowbar-applied"] rescue false
+      item["deployment"][barclamp]["crowbar-applied"] rescue false
     end
 
     def latest_applied=(applied)
-      @item["deployment"] ||= {}
-      @item["deployment"][barclamp] ||= {}
-      @item["deployment"][barclamp]["crowbar-applied"] = applied
+      item["deployment"] ||= {}
+      item["deployment"][barclamp] ||= {}
+      item["deployment"][barclamp]["crowbar-applied"] = applied
     end
 
     def active?
@@ -135,19 +135,19 @@ module Crowbar
     end
 
     def raw_data
-      @item.raw_data
+      item.raw_data
     end
 
     def raw_data=(value)
-      @item.raw_data = value
+      item.raw_data = value
     end
 
     def [](attrib)
-      @item[attrib]
+      item[attrib]
     end
 
     def []=(attrib, value)
-      @item[attrib] = value
+      item[attrib] = value
     end
   end
 end

--- a/crowbar_framework/lib/crowbar/proposal_methods.rb
+++ b/crowbar_framework/lib/crowbar/proposal_methods.rb
@@ -1,0 +1,153 @@
+module Crowbar
+  module ProposalMethods
+    def raw_attributes
+      @raw_attributes ||= begin
+        raw_data["attributes"][self.barclamp] || {}
+      end
+    end
+
+    def pretty_attributes
+      @pretty_attributes ||= begin
+        Utils::ExtendedHash.new(
+          raw_attributes.dup
+        )
+      end
+    end
+
+    def pretty_attributes_json
+      JSON.pretty_generate(
+        JSON.parse(
+          (raw_data["attributes"][barclamp] || {}).to_json
+        )
+      )
+    end
+
+    def raw_deployment
+      @raw_deployment ||= begin
+        raw_data["deployment"][barclamp] || {}
+      end
+    end
+
+    def pretty_deployment
+      @pretty_deployment ||= begin
+        Utils::ExtendedHash.new(
+          raw_data["deployment"][barclamp].dup
+        )
+      end
+    end
+
+    def pretty_deployment_json
+      JSON.pretty_generate(
+        JSON.parse(
+          (raw_data["deployment"][barclamp] || {}).to_json
+        )
+      )
+    end
+
+    def category
+      @category ||= BarclampCatalog.category(barclamp)
+    end
+
+    def item
+      @item
+    end
+
+    def prop
+      [barclamp, name].join("_")
+    end
+
+    def display_name
+      @display_name ||= BarclampCatalog.display_name(barclamp)
+    end
+
+    def allow_multiple_proposals?
+      ServiceObject.get_service(barclamp).allow_multiple_proposals?
+    end
+
+    #NOTE: Status is NOT accurate if the proposal has been deactivated!  You must check the role.
+    def status
+      bc = @item["deployment"][self.barclamp]
+      if bc.nil?
+        "hold"
+      else
+        return "unready" if bc["crowbar-committing"]
+        return "pending" if bc["crowbar-queued"]
+        return "hold" if !bc.has_key? "crowbar-queued" and !bc.has_key? "crowbar-committing"
+        if !bc.key? "crowbar-status" or bc["crowbar-status"] === "success"
+          "ready"
+        else
+          "failed"
+        end
+      end
+    end
+    
+    # nil if not appliciable, true = if success, false if failed
+    def failed?
+       status === 'failed'
+    end
+
+    # for locationlization, will lookup text before the :  
+    def fail_reason
+       s = if failed?
+         @item["deployment"][self.barclamp]["crowbar-failed"].to_s
+       elsif status === "ready"
+         "Did not fail.  Successfully applied: #{barclamp}-#{name} (status #{status})"
+       else
+         "No success information for proposal: #{barclamp}-#{name} (status #{status})"
+       end
+       out = s.split(":")
+       out[0] = I18n.t out[0], :default=> out[0]
+       return out.join(":").to_s
+    end
+    
+    def description
+      @item['description']
+    end
+    
+    def elements
+      @item.raw_data['deployment'][self.barclamp]["elements"]
+    end
+
+    def all_elements
+      @item.raw_data['deployment'][self.barclamp]["element_order"].flatten.uniq
+    end
+
+    def role
+      RoleObject.find_role_by_name("#{barclamp}-config-#{name}")
+    end
+
+    def crowbar_revision
+      @item["deployment"][barclamp]["crowbar-revision"].to_i rescue 0
+    end
+
+    def latest_applied?
+      @item["deployment"][barclamp]["crowbar-applied"] rescue false
+    end
+
+    def latest_applied=(applied)
+      @item["deployment"] ||= {}
+      @item["deployment"][barclamp] ||= {}
+      @item["deployment"][barclamp]["crowbar-applied"] = applied
+    end
+
+    def active?
+      !role.nil?
+    end
+
+    def raw_data
+      @item.raw_data
+    end
+
+    def raw_data=(value)
+      @item.raw_data = value
+    end
+
+    def [](attrib)
+      @item[attrib]
+    end
+
+    def []=(attrib, value)
+      @item[attrib] = value
+    end
+  end
+end

--- a/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-bc-template-crowbar.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-bc-template-crowbar.json
@@ -1,1 +1,49 @@
-{"name":"data_bag_item_crowbar_bc-template-crowbar","_rev":"2-35230a2246b379e3c48ad96479954282","raw_data":{"attributes":{"rails":{"max_pool_size":256,"environment":"development"},"crowbar":{"barclamps":["crowbar","deployer","ipmi","network","provisioner","redhat_install","ubuntu_install","ntp","dns","nagios","ganglia","logging"],"instances":{"deployer":["default"],"nagios":["default"],"ubuntu_install":["default"],"provisioner":["default"],"network":["default"],"ipmi":["default"],"ganglia":["default"],"logging":["default"],"dns":["default"],"ntp":["default"],"redhat_install":["default"]},"web_port":3000,"run_order":{"deployer":10,"nagios":60,"ubuntu_install":14,"provisioner":1060,"network":20,"ipmi":17,"ganglia":70,"logging":40,"dns":30,"ntp":50,"redhat_install":14},"users":{"machine-install":{"password":"58de2643926c6b975f711e16177c23164eda08b6bf1e51047345e9ec905d680662ea1b63876ed8d6234d66a196580400a1907e13f9a3b6924524f382440c2910"},"crowbar":{"password":"crowbar"}},"realm":"Crowbar - By selecting OK are agreeing to the License Agreement"}},"id":"bc-template-crowbar","description":"Self-referential barclamp enabling other barclamps","deployment":{"crowbar":{"element_order":[["crowbar"]],"config":{"transitions":false,"transition_list":[],"mode":"full","environment":"crowbar-config-test"},"crowbar-revision":0,"elements":{}}}},"json_class":"Chef::DataBagItem","data_bag":"crowbar","chef_type":"data_bag_item"}
+{"name":"data_bag_item_crowbar_bc-template-crowbar","_rev":"2-35230a2246b379e3c48ad96479954282","raw_data":{
+  "id": "bc-template-crowbar",
+  "description": "Self-referential barclamp enabling other barclamps",
+  "attributes": {
+    "crowbar": {
+      "instances": {
+        "deployer": [ "default" ],
+        "ipmi": [ "default" ],
+        "provisioner": [ "default" ],
+        "network": [ "default" ],
+        "ntp": [ "default" ],
+        "dns": [ "default" ],
+        "nagios": [ "default" ],
+        "ganglia": [ "default" ],
+        "logging": [ "default" ]
+      },
+      "realm": "Crowbar - By selecting OK you are agreeing to the License Agreement",
+      "web_port": 3000,
+      "users": {
+        "machine-install": { "password": "machine_password" },
+        "crowbar": { "password": "crowbar" }
+      },
+      "simple_proposal_ui": true
+    },
+    "rails": {
+      "max_pool_size": 256,
+      "environment": "production"
+    }
+  },
+  "deployment": {
+    "crowbar": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "element_states": {
+        "crowbar": [ "all" ]
+      },
+      "elements": {},
+      "element_order": [
+        [ "crowbar" ]
+      ],
+      "config": {
+        "environment": "crowbar-config-test",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": [ ]
+      }
+    }
+  }
+},"json_class":"Chef::DataBagItem","data_bag":"crowbar","chef_type":"data_bag_item"}

--- a/crowbar_framework/spec/models/proposal_object_spec.rb
+++ b/crowbar_framework/spec/models/proposal_object_spec.rb
@@ -18,6 +18,41 @@
 require 'spec_helper'
 
 describe ProposalObject do
+  describe "save" do
+    let(:proposal) { ProposalObject.find_proposal_by_id("bc-crowbar-default") }
+
+    before(:each) { Proposal.delete_all }
+
+    before { proposal.item.stubs(:save).returns(true) }
+
+    it "creates equivalent proposal model" do
+      expect {
+        proposal.save
+      }.to change {
+        Proposal.count
+      }.by(1)
+
+      # While raw_data are equivalent, the ProposalObject.item differs as
+      # Proposal doesn't store this data.
+      expect(proposal.raw_data.to_json).to eq(Proposal.last.raw_data.to_json)
+    end
+
+    it "updates changes" do
+      proposal.save
+
+      new_description = "Just a test"
+      proposal.raw_data["description"] = new_description
+
+      expect {
+        proposal.save
+      }.to_not change {
+        Proposal.count
+      }
+
+      expect(Proposal.last.description).to eq(new_description)
+    end
+  end
+
   describe "barclamp" do
     it "returns barclamp for regular proposals" do
       proposal = ProposalObject.find_proposal_by_id("bc-crowbar-default")

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -30,5 +30,18 @@ describe Proposal do
       expect(proposal).to_not be_valid
       expect(proposal.errors[:name]).to_not be_empty
     end
+
+    it "name and barclamp combination is unique" do
+      proposal = nil
+      begin
+        proposal = Proposal.create!(:barclamp => "database", :name => "default", :properties => { :foo => :bar })
+        another  = Proposal.new(:barclamp => "database", :name => "default", :properties => {:foo => :bar})
+
+        expect(another).to_not be_valid
+        expect(another.errors[:name]).to_not be_empty
+      ensure
+        proposal.destroy if proposal
+      end
+    end
   end
 end

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Proposal do
+  let(:proposal) { Proposal.new }
+
+  describe "validations" do
+    it "is not valid without a barclamp" do
+      proposal.barclamp = nil
+      expect(proposal).to_not be_valid
+      expect(proposal.errors[:barclamp]).to_not be_empty
+    end
+
+    it "is not valid without a name" do
+      proposal.name = nil
+      expect(proposal).to_not be_valid
+      expect(proposal.errors[:name]).to_not be_empty
+    end
+
+    it "is not valid without any properties" do
+      proposal.properties = nil
+      expect(proposal).to_not be_valid
+      expect(proposal.errors[:properties]).to_not be_empty
+    end
+  end
+end

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe Proposal do
-  let(:proposal) { Proposal.new(:barclamp => "crowbar")}
+  let(:proposal) { Proposal.new(:barclamp => "crowbar", :name => "default")}
+
+  it "updates the proposal id before save" do
+    proposal.save
+    expect(proposal.properties["id"]).to eq("bc-crowbar-default")
+  end
 
   it "raises when barclamp is not specified in the constructor" do
     expect {

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -173,6 +173,12 @@ describe Proposal do
       expect(proposal.errors[:name]).to_not be_empty
     end
 
+    it "a template cannot be saved" do
+      prop = Proposal.new(:barclamp => "crowbar")
+      expect(prop.name).to eq("template")
+      expect(prop.save).to eq(false)
+    end
+
     it "name and barclamp combination is unique" do
       proposal = nil
       begin

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -3,6 +3,74 @@ require 'spec_helper'
 describe Proposal do
   let(:proposal) { Proposal.new(:barclamp => "crowbar", :name => "default")}
 
+  describe "Finders" do
+    before do
+      Proposal.delete_all
+      Proposal.create(:barclamp => "crowbar", :name => "default")
+    end
+
+    after do
+      Proposal.delete_all
+    end
+
+    describe "interface" do
+      [
+        :all,
+        :find,
+        :find_proposals,
+        :find_barclamp,
+        :find_proposal,
+        :find_proposal_by_id,
+      ].each do |method|
+        it "responds to #{method}" do
+          expect(proposal.class).to respond_to(method)
+        end
+      end
+    end
+
+    describe "find" do
+      it "returns proposals matching a search" do
+        skip("Incompatible API, fix call sites")
+      end
+    end
+
+    describe "find_data_bag_item" do
+      it "returns a bag" do
+        skip("Data bag item still handled by ProposalObject")
+      end
+    end
+
+    describe "all" do
+      it "returns all proposals" do
+        proposals = Proposal.all
+        expect(proposals).to_not be_empty
+        expect(proposals.all? { |p| p.is_a?(Proposal) }).to be true
+      end
+    end
+
+    describe "find_proposals" do
+      it "returns all barclamp proposals with a given name" do
+        proposals = Proposal.find_proposals("crowbar")
+        expect(proposals).to_not be_empty
+        expect(proposals.all? { |p| p.key == "bc-crowbar-default" }).to be true
+      end
+    end
+
+    describe "find_barclamp" do
+      it "returns a barclamp with a given name" do
+        barclamp = Proposal.find_barclamp("crowbar")
+        expect(barclamp.key).to eq("bc-template-crowbar")
+      end
+    end
+
+    describe "find_proposal_by_id" do
+      it "returns a matching proposal" do
+        proposal = Proposal.find_proposal_by_id("bc-crowbar-default")
+        expect(proposal.key).to eq("bc-crowbar-default")
+      end
+    end
+  end
+
   describe "API" do
     let(:proposal_object)   { ProposalObject.find_proposal_by_id("bc-template-crowbar") }
     let(:proposal_template) { Proposal.new(:barclamp => "crowbar", :name => "template")}

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -21,5 +21,14 @@ describe Proposal do
       expect(proposal).to_not be_valid
       expect(proposal.errors[:properties]).to_not be_empty
     end
+
+    it "is not valid if name is reserved" do
+      # Template is a name for proposal grabbed from the JSON, this should not be allowed.
+      # There is a bunch of other names that are illegal, but the list is private, see
+      # model validations.
+      proposal.name = "template"
+      expect(proposal).to_not be_valid
+      expect(proposal.errors[:name]).to_not be_empty
+    end
   end
 end

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -1,7 +1,29 @@
 require 'spec_helper'
 
 describe Proposal do
-  let(:proposal) { Proposal.new }
+  let(:proposal) { Proposal.new(:barclamp => "crowbar")}
+
+  it "raises when barclamp is not specified in the constructor" do
+    expect {
+      Proposal.new
+    }.to raise_error(ArgumentError)
+
+    expect {
+      Proposal.new(:name => "default")
+    }.to raise_error(ArgumentError)
+  end
+
+  describe "default properties loading" do
+    it "loads the properties based on barclamp" do
+      expect(proposal.properties).to_not be_empty
+    end
+
+    it "raises an error if the barclamp template does not exist" do
+      expect {
+        Proposal.new(:barclamp => "nonexistent_barclamp")
+      }.to raise_error(Proposal::TemplateMissing)
+    end
+  end
 
   describe "validations" do
     it "is not valid without a barclamp" do
@@ -34,8 +56,8 @@ describe Proposal do
     it "name and barclamp combination is unique" do
       proposal = nil
       begin
-        proposal = Proposal.create!(:barclamp => "database", :name => "default", :properties => { :foo => :bar })
-        another  = Proposal.new(:barclamp => "database", :name => "default", :properties => {:foo => :bar})
+        proposal = Proposal.create!(:barclamp => "crowbar", :name => "default", :properties => { :foo => :bar })
+        another  = Proposal.new(:barclamp => "crowbar", :name => "default", :properties => {:foo => :bar})
 
         expect(another).to_not be_valid
         expect(another.errors[:name]).to_not be_empty

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -2,23 +2,24 @@ require 'spec_helper'
 
 describe Proposal do
   let(:proposal) { Proposal.new(:barclamp => "crowbar", :name => "default")}
-  let(:proposal_object) { ProposalObject.find_proposal_by_id("bc-template-crowbar") }
 
   describe "API" do
+    let(:proposal_object)   { ProposalObject.find_proposal_by_id("bc-template-crowbar") }
     let(:proposal_template) { Proposal.new(:barclamp => "crowbar", :name => "template")}
 
-    let(:public_methods) { proposal_object.public_methods }
+    let(:checked_methods) { proposal_object.public_methods(false) + Crowbar::ProposalMethods.public_instance_methods }
+
     it "quacks like a ProposalObject" do
-      public_methods.each do |m|
+      checked_methods.each do |m|
         expect(proposal_template).to respond_to(m)
       end
     end
 
     it "returns the same values as ProposalObject" do
-      public_methods.reject do |m|
+      checked_methods.reject do |m|
         proposal_object.method(m).arity > 0 # Only getters
       end.reject do |m|
-        [:id]
+          [:id, :item, :save, :destroy, :export].include?(m) # These methods are incompatible and need attention
       end.each do |m|
         new_implementation = proposal_template.send(m)
         old_implementation = proposal_object.send(m)

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -2,6 +2,31 @@ require 'spec_helper'
 
 describe Proposal do
   let(:proposal) { Proposal.new(:barclamp => "crowbar", :name => "default")}
+  let(:proposal_object) { ProposalObject.find_proposal_by_id("bc-template-crowbar") }
+
+  describe "API" do
+    let(:proposal_template) { Proposal.new(:barclamp => "crowbar", :name => "template")}
+
+    let(:public_methods) { proposal_object.public_methods }
+    it "quacks like a ProposalObject" do
+      public_methods.each do |m|
+        expect(proposal_template).to respond_to(m)
+      end
+    end
+
+    it "returns the same values as ProposalObject" do
+      public_methods.reject do |m|
+        proposal_object.method(m).arity > 0 # Only getters
+      end.reject do |m|
+        [:id]
+      end.each do |m|
+        new_implementation = proposal_template.send(m)
+        old_implementation = proposal_object.send(m)
+
+        expect(old_implementation).to eq(new_implementation), "#{m.to_s} - old (#{old_implementation}) vs. new (#{new_implementation})"
+      end
+    end
+  end
 
   it "updates the proposal id before save" do
     proposal.save


### PR DESCRIPTION
This is a wip branch attempting to move proposals out of couch db into sqlite.

cc: @vuntz @tboerger @aspiers

Re-creating the pull request against a feature branch as this is not mergeable into master ATM.

The idea behind this is to create a `ProposalObject`-compatible replacement, then keep it in sync by adding hooks into `ProposalObject` `save` and `destroy` methods.

Bi-directional sync is still WIP, but it'd allow us to gradually replace the old `ProposalObject`, instead of making the switch in one step.

To reduce duplication, all common methods are refactored out into `ProposalMethods` module, then included into both classes. The rest is implemented by each class separately.

The API compatibility is tested using rspec, by checking that  both objects respond to the same set of public methods (and methods in the `ProposalMethods` module), and that getters (0-arity methods) in fact return the same result. Data from fixtures (in the case of `ProposalObject`) and those stored in sqlite (for `Proposal` model) are compared.

The most notable difference between the interfaces is the `id` method, which is used by `ActiveRecord` and so it cannot be implemented by `Proposal` (`key` is the corresponding method). There aren't many callers of `id`, so it should not be a big deal anyway.