### PR TITLE
Replace remaining ProposalObject calls with Chef::DataBag

### DIFF
--- a/crowbar_framework/app/controllers/deploy_queue_controller.rb
+++ b/crowbar_framework/app/controllers/deploy_queue_controller.rb
@@ -25,6 +25,6 @@ class DeployQueueController < ApplicationController
   end
 
   def deployment_queue
-    ProposalObject.find_data_bag_item("crowbar/queue")["proposal_queue"] rescue []
+    Chef::DataBag.load("crowbar/queue")["proposal_queue"] rescue []
   end
 end

--- a/crowbar_framework/app/models/proposal.rb
+++ b/crowbar_framework/app/models/proposal.rb
@@ -94,7 +94,9 @@ class Proposal < ActiveRecord::Base
 
   # XXX: we need to be careful to not create an endless loop
   def update_corresponding_proposal_object
-    return if self.key =~ /_network$/
+    # XXX: Do not save other network proposals - its a network configuration
+    # this is transitional code, as soon as network uses databags, this can go away.
+    return if self.barclamp == "network" && self.name != "default"
 
     proposal_object = ProposalObject.find_proposal_by_id(self.key)
     if proposal_object
@@ -111,7 +113,9 @@ class Proposal < ActiveRecord::Base
   end
 
   def drop_corresponding_proposal_object
-    return if self.key =~ /_network$/
+    # XXX: Do not save other network proposals - its a network configuration
+    # this is transitional code, as soon as network uses databags, this can go away.
+    return if self.barclamp == "network" && self.name != "default"
 
     proposal_object = ProposalObject.find_proposal_by_id(self.key)
     proposal_object.destroy(sync: false) if proposal_object

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -140,6 +140,8 @@ class ProposalObject < ChefObject
   private
 
   def delete_proposal_from_sqlite
+    return if self.id =~ /_network/
+
     attrs = { barclamp: self.barclamp, name: self.name }
 
     prop = Proposal.where(attrs).first
@@ -147,6 +149,8 @@ class ProposalObject < ChefObject
   end
 
   def save_proposal_in_sqlite
+    return if self.id =~ /_network/
+
     attrs = { barclamp: self.barclamp, name: self.name }
 
     prop = Proposal.where(attrs).first_or_initialize(attrs)

--- a/crowbar_framework/app/models/proposal_object.rb
+++ b/crowbar_framework/app/models/proposal_object.rb
@@ -140,6 +140,8 @@ class ProposalObject < ChefObject
   private
 
   def delete_proposal_from_sqlite
+    # XXX: Leave network proposals alone - its a network configuration
+    # this is transitional code, as soon as network uses databags, this can go away.
     return if self.id =~ /_network/
 
     attrs = { barclamp: self.barclamp, name: self.name }
@@ -149,6 +151,8 @@ class ProposalObject < ChefObject
   end
 
   def save_proposal_in_sqlite
+    # XXX: Leave network proposals alone - its a network configuration
+    # this is transitional code, as soon as network uses databags, this can go away.
     return if self.id =~ /_network/
 
     attrs = { barclamp: self.barclamp, name: self.name }

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1036,7 +1036,7 @@ class ServiceObject
   end
 
   def _proposal_update(bc_name, inst, proposal, validate_after_save = true)
-    prop = Proposal.new(barclamp: bc_name, name: inst)
+    prop = Proposal.where(barclamp: bc_name, name: inst).first_or_initialize(barclamp: bc_name, name: inst)
 
     begin
       prop.properties = proposal

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -776,9 +776,10 @@ class ServiceObject
         response = [500, e.message]
       ensure
         # Make sure we unmark the wall
-        prop = ProposalObject.find_proposal(@bc_name, inst)
+        prop = Proposal.where(barclamp: @bc_name, name: inst).reload
         prop["deployment"][@bc_name]["crowbar-committing"] = false
-        prop.save(:applied => (response.first == 200))
+        prop.latest_applied = (response.first == 200)
+        prop.save
       end
       response
     end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -287,7 +287,7 @@ class ServiceObject
     begin
       f = acquire_lock "queue"
 
-      db = Chef::DataBag.load "crowbar/queue"
+      db = Chef::DataBag.load("crowbar/queue") rescue nil
       if db.nil?
         db = Chef::DataBagItem.new
         db.data_bag "crowbar"
@@ -385,7 +385,7 @@ class ServiceObject
     begin
       f = acquire_lock "queue"
 
-      db = Chef::DataBag.load "crowbar/queue"
+      db = Chef::DataBag.load("crowbar/queue") rescue nil
       @logger.debug("dequeue proposal: exit #{inst} #{bc}: no entry") if db.nil?
       return [200, {}] if db.nil?
 
@@ -416,7 +416,7 @@ class ServiceObject
       begin
         f = acquire_lock "queue"
 
-        db = Chef::DataBag.load "crowbar/queue"
+        db = Chef::DataBag.load("crowbar/queue") rescue nil
         if db.nil?
           @logger.debug("process queue: exit: queue gone")
           return

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -780,7 +780,7 @@ class ServiceObject
         response = [500, e.message]
       ensure
         # Make sure we unmark the wall
-        prop = Proposal.where(barclamp: @bc_name, name: inst).first.reload
+        prop.reload
         prop["deployment"][@bc_name]["crowbar-committing"] = false
         prop.latest_applied = (response.first == 200)
         prop.save

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1473,7 +1473,7 @@ class ServiceObject
     unless prop["deployment"][barclamp]["elements"][newrole].include?(node.name)
       @logger.debug("ARTOI: updating proposal with node #{node.name}, role #{newrole} for deployment of #{barclamp}")
       prop["deployment"][barclamp]["elements"][newrole] << node.name
-      prop.save(:applied => prop.latest_applied?)
+      prop.save
     else
       @logger.debug("ARTOI: node #{node.name} already in proposal: role #{newrole} for #{barclamp}")
     end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -284,13 +284,13 @@ class ServiceObject
     begin
       f = acquire_lock "queue"
 
-      db = ProposalObject.find_data_bag_item "crowbar/queue"
+      db = Chef::DataBag.load "crowbar/queue"
       if db.nil?
-        new_queue = Chef::DataBagItem.new
-        new_queue.data_bag "crowbar"
-        new_queue["id"] = "queue"
-        new_queue["proposal_queue"] = []
-        db = ProposalObject.new new_queue
+        db = Chef::DataBagItem.new
+        db.data_bag "crowbar"
+        db["id"] = "queue"
+        db["proposal_queue"] = []
+        db.save
       end
 
       preexisting_queued_item = nil
@@ -382,7 +382,7 @@ class ServiceObject
     begin
       f = acquire_lock "queue"
 
-      db = ProposalObject.find_data_bag_item "crowbar/queue"
+      db = Chef::DataBag.load "crowbar/queue"
       @logger.debug("dequeue proposal: exit #{inst} #{bc}: no entry") if db.nil?
       return [200, {}] if db.nil?
 
@@ -413,7 +413,7 @@ class ServiceObject
       begin
         f = acquire_lock "queue"
 
-        db = ProposalObject.find_data_bag_item "crowbar/queue"
+        db = Chef::DataBag.load "crowbar/queue"
         if db.nil?
           @logger.debug("process queue: exit: queue gone")
           return

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -725,14 +725,15 @@ class ServiceObject
     # When we create a proposal, it might be "invalid", as some roles might be missing
     # This is OK, as the next step for the user is to add nodes to the roles
     # But we need to skip the after_save validations in the _proposal_update
-    _proposal_update(@bc_name, params["id"] || params[:name], proposal, false)
+    _proposal_update(@bc_name, base_id, proposal, false)
   end
 
   def proposal_edit(params, validate_after_save = true)
-    params["id"] = "bc-#{@bc_name}-#{params["id"] || params[:name]}"
+    base_id = params["id"] || params[:name]
+    params["id"] = "bc-#{@bc_name}-#{base_id}"
     proposal = {}.merge(params)
     clean_proposal(proposal)
-    _proposal_update(@bc_name, params["id"] || params[:name], proposal, validate_after_save)
+    _proposal_update(@bc_name, base_id, proposal, validate_after_save)
   end
 
   def proposal_delete(inst)

--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -25,7 +25,7 @@ module SchemaMigration
   end
 
   def self.run_for_bc bc_name
-    template = ProposalObject.find_proposal("template", bc_name)
+    template = Proposal.new(barclamp: bc_name)
 
     return if template.nil?
     return if template["deployment"].nil?
@@ -34,7 +34,7 @@ module SchemaMigration
     all_scripts = find_scripts_for_bc(bc_name)
     return if all_scripts.empty?
 
-    props = ProposalObject.find_proposals bc_name
+    props = Proposal.where(barclamp: bc_name)
 
     props.each do |prop|
       migrate_proposal(bc_name, template, all_scripts, prop)


### PR DESCRIPTION
This patch replaces the remaining uses of ProposalObject with either Proposal calls, or, where none of the Proposal API methods are required (as e.g. for the deployment queue), uses Chef::DataBag class directly.

This will allow for dropping the ProposalObject related code now, then move away from data bags towards a separate table/database later.

There are similar pull requests for other barclamps, they'll be referenced below.

I noticed a slight problem with this and referencing PRs - ProposalObject rescues any error raised by Chef::DataBag.load - this'll have to be fixed...