### PR TITLE
Update "Provided by" text and links

### DIFF
--- a/crowbar_framework/config/branding.yml
+++ b/crowbar_framework/config/branding.yml
@@ -1,6 +1,5 @@
-#
 # Copyright 2011-2013, Dell
-# Copyright 2013, SUSE LINUX Products GmbH
+# Copyright 2013-2015, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,4 +30,4 @@ version: 'Version CROWBAR_VERSION'
 
 # The provider will get displayed on the footer of crowbar to show who provides
 # this nice project ;-)
-provider: '<a href="http://dell.com/cloud" target="_blank"><img src="/assets/dell/dell.png" alt="Dell, Inc." /> CloudEdge Solutions team</a>'
+provider: '<a href="https://crowbar.github.io/" target="_blank">Crowbar</a>'

--- a/crowbar_framework/index/index.html
+++ b/crowbar_framework/index/index.html
@@ -100,7 +100,7 @@
 
       <footer>
         <span>
-          Provided by <a href="http://dell.com/cloud" target="_blank">Dell CloudEdge Solutions team</a>
+          Provided by <a href="https://crowbar.github.io/" target="_blank">Crowbar</a>
         </span>
       </footer>
     </div>

--- a/crowbar_framework/public/404.html
+++ b/crowbar_framework/public/404.html
@@ -60,7 +60,7 @@
 
       <footer>
         <span>
-          Provided by <a href="http://dell.com/cloud" target="_blank"><img src="/assets/dell/dell.png" alt="Dell, Inc." /> CloudEdge Solutions team</a>
+          Provided by <a href="https://crowbar.github.io/" target="_blank">Crowbar</a>
         </span>
       </footer>
     </div>

--- a/crowbar_framework/public/422.html
+++ b/crowbar_framework/public/422.html
@@ -60,7 +60,7 @@
 
       <footer>
         <span>
-          Provided by <a href="http://dell.com/cloud" target="_blank"><img src="/assets/dell/dell.png" alt="Dell, Inc." /> CloudEdge Solutions team</a>
+          Provided by <a href="https://crowbar.github.io/" target="_blank">Crowbar</a>
         </span>
       </footer>
     </div>

--- a/crowbar_framework/public/500.html
+++ b/crowbar_framework/public/500.html
@@ -60,7 +60,7 @@
 
       <footer>
         <span>
-          Provided by <a href="http://dell.com/cloud" target="_blank"><img src="/assets/dell/dell.png" alt="Dell, Inc." /> CloudEdge Solutions team</a>
+          Provided by <a href="https://crowbar.github.io/" target="_blank">Crowbar</a>
         </span>
       </footer>
     </div>


### PR DESCRIPTION
The default crowbar should be provider neutral as possible. So let's
move the standard to the crowbar website.