### PR TITLE
Use admin name attribute when computing host for admin URL (bsc#927469)

### DIFF
--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -18,9 +18,18 @@ module CrowbarHelper
     if use_cluster && defined?(CrowbarPacemakerHelper)
       # loose dependency on the pacemaker cookbook
       cluster_vhostname = CrowbarPacemakerHelper.cluster_vhostname(node)
-      "#{cluster_vhostname}.#{node[:domain]}"
+
+      admin_name = CrowbarPacemakerHelper.cluster_haproxy_vadmin_name(node)
+      admin_fqdn = "#{cluster_vhostname}.#{node[:domain]}"
     else
-      node[:fqdn]
+      admin_name = node[:crowbar][:admin_name]
+      admin_fqdn = node[:fqdn]
+    end
+
+    if admin_name.nil? || admin_name.empty?
+      admin_fqdn
+    else
+      admin_name
     end
   end
 


### PR DESCRIPTION
This is the exact same thing we're doing for the public IP address/DNS
name.

The reason it's needed is for keystone admin API which are being done
through the admin endpoint. As this is a rather minimal use case, we do
not expose the setting in the UI for the nodes -- which means the node
would have to be edited directly.

https://bugzilla.suse.com/show_bug.cgi?id=927469

Depends on https://github.com/crowbar/barclamp-pacemaker/pull/190