### PR TITLE
Fix apache config file to work with apache 2.4 or later

### DIFF
--- a/chef/cookbooks/apache2/templates/default/apache2.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/apache2.conf.erb
@@ -105,8 +105,12 @@ AccessFileName .htaccess
 # viewed by Web clients. 
 #
 <Files ~ "^\.ht">
+    <%- if node[:apache][:version].to_f < 2.4 %>
     Order allow,deny
     Deny from all
+    <%- else %>
+    Require all denied
+    <%- end %>
 </Files>
 
 #

--- a/chef/cookbooks/apache2/templates/default/default-site.erb
+++ b/chef/cookbooks/apache2/templates/default/default-site.erb
@@ -9,8 +9,12 @@
         <Directory /var/www/>
                 Options Indexes FollowSymLinks MultiViews
                 AllowOverride None
+                <%- if node[:apache][:version].to_f < 2.4 %>
                 Order allow,deny
                 allow from all
+                <%- else %>
+                Require all granted
+                <%- end %>
                 # This directive allows us to have apache2's default start page
                 # in /apache2-default/, but still have / go to the right place
                 #RedirectMatch ^/$ /apache2-default/
@@ -20,8 +24,12 @@
         <Directory "/usr/lib/cgi-bin">
                 AllowOverride None
                 Options ExecCGI -MultiViews +SymLinksIfOwnerMatch
+                <%- if node[:apache][:version].to_f < 2.4 %>
                 Order allow,deny
                 Allow from all
+                <%- else %>
+                Require all granted
+                <%- end %>
         </Directory>
 
         ErrorLog <%= node[:apache][:log_dir] %>/error.log 
@@ -37,9 +45,13 @@
         <Directory "/usr/share/doc/">
             Options Indexes MultiViews FollowSymLinks
             AllowOverride None
+            <%- if node[:apache][:version].to_f < 2.4 %>
             Order deny,allow
             Deny from all
             Allow from 127.0.0.0/255.0.0.0 ::1/128
+            <%- else %>
+            Require local
+            <%- end %>
         </Directory>
 
         <% if node[:platform] == "centos" || node[:platform] == "redhat" || node[:platform] == "fedora" -%>

--- a/chef/cookbooks/apache2/templates/default/mods/alias.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/mods/alias.conf.erb
@@ -17,8 +17,12 @@ Alias /icons/ "<%= node[:apache][:icondir] %>"
 <Directory "<%= node[:apache][:icondir] %>">
     Options Indexes MultiViews
     AllowOverride None
+    <%- if node[:apache][:version].to_f < 2.4 %>
     Order allow,deny
     Allow from all
+    <%- else %>
+    Require all granted
+    <%- end %>
 </Directory>
 
 </IfModule>

--- a/chef/cookbooks/apache2/templates/default/mods/proxy.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/mods/proxy.conf.erb
@@ -6,9 +6,13 @@
 
         <Proxy *>
                 AddDefaultCharset off
+                <%- if node[:apache][:version].to_f < 2.4 %>
                 Order deny,allow
                 Deny from all
                 #Allow from .example.com
+                <%- else %>
+                Require all denied
+                <%- end %>
         </Proxy>
 
         # Enable/disable the handling of HTTP/1.1 "Via:" headers.

--- a/chef/cookbooks/apache2/templates/default/mods/status.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/mods/status.conf.erb
@@ -7,10 +7,14 @@
 #
 <Location /server-status>
     SetHandler server-status
+    <%- if node[:apache][:version].to_f < 2.4 %>
     Order deny,allow
     Deny from all
     Allow from localhost ip6-localhost
 #    Allow from .example.com
+    <%- else %>
+    Require local
+    <%- end %>
 </Location>
 
 </IfModule>

--- a/chef/cookbooks/apache2/templates/default/ports.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/ports.conf.erb
@@ -1,6 +1,8 @@
 #This file generated via template by Chef.
 <% @apache_listen_ports.each do |port| -%>
 Listen <%= port %>
+<%- if node[:apache][:version].to_f < 2.4 %>
 NameVirtualHost *:<%= port %>
 
+<%- end %>
 <% end -%>

--- a/chef/cookbooks/apache2/templates/default/web_app.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/web_app.conf.erb
@@ -7,8 +7,12 @@
   <Directory <%= @params[:docroot] %>>
     Options FollowSymLinks
     AllowOverride None
+    <%- if node[:apache][:version].to_f < 2.4 %>
     Order allow,deny
     Allow from all
+    <%- else %>
+    Require all granted
+    <%- end %>
   </Directory>
   
   <Directory />
@@ -19,9 +23,13 @@
   <Location /server-status>
     SetHandler server-status
 
+    <%- if node[:apache][:version].to_f < 2.4 %>
     Order Deny,Allow
     Deny from all
     Allow from 127.0.0.1
+    <%- else %>
+    Require local
+    <%- end %>
   </Location>
 
   LogLevel info

--- a/chef/cookbooks/apache2/templates/suse/mods/status.conf.erb
+++ b/chef/cookbooks/apache2/templates/suse/mods/status.conf.erb
@@ -7,8 +7,12 @@
 <IfModule mod_status.c>
     <Location /server-status>
         SetHandler server-status
+        <%- if node[:apache][:version].to_f < 2.4 %>
         Order deny,allow
         Deny from all
         Allow from localhost ipv6-localhost 127.0.0.1
+        <%- else %>
+        Require local
+        <%- end %>
     </Location>
 </IfModule>


### PR DESCRIPTION
Note that NameVirtualHost is gone now: this is automatically detected.