### PR TITLE
Tighten up Crowbar::Product::is_ses? check

### DIFF
--- a/crowbar_framework/lib/crowbar/product.rb
+++ b/crowbar_framework/lib/crowbar/product.rb
@@ -17,7 +17,14 @@
 module Crowbar
   class Product
     def self.is_ses?
-      BarclampCatalog.barclamps.key?("suse_enterprise_storage")
+      # This checks if the product is SUSE Enterprise Storage.  It's not
+      # enough to just check if 'suse_enterprise_storage' is in BarclampCatalog,
+      # because that'll be true if the ceph barclamp is installed (as it's
+      # a member of suse_enterprise_storage), so we also need to make sure
+      # that suse_enterprise_storage is a member of itself, which will only
+      # be true if the suse_enterprise_storage barclamp is actually installed.
+      BarclampCatalog.barclamps.key?("suse_enterprise_storage") &&
+        BarclampCatalog.members("suse_enterprise_storage").key?("suse_enterprise_storage")
     end
   end
 end


### PR DESCRIPTION
Previously this would just check if suse_enterprise_storage was in the
BarclampCatalog.  Unfortunately, this will always be true if the Ceph
barclamp is installed, as it's a member of suse_enterprise_storage since:

  https://github.com/crowbar/barclamp-ceph/pull/154

See subsequent discussion at:

  https://github.com/crowbar/barclamp-crowbar/pull/1266

This fix tightents up the check to verify that suse_enterprise_storage
is a member of itself, which won't happen unless that barclamp is
really, truly installed.

Signed-off-by: Tim Serong <tserong@suse.com>