### PR TITLE
Fix for search_env_filtered(), (bnc#934227)

### DIFF
--- a/chef/cookbooks/utils/libraries/search.rb
+++ b/chef/cookbooks/utils/libraries/search.rb
@@ -25,7 +25,7 @@ class Chef
       # There are two conventions to filter by barclamp proposal:
       #  1) Other barclamp cookbook: node[@cookbook_name][$OTHER_BC_NAME_instance]
       #  2) Same cookbook: node[@cookbook_name][:config][:environment]
-      if barclamp == cookbook_name
+      if node[barclamp] && node[barclamp][:config] && (barclamp == cookbook_name)
         env = node[barclamp][:config][:environment]
       else
         env = "#{barclamp}-config-#{node[cookbook_name]["#{barclamp}_instance"]}"


### PR DESCRIPTION
Check if node[barclamp][:config] exist to prevent

    undefined method `[]' for nil:NilClass

It was reported in https://bugzilla.suse.com/show_bug.cgi?id=934227