### PR TITLE
[tex] Fix 'unique_device_for()' for SLES12 virtio devices (bsc#936712)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1435,7 +1435,12 @@ class NodeObject < ChefObject
 
     meta = @node["block_device"][device]
 
-    if meta and meta["disks"]
+    if meta
+      # For some disk (e.g. virtio without serial number on SLE12)
+      # meta["disks"] is empty. In that case we can't get a "more unique"
+      # name than "vdX"
+      return "/dev/#{device}" unless meta["disks"]
+
       disk_lookups = ["by-path"]
 
       # If this looks like a virtio disk and the target platform is one


### PR DESCRIPTION
In some setups on SLES12 there are no /dev/disk-by*/ links at all for virtio
disks. Return /dev/vdX as the unique name immediately in such cases.

(cherry picked from commit f697321555a05a1a78b6100564e4aa9e81e653c6)

It was code-reviewed in https://github.com/crowbar/barclamp-crowbar/pull/1297