### PR TITLE
Bidirectional sync for models

### DIFF
--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -22,8 +22,8 @@ class Proposal < ActiveRecord::Base
 
   # FIXME: these are safe to remove once all barclamps are converted to use
   # Proposal instead of ProposalObject
-  after_destroy :drop_corresponding_proposal_object
-  after_save    :update_corresponding_proposal_object
+  before_destroy :drop_corresponding_proposal_object
+  before_save    :update_corresponding_proposal_object
 
   # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory
   # method for creating them. Then the check for barclamp arg would not be needed,

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -101,7 +101,7 @@ class Proposal < ActiveRecord::Base
         proposal_object.save(sync: false)
       end
     else
-      bag = Chef::DataBagItem.json_create({"raw_data" => self.properties, "data_bag" => "crowbar"})
+      bag = Chef::DataBagItem.json_create({"raw_data" => self.raw_data, "data_bag" => "crowbar"})
       proposal_object = ProposalObject.new(bag)
       proposal_object.save(sync: false)
     end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -20,6 +20,11 @@ class Proposal < ActiveRecord::Base
   after_initialize :load_properties_template, :set_default_name
   before_save      :update_proposal_id
 
+  # FIXME: these are safe to remove once all barclamps are converted to use
+  # Proposal instead of ProposalObject
+  after_destroy :drop_corresponding_proposal_object
+  after_save    :update_corresponding_proposal_object
+
   # XXX: a 'registered' barclamp could have a has_many :proposals and have a factory
   # method for creating them. Then the check for barclamp arg would not be needed,
   # as we'd always know the barclamp exists.
@@ -86,6 +91,26 @@ class Proposal < ActiveRecord::Base
   end
 
   private
+
+  # XXX: we need to be careful to not create an endless loop
+  def update_corresponding_proposal_object
+    proposal_object = ProposalObject.find_proposal_by_id(self.key)
+    if proposal_object
+      if proposal_object.raw_data != self.raw_data
+        proposal_object.raw_data = self.raw_data
+        proposal_object.save(sync: false)
+      end
+    else
+      bag = Chef::DataBagItem.json_create({"raw_data" => self.properties, "data_bag" => "crowbar"})
+      proposal_object = ProposalObject.new(bag)
+      proposal_object.save(sync: false)
+    end
+  end
+
+  def drop_corresponding_proposal_object
+    proposal_object = ProposalObject.find_proposal_by_id(self.key)
+    proposal_object.destroy(sync: false) if proposal_object
+  end
 
   def name_not_on_blacklist
     forbidden_names = ["template", "nodes", "commit", "status"]

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -97,13 +97,14 @@ class Proposal < ActiveRecord::Base
     proposal_object = ProposalObject.find_proposal_by_id(self.key)
     if proposal_object
       if proposal_object.raw_data != self.raw_data
+        increment_crowbar_revision!
         proposal_object.raw_data = self.raw_data
-        proposal_object.save(sync: false)
+        proposal_object.save(sync: false, update_revision: false)
       end
     else
       bag = Chef::DataBagItem.json_create({"raw_data" => self.raw_data, "data_bag" => "crowbar"})
       proposal_object = ProposalObject.new(bag)
-      proposal_object.save(sync: false)
+      proposal_object.save(sync: false, update_revision: false)
     end
   end
 

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -153,17 +153,6 @@ class ProposalObject < ChefObject
     prop.update(attrs.merge(properties: @item.raw_data)) if @item.raw_data != prop.raw_data
   end
 
-  def increment_crowbar_revision!
-    @item["deployment"] ||= {}
-    @item["deployment"][barclamp] ||= {}
-    if @item["deployment"][barclamp]["crowbar-revision"].nil?
-      @item["deployment"][barclamp]["crowbar-revision"] = 0
-    else
-      @item["deployment"][barclamp]["crowbar-revision"] += 1
-    end
-  end
-
-  
   # 'array' is the unsorted set of objects
   # 'att_sym' is the symbol of the attribute each object in array, that is represented in index_array
   # 'index_array' is the ordered array of values

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -126,14 +126,14 @@ class ProposalObject < ChefObject
     increment_crowbar_revision!
     Rails.logger.debug("Saving data bag item: #{@item["id"]} - #{crowbar_revision}")
     @item.save
-    save_proposal_in_sqlite
+    save_proposal_in_sqlite if options.fetch(:sync, true)
     Rails.logger.debug("Done saving data bag item: #{@item["id"]} - #{crowbar_revision}")
   end
 
-  def destroy
+  def destroy(options = {})
     Rails.logger.debug("Destroying data bag item: #{@item["id"]} - #{crowbar_revision}")
     @item.destroy(@item.data_bag, @item["id"])
-    delete_proposal_from_sqlite
+    delete_proposal_from_sqlite if options.fetch(:sync, true)
     Rails.logger.debug("Done removal of data bag item: #{@item["id"]} - #{crowbar_revision}")
   end
   

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -123,7 +123,7 @@ class ProposalObject < ChefObject
 
   def save(options = {})
     self.latest_applied = !!options[:applied]
-    increment_crowbar_revision!
+    increment_crowbar_revision! if options.fetch(:update_revision, true)
     Rails.logger.debug("Saving data bag item: #{@item["id"]} - #{crowbar_revision}")
     @item.save
     save_proposal_in_sqlite if options.fetch(:sync, true)

--- a/crowbar_framework/lib/crowbar/proposal_methods.rb
+++ b/crowbar_framework/lib/crowbar/proposal_methods.rb
@@ -1,5 +1,15 @@
 module Crowbar
   module ProposalMethods
+    def increment_crowbar_revision!
+      item["deployment"] ||= {}
+      item["deployment"][self.barclamp] ||= {}
+      if item["deployment"][self.barclamp]["crowbar-revision"].nil?
+        item["deployment"][self.barclamp]["crowbar-revision"] = 0
+      else
+        item["deployment"][self.barclamp]["crowbar-revision"] += 1
+      end
+    end
+
     def raw_attributes
       @raw_attributes ||= begin
         raw_data["attributes"][self.barclamp] || {}

--- a/crowbar_framework/spec/models/proposal_object_spec.rb
+++ b/crowbar_framework/spec/models/proposal_object_spec.rb
@@ -25,6 +25,9 @@ describe ProposalObject do
     before(:each) { Proposal.delete_all }
 
     before do
+      Proposal.any_instance.stubs(:update_corresponding_proposal_object).returns(true)
+      Proposal.any_instance.stubs(:drop_corresponding_proposal_object).returns(true)
+
       proposal.item.stubs(:save).returns(true)
       proposal.item.stubs(:destroy).returns(true)
     end

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -82,7 +82,7 @@ describe Proposal do
       Proposal.delete_all
 
       # Stub out item.save to prevent writes to non-existent couchdb. We also
-      # have to metadata updates, as they'd propagate into the sqlite and cause
+      # have to stub out metadata updates, as they'd propagate into the sqlite and cause
       # a de-sync.
       p = ProposalObject.find_proposal_by_id("bc-crowbar-default")
       p.stubs(:increment_crowbar_revision!).returns(true)

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Proposal do
+  # The real ProposalObject won't get saved, so we need to stub this out
+  before do
+    Proposal.any_instance.stubs(:update_corresponding_proposal_object).returns(true)
+  end
+
   let(:proposal) { Proposal.new(:barclamp => "crowbar", :name => "default")}
 
   describe "Finders" do

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -188,7 +188,7 @@ describe Proposal do
         expect(another).to_not be_valid
         expect(another.errors[:name]).to_not be_empty
       ensure
-        proposal.destroy if proposal
+        proposal.delete if proposal
       end
     end
   end


### PR DESCRIPTION
This enables almost seamless replacement of ProposalObject and Proposal,
as the changes will be mirrored into the other model transparently.

The changes can be dropped after we're done migrating barclamps.