### PR TITLE
On apply_role, do not stop/start chef several times for nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1107,7 +1107,7 @@ class ServiceObject
     new_elements = expanded_new_elements
 
     # stop chef daemon on all nodes
-    chef_daemon_nodes = new_elements.values.flatten
+    chef_daemon_nodes = new_elements.values.flatten.uniq
     chef_daemon(:stop, chef_daemon_nodes)
 
     # save list of expanded elements, as this is needed when we look at the


### PR DESCRIPTION
If a node is on multiple roles for this proposal, then we only want to
have chef-client stopped/started once for this node.