### PR TITLE
Introduce HoundCI

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,21 @@
+AllCopy:
+  RunRailsCops: true
+  DisplayCopNames: true
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/AlignParameters:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Lint/EndAlignment:
+  AlignWith: variable


### PR DESCRIPTION
This configs are needed to run HoundCI Style tests for our PRs. The
rubocop config is a adaption from the default config.

https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/ruby.yml