### PR TITLE
crowbar_batch build: improve YAML file error handling

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -102,6 +102,7 @@ def build(input_file)
   end
 
   data = YAML.load(input_data)
+  abort "#{input_file} is empty" unless data
 
   global_options = data["global_options"] || {}
 

--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -96,6 +96,11 @@ def build(input_file)
     input_data.gsub!(ALIAS_TEMPLATE % aliaz, hostname)
   end
 
+  unknown_aliases = input_data.to_enum(:scan, ALIAS_REGEXP).map { Regexp.last_match.to_s }
+  unless unknown_aliases.empty?
+    abort "Some of the aliases in the YAML file are not known to Crowbar:\n- #{unknown_aliases.uniq.join("\n- ")}"
+  end
+
   data = YAML.load(input_data)
 
   global_options = data["global_options"] || {}

--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -89,7 +89,8 @@ def build(input_file)
 
   host_by_alias = get_aliases[0]
 
-  input_data = File.open(input_file).readlines.join('')
+  abort "#{input_file} does not exist" unless File.file?(input_file)
+  input_data = IO.read(input_file)
 
   # Translate @@alias@@ to Chef node name
   host_by_alias.each do |aliaz, hostname|

--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -108,8 +108,7 @@ def build(input_file)
 
   proposals = data["proposals"]
   if ! proposals || proposals.empty?
-    warn "#{input_file} didn't contain any proposals"
-    exit(-1)
+    abort "#{input_file} didn't contain any proposals"
   end
 
   begin


### PR DESCRIPTION
- abort with a better error message if the exported YAML file contains aliases that are unknown to Crowbar
- abort if the YAML file is empy (bugfix)
- replace a warn&exit two-liner with a simple abort