### PR TITLE
batch export: don't strip double-quotes from aliases

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -44,7 +44,6 @@ require "easy_diff"
 require "chef/mixin/deep_merge"
 require "pp"
 
-ALIAS_REGEXP = /"(@@[^ @]+@@)"/
 ALIAS_TEMPLATE = '@@%s@@'
 
 INDENT = '   '
@@ -540,8 +539,7 @@ def export_proposal(barclamp, template, proposal, alias_by_host)
 end
 
 def batch_to_yaml(data)
-  data.to_yaml.sub('---', '').strip.
-    gsub(ALIAS_REGEXP, '\1')
+  data.to_yaml.sub('---', '').strip
 end
 
 def print_yaml(data)


### PR DESCRIPTION
`@` is a reserved indicator in YAML and can't start a plain scalar:

  http://yaml.org/spec/1.2/spec.html#id2774228

Therefore aliases need to be wrapped in double-quotes.  This was already fixed in the documentation for `crowbar batch build`:

  https://github.com/crowbar/barclamp-crowbar/pull/1278

but it appears that I deliberately made `batch export` strip the quotes in the original implementation (presumably on grounds of ugliness) before realising that that violated the YAML spec.