### PR TITLE
prevent crowbar batch from locking itself and the user out

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -313,20 +313,38 @@ def wipe_attribute(new_json, barclamp, attribute)
 end
 
 def merge_attributes(new_json, barclamp, proposal)
+  attrs = proposal["attributes"]
+
   to_merge = {
     "attributes" => {
-      barclamp => proposal["attributes"]
+      barclamp => attrs
     },
     "deployment" => {
       barclamp => proposal["deployment"]
     },
   }
 
+  prevent_password_lockout(attrs) if barclamp == 'crowbar'
+
   # easy_merge! seems to have problems with Arrays of Hashes :-/
   #new_json.easy_merge! to_merge
 
   #new_json.extend Chef::Mixin::DeepMerge
   Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
+end
+
+def prevent_password_lockout(attrs)
+  return unless attrs
+
+  users = attrs['users']
+  return unless users && users[@username]
+
+  if @password != users[@username]['password']
+    warn "Refusing to change password for '#{@username}' user " + \
+         #"from #{@password} to #{users[@username]['password']} " + \
+         "which would lock myself out!"
+  end
+  users.delete @username
 end
 
 def commit_proposal(barclamp, name)

--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -135,7 +135,7 @@ def get_aliases
     get_json("/")
   end
 
-  abort "Couldn't get aliases" unless status == 200
+  abort "Couldn't get aliases: #{status}: #{body}" unless status == 200
 
   host_by_alias = {}
   alias_by_host = {}


### PR DESCRIPTION
If crowbar batch is used to export the crowbar proposal from one cloud and apply it to another, it will change the machine-install user's password, which is typically the one used to run crowbar batch.  This would break any future HTTP digest authentications against the Crowbar REST API, including ones invoked immediately after the change, by the still running crowbar batch process.  So if the user inadvertently attempts to change the password they're currently relying on, simply output a warning and ignore the attempt.

Also improve error reporting when retrieving aliases.
