### PR TITLE
Do not try to stop/start chef-client daemon on windows nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1552,14 +1552,21 @@ class ServiceObject
   end
 
   def chef_daemon(action, node_list)
+    wait_nodes = []
+
     node_list.each do |node_name|
       node = NodeObject.find_node_by_name(node_name)
+
+      # we can't connect to windows nodes
+      next if node[:platform] == "windows"
+
       @logger.debug "apply_role: #{action.to_s} chef service on #{node_name}"
       node.run_service :chef, action
+      wait_nodes << node_name
     end
 
     # wait for chef clients on all nodes
-    node_list.each do |node_name|
+    wait_nodes.each do |node_name|
       wait_for_chef_clients(node_name, :logger => true)
     end if action == :stop
   end


### PR DESCRIPTION
For windows nodes, we rely on the regular chef-client run and we don't
connect through ssh.

http://bugzilla.suse.com/show_bug.cgi?id=937760
(cherry picked from commit 47d35423f547a5b3cdcbc4564dfca86b55a9988c)