### PR TITLE
add and adjust links on port 80 page

### DIFF
--- a/crowbar_framework/index/index.html
+++ b/crowbar_framework/index/index.html
@@ -70,13 +70,13 @@
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
       <div class="container">
         <div class="navbar-header">
-          <a href="/" class="navbar-brand">
+          <a href="/" class="navbar-brand dashboard">
             <span class="title">Crowbar</span>
           </a>
         </div>
         <div class="navbar-right">
           <ul class="nav navbar-nav">
-            <li><a id="dashboard" href="http://127.0.0.1:3000/">Go to dashboard</a></li>
+            <li><a class="dashboard" href="http://127.0.0.1:3000/">Go to dashboard</a></li>
           </ul>
         </div>
       </div>
@@ -91,7 +91,7 @@
         </div>
         <div class="panel-body">
           <p>
-            The Crowbar Admin Server is only running on port 3000, so please follow the link above to the Crowbar dashboard. If
+            The Crowbar Admin Server is only running on <a class="dashboard" href="http://127.0.0.1:3000/">port 3000</a>. If
             you still have problems feel free to visit the <a href="http://github.com/crowbar/crowbar/wiki">Crowbar site</a> for
             more information.
           </p>
@@ -106,7 +106,10 @@
     </div>
 
     <script>
-      document.getElementById("dashboard").href="http://" + window.location.host + ":3000";
+      var links_to_dashboard = document.getElementsByClassName("dashboard");
+      for (i = 0; i < links_to_dashboard.length; i++) {
+        links_to_dashboard[i].href="http://" + window.location.host + ":3000";
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
As @nkrinner suggested in [Bugzilla](https://bugzilla.suse.com/show_bug.cgi?id=922699) the panel-heading text could be a link to port 3000 as well.
This needs minor changes in the page's JavaScript.

Besides that, I found two other small issues:
- The top-left logo is a link to "/" which does nothing but lead to the same error page the user is already on. So shouldn't we change that to a link to port 3000 too?
- The JavaScript adds ":3000" to the current location which is fine when you reached that site directly via port 80. But if you work with port-forwarding like in our virtual cloud setups, the link then becomes something like "hardware:1180:3000" which is not valid nor working. Shouldn't we improve the script to remove the trailing ":\d*" first and then add the ":3000" ? 
```javascript
var url = document.createElement('a');
url.href = window.location.host;
dashboard_link = url.hostname + ":3000";
```
That might be still the wrong link then but at least it is a valid one.

This PR was previously opened on [SUSE-Cloud](https://github.com/SUSE-Cloud/barclamp-crowbar/pull/19) but probably belongs here as @vuntz suggested.