### PR TITLE
[tex] Handle /nodes/families json requests properly (bsc#926395)

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -219,6 +219,11 @@ class NodesController < ApplicationController
         })
       end
     end
+
+    #UI-only method
+    respond_to do |format|
+      format.html
+    end
   end
 
   def group_change

--- a/crowbar_framework/spec/controllers/nodes_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/nodes_controller_spec.rb
@@ -154,6 +154,12 @@ describe NodesController do
       get :families
       assigns(:families).keys.should include(node.family.to_s)
     end
+
+    it "as json is not acceptable" do
+      expect {
+        get :families, :format => "json"
+      }.to raise_error
+    end
   end
 
   describe "GET status" do


### PR DESCRIPTION
We do not handle json request for this page. Let's return a prober error
code instead of run in a "internal server error".

(cherry picked from commit 17734a7ef8a46738b8d61ced92d2517187bb80e4)