### PR TITLE
Use default_os attribute from provisioner as default platform

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -68,7 +68,7 @@ class NodeObject < ChefObject
       unless provisioner.nil? || provisioner["provisioner"]["default_os"].nil?
          provisioner["provisioner"]["default_os"]
       else
-        admin = NodeObject.find("role:crowbar").select { |n| n.admin? }.first
+        admin = NodeObject.find("role:crowbar").find { |n| n.admin? }
         if admin.nil?
           ""
         else

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -63,12 +63,17 @@ class NodeObject < ChefObject
   end
 
   def self.default_platform
-    @@default_platform ||= begin
-      admin = NodeObject.find("role:crowbar").select { |n| n.admin? }.first
-      if admin.nil?
-        ""
+    @default_platform ||= begin
+      provisioner = NodeObject.find("roles:provisioner-server").first
+      unless provisioner.nil? || provisioner["provisioner"]["default_os"].nil?
+         provisioner["provisioner"]["default_os"]
       else
-        "#{admin[:platform]}-#{admin[:platform_version]}"
+        admin = NodeObject.find("role:crowbar").select { |n| n.admin? }.first
+        if admin.nil?
+          ""
+        else
+          "#{admin[:platform]}-#{admin[:platform_version]}"
+        end
       end
     end
   end


### PR DESCRIPTION
It turns out that there is an attribute for defining the default
platform, and therefore we should not just rely on the OS of the admin
server.

This also means that the variable cannot be cached forever since the
attribute might change.