### PR TITLE
Fix display_name when barclamps[barclamp] doesn't exists (bsc#935233)

### DIFF
--- a/crowbar_framework/lib/barclamp_catalog.rb
+++ b/crowbar_framework/lib/barclamp_catalog.rb
@@ -64,12 +64,13 @@ class BarclampCatalog
   end
 
   def display_name(barclamp)
-    display = barclamps[barclamp]['display']
-
-    if display.nil? or display.empty?
-      barclamp.titlecase
+    if barclamps[barclamp] && !barclamps[barclamp]["display"].blank?
+      barclamps[barclamp]["display"]
     else
-      display
+      Rails.logger.warn(
+        "Could not find barclamp #{barclamp} in the crowbar catalog."
+      )
+      barclamp.titleize
     end
   end
 


### PR DESCRIPTION
`barclamps[barclamp]` is not always available (e.g. `barclamp-deployer`) in this
case we also want the barclamp name.