### PR TITLE
[wip] Replace calls to ProposalObject with Proposal

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -175,7 +175,7 @@ class BarclampController < ApplicationController
     return render :text => @proposals, :status => ret[0] if ret[0] != 200
     respond_to do |format|
       format.html {
-        @proposals.map! { |p| Proposal.where(barclamp: @bc_name, name: p).first }
+        @proposals = @proposals.map { |p| Proposal.where(barclamp: @bc_name, name: p).first }
         render :template => 'barclamp/proposals'
       }
       format.xml  { render :xml => @proposals }

--- a/crowbar_framework/app/controllers/dashboard_controller.rb
+++ b/crowbar_framework/app/controllers/dashboard_controller.rb
@@ -20,6 +20,6 @@ class DashboardController < ApplicationController
   def load_records
     @nodes     = NodeObject.all
     @roles     = RoleObject.all
-    @proposals = ProposalObject.all
+    @proposals = Proposal.all
   end
 end

--- a/crowbar_framework/app/controllers/deploy_queue_controller.rb
+++ b/crowbar_framework/app/controllers/deploy_queue_controller.rb
@@ -16,12 +16,12 @@ class DeployQueueController < ApplicationController
 
   def prop_name_map
     props = {}
-    ProposalObject.all.each { |prop| props["#{prop.barclamp}_#{prop.name}"] = prop }
+    Proposal.all.each { |prop| props["#{prop.barclamp}_#{prop.name}"] = prop }
     props
   end
 
   def currently_deployed
-    ProposalObject.all.find { |p| p["deployment"][p.barclamp]["crowbar-committing"] }
+    Proposal.all.find { |p| p["deployment"][p.barclamp]["crowbar-committing"] }
   end
 
   def deployment_queue

--- a/crowbar_framework/app/controllers/support_controller.rb
+++ b/crowbar_framework/app/controllers/support_controller.rb
@@ -109,7 +109,7 @@ class SupportController < ApplicationController
 
       NodeObject.all.each { |n| n.export }
       RoleObject.all.each { |r| r.export }
-      ProposalObject.all.each { |p| p.export }
+      Proposal.all.each { |p| p.export }
 
       filename = "crowbar-chef-#{Time.now.strftime("%Y%m%d-%H%M%S")}.tgz"
 

--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -374,7 +374,7 @@ module NodesHelper
   end
 
   def node_barclamp_list(node)
-    all_proposals = ProposalObject.all
+    all_proposals = Proposal.all
 
     list_items = ActiveSupport::OrderedHash.new.tap do |listing|
       node_barclamps(node).map do |role|
@@ -445,7 +445,7 @@ module NodesHelper
 
   def node_role_list(node)
     all_roles     = RoleObject.all
-    all_proposals = ProposalObject.all
+    all_proposals = Proposal.all
 
     list_items = ActiveSupport::OrderedHash.new.tap do |listing|
       node_roles(node).map do |role|

--- a/crowbar_framework/app/helpers/proposals_helper.rb
+++ b/crowbar_framework/app/helpers/proposals_helper.rb
@@ -209,7 +209,7 @@ module ProposalsHelper
     @retrieve_proposal_for ||= {}
 
     @retrieve_proposal_for[barclamp] ||= begin
-      proposals = ProposalObject.find_proposals(barclamp.to_s)
+      proposals = Proposal.where(barclamp: barclamp.to_s)
 
       unless proposals.empty? || proposals.length != 1
         proposals.first

--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -26,7 +26,7 @@ class ChefObject
     begin
       # NOTE: We are using a global here to avoid lookups.  We need to consider some better cache/expiration strategy
       if @@CrowbarDomain.nil?
-        bag = ProposalObject.find_proposal('dns', 'default')
+        bag = Proposal.where(barclamp: 'dns', name: 'default').first
         @@CrowbarDomain = bag[:attributes][:dns][:domain] || %x{dnsdomainname}.strip
       end
       return @@CrowbarDomain

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -99,7 +99,7 @@ class CrowbarService < ServiceObject
       #
       if state == "discovering" and node.admin?
         crole = RoleObject.find_role_by_name("crowbar-config-#{inst}")
-        db = ProposalObject.find_proposal("crowbar", inst)
+        db = Proposal.where(barclamp: "crowbar", name: inst).first
         add_role_to_instance_and_node("crowbar", inst, name, db, crole, "crowbar")
       end
 
@@ -267,7 +267,7 @@ class CrowbarService < ServiceObject
 
   def self.read_options
     # read in default proposal, to make some vaules avilable
-    proposals = ProposalObject.find_proposals("crowbar")
+    proposals = Proposal.where(barclamp: "crowbar")
     raise "Can't find any crowbar proposal" if proposals.nil? or proposals[0].nil?
     # populate options from attributes/crowbar/*-settings
     options = { :raid=>{}, :bios=>{}, :show=>[] }

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -9,7 +9,7 @@ class Proposal < ActiveRecord::Base
   class TemplateMissing < StandardError; end
   class TemplateInvalid < StandardError; end
 
-  serialize :properties, JSON
+  serialize :properties, Utils::JSONWithIndifferentAccess
 
   validates :barclamp, :properties, presence: true
   validates :name, uniqueness: { scope: :barclamp, message: I18n.t('model.service.name_exists') }
@@ -128,7 +128,7 @@ class Proposal < ActiveRecord::Base
   end
 
   def load_properties_template
-    self.properties ||= JSON.parse(File.read(properties_template_path))
+    self.properties ||= Utils::JSONWithIndifferentAccess.load(File.read(properties_template_path))
   rescue Errno::ENOENT, Errno::EACCES
     raise TemplateMissing.new(I18n.t('model.service.template_missing', name: self.name))
   rescue JSON::ParserError

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -94,6 +94,8 @@ class Proposal < ActiveRecord::Base
 
   # XXX: we need to be careful to not create an endless loop
   def update_corresponding_proposal_object
+    return if self.key =~ /_network$/
+
     proposal_object = ProposalObject.find_proposal_by_id(self.key)
     if proposal_object
       if proposal_object.raw_data != self.raw_data
@@ -109,6 +111,8 @@ class Proposal < ActiveRecord::Base
   end
 
   def drop_corresponding_proposal_object
+    return if self.key =~ /_network$/
+
     proposal_object = ProposalObject.find_proposal_by_id(self.key)
     proposal_object.destroy(sync: false) if proposal_object
   end

--- a/crowbar_framework/app/models/role_object.rb
+++ b/crowbar_framework/app/models/role_object.rb
@@ -62,7 +62,7 @@ class RoleObject < ChefObject
       if proposals
         proposals.find { |p| p.barclamp == barclamp && p.name == inst }
       else
-        ProposalObject.find_proposal(barclamp, inst)
+        Proposal.where(barclamp: barclamp, name: inst).first
       end
     end
   end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -72,7 +72,7 @@ class ServiceObject
   end
 
   def simple_proposal_ui?
-    proposals = ProposalObject.find_proposals("crowbar")
+    proposals = Proposal.where(barclamp: "crowbar")
 
     result = false
     unless proposals[0].nil? or proposals[0]["attributes"].nil? or proposals[0]["attributes"]["crowbar"].nil?
@@ -306,7 +306,7 @@ class ServiceObject
       queue_me = false
 
       deps.each do |dep|
-        prop = ProposalObject.find_proposal(dep["barclamp"], dep["inst"])
+        prop = Proposal.where(barclamp: dep["barclamp"], name: dep["inst"]).first
 
         # queue if prop doesn't exist
         queue_me = true if prop.nil?
@@ -346,7 +346,7 @@ class ServiceObject
       release_lock f
     end
 
-    prop = ProposalObject.find_proposal(bc, inst)
+    prop = Proposal.where(barclamp: bc, name: inst).first
     prop["deployment"][bc]["crowbar-queued"] = true
     prop.save
     @logger.debug("queue proposal: exit #{inst} #{bc}")
@@ -362,7 +362,7 @@ class ServiceObject
 
       remove_pending_elements(bc, inst, elements) if elements
 
-      prop = ProposalObject.find_proposal(bc, inst)
+      prop = Proposal.where(barclamp: bc, name: inst).first
       unless prop.nil?
         prop["deployment"][bc]["crowbar-queued"] = false
         prop.save
@@ -430,7 +430,7 @@ class ServiceObject
         # Test for ready
         remove_list = []
         queue.each do |item|
-          prop = ProposalObject.find_proposal(item["barclamp"], item["inst"])
+          prop = Proposal.where(barclamp: item["barclamp"], name: item["inst"]).first
           if prop.nil?
             remove_list << item
             next
@@ -439,7 +439,7 @@ class ServiceObject
           queue_me = false
           # Make sure the deps if we aren't being queued.
           item["deps"].each do |dep|
-            depprop = ProposalObject.find_proposal(dep["barclamp"], dep["inst"])
+            depprop = Proposal.where(barclamp: dep["barclamp"], name: dep["inst"]).first
 
             # queue if depprop doesn't exist
             queue_me = true if depprop.nil?
@@ -500,7 +500,7 @@ class ServiceObject
   def update_proposal_status(inst, status, message, bc = @bc_name)
     @logger.debug("update_proposal_status: enter #{inst} #{bc} #{status} #{message}")
 
-    prop = ProposalObject.find_proposal(bc, inst)
+    prop = Proposal.where(barclamp: bc, name: inst).first
     unless prop.nil?
       prop["deployment"][bc]["crowbar-status"] = status
       prop["deployment"][bc]["crowbar-failed"] = message
@@ -582,7 +582,7 @@ class ServiceObject
   # bc_name/inst anyway. So it might be better to not pollute the inheritance
   # chain.
   def elements
-    [200, ProposalObject.find_barclamp(@bc_name).all_elements]
+    [200, Proposal.new(barclamp: @bc_name).all_elements]
   end
 
   def element_info(role = nil)
@@ -590,7 +590,7 @@ class ServiceObject
 
     return [200, nodes] unless role
 
-    valid_roles = ProposalObject.find_barclamp(@bc_name).all_elements
+    valid_roles = Proposal.new(barclamp: @bc_name).all_elements
     return [400, "No role #{role} found for #{@bc_name}."] if !valid_roles.include?(role)
 
     # FIXME: we could try adding each node in turn to existing proposal's 'elements' and removing it
@@ -604,7 +604,7 @@ class ServiceObject
   end
 
   def proposals_raw
-    ProposalObject.find_proposals(@bc_name)
+    Proposal.where(barclamp: @bc_name)
   end
 
   def proposals
@@ -614,7 +614,7 @@ class ServiceObject
   end
 
   def proposal_show(inst)
-    prop = ProposalObject.find_proposal(@bc_name, inst)
+    prop = Proposal.where(barclamp: @bc_name, name: inst).first
     if prop.nil?
       [404, {}]
     else
@@ -687,7 +687,7 @@ class ServiceObject
   #
   # FIXME: check if it is overridden and move to caller
   def create_proposal
-    prop = ProposalObject.find_proposal("template", @bc_name)
+    prop = Proposal.new(barclamp: @bc_name)
     raise(I18n.t('model.service.template_missing', :name => @bc_name )) if prop.nil?
     prop.raw_data
   end
@@ -700,7 +700,7 @@ class ServiceObject
       return [403,I18n.t('model.service.illegal_name', names: FORBIDDEN_PROPOSAL_NAMES.to_sentence)]
     end
 
-    prop = ProposalObject.find_proposal(@bc_name, base_id)
+    prop = Proposal.where(barclamp: @bc_name, name: base_id).first
     return [400, I18n.t('model.service.name_exists')] unless prop.nil?
     return [400, I18n.t('model.service.too_short')] if base_id.length == 0
     return [400, I18n.t('model.service.illegal_chars')] if base_id =~ /[^A-Za-z0-9_]/
@@ -733,7 +733,7 @@ class ServiceObject
   end
 
   def proposal_delete(inst)
-    prop = ProposalObject.find_proposal(@bc_name, inst)
+    prop = Proposal.where(barclamp: @bc_name, name: inst).first
     if prop.nil?
       [404, {}]
     else

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -609,7 +609,7 @@ class ServiceObject
 
   def proposals
     props = proposals_raw
-    props.map! { |p| p["id"].gsub("bc-#{@bc_name}-", "") } unless props.empty?
+    props = props.map { |p| p["id"].gsub("bc-#{@bc_name}-", "") } unless props.empty?
     [200, props]
   end
 

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -609,7 +609,7 @@ class ServiceObject
 
   def proposals
     props = proposals_raw
-    props = props.map { |p| p["id"].gsub("bc-#{@bc_name}-", "") } unless props.empty?
+    props = props.map { |p| p["id"].gsub("bc-#{@bc_name}-", "") }
     [200, props]
   end
 

--- a/crowbar_framework/lib/utils.rb
+++ b/crowbar_framework/lib/utils.rb
@@ -16,3 +16,4 @@
 #
 
 require "utils/extended_hash"
+require "utils/json_with_indifferent_access"

--- a/crowbar_framework/lib/utils/json_with_indifferent_access.rb
+++ b/crowbar_framework/lib/utils/json_with_indifferent_access.rb
@@ -1,0 +1,23 @@
+module Utils
+  class JSONWithIndifferentAccess
+    def self.load(string)
+      indifferent_access(JSON.load(string))
+    end
+
+    def self.dump(obj)
+      JSON.dump(obj)
+    end
+
+    private
+
+    def self.indifferent_access(obj)
+      if obj.is_a? Hash
+        obj.with_indifferent_access
+      elsif obj.is_a? Array
+        obj.map! { |o| indifferent_access(o) }
+      else
+        obj
+      end
+    end
+  end
+end

--- a/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
@@ -21,6 +21,8 @@ describe CrowbarController do
   render_views
 
   before do
+    ProposalObject.any_instance.stubs(:save).returns(true)
+    Proposal.where(barclamp: "crowbar", name: "default").first_or_create(barclamp: "crowbar", name: "default")
     CrowbarService.any_instance.stubs(:apply_role).returns([200, "OK"])
   end
 

--- a/crowbar_framework/spec/controllers/nodes_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/nodes_controller_spec.rb
@@ -21,6 +21,8 @@ describe NodesController do
   render_views
 
   before do
+    ProposalObject.any_instance.stubs(:save).returns(true)
+    Proposal.where(barclamp: "crowbar", name: "default").first_or_create(barclamp: "crowbar", name: "default")
     NodeObject.any_instance.stubs(:system).returns(true)
   end
 

--- a/crowbar_framework/spec/models/chef_object_spec.rb
+++ b/crowbar_framework/spec/models/chef_object_spec.rb
@@ -42,28 +42,4 @@ describe ChefObject do
       chef_object.query_chef.should be_a(Chef::Node)
     end
   end
-
-  describe "cloud domain" do
-    it "looks up the proposal object" do
-      domain = "localdomain"
-      bag = { :attributes => { :dns => { :domain => domain} } }
-      ProposalObject.stubs(:find_proposal).once.returns(bag)
-      domain.should == chef_object.cloud_domain
-    end
-
-    it "uses domainname if get proposal failed" do
-      ProposalObject.stubs(:find_proposal).raises(StandardError)
-      assert_equal %x{dnsdomainname}.strip, chef_object.cloud_domain
-    end
-
-    it "caches answers" do
-      domain = "localdomain"
-      bag = { :attributes => { :dns => { :domain => domain} } }
-
-      ProposalObject.expects(:find_proposal).once.returns(bag)
-
-      chef_object.cloud_domain
-      chef_object.cloud_domain
-    end
-  end
 end

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -101,6 +101,10 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/v/3-0/docs
   config.infer_spec_type_from_file_location!
 
+  config.before do
+    ChefObject.stubs(:cloud_domain).returns("crowbar.com")
+  end
+
   config.append_before(:each) do
     stub_request(:any, /localhost:4000/).to_rack(OfflineChef)
   end


### PR DESCRIPTION
This patchset replaces most of the calls to ProposalObject with calls to Proposal in the crowbar barclamp.

What has not been replaced and is still backed by databags:

  * The deployment queue
  * Network configuration