### PR TITLE
[tex] Fix display_name when barclamps[barclamp] doesn't exists (bsc#935233)

### DIFF
--- a/crowbar_framework/lib/barclamp_catalog.rb
+++ b/crowbar_framework/lib/barclamp_catalog.rb
@@ -64,12 +64,13 @@ class BarclampCatalog
   end
 
   def display_name(barclamp)
-    display = barclamps[barclamp]['display']
-
-    if display.nil? or display.empty?
-      barclamp.titlecase
+    if barclamps[barclamp] && !barclamps[barclamp]["display"].blank?
+      barclamps[barclamp]["display"]
     else
-      display
+      Rails.logger.warn(
+        "Could not find barclamp #{barclamp} in the crowbar catalog."
+      )
+      barclamp.titleize
     end
   end
 


### PR DESCRIPTION
It can happen that a barclamp has no catalog entry (e.g. failed
installation). To prefent UI crashes use the barclamp name but log this
as a warning.

https://bugzilla.suse.com/show_bug.cgi?id=935233
(cherry picked from commit ec6053ea6afc00a2bab7db062604b182c8d161e4)