### PR TITLE
remove broken collapse menu on port 80 page

### DIFF
--- a/crowbar_framework/index/index.html
+++ b/crowbar_framework/index/index.html
@@ -70,19 +70,11 @@
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
       <div class="container">
         <div class="navbar-header">
-          <button class="navbar-toggle" data-target=".navbar-collapse" data-toggle="collapse">
-            <span class="sr-only">
-              Navigation
-            </span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
           <a href="/" class="navbar-brand">
             <span class="title">Crowbar</span>
           </a>
         </div>
-        <div class="collapse navbar-collapse navbar-right">
+        <div class="navbar-right">
           <ul class="nav navbar-nav">
             <li><a id="dashboard" href="http://127.0.0.1:3000/">Go to dashboard</a></li>
           </ul>


### PR DESCRIPTION
As discussed [here](https://github.com/SUSE-Cloud/barclamp-crowbar/pull/18) we don't need the collapse menu as we only have a single link in the right navbar menu and don't want to depend on more CDN content.