### PR TITLE
add yaml_db to the list of gems

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -78,6 +78,7 @@ when "suse"
     ruby2.1-rubygem-simple_navigation_renderers
     ruby2.1-rubygem-sqlite3
     ruby2.1-rubygem-syslogger
+    ruby2.1-rubygem-yaml_db
   )
   unless search(:node, "platform:windows").empty?
     pkglist.push "samba-client"

--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -34,6 +34,7 @@ gem "simple-navigation", "~> 3.12.2"
 gem "simple_navigation_renderers", "~> 1.0.2"
 gem "sqlite3", "~> 1.3.9"
 gem "syslogger", "~> 1.6.0"
+gem "yaml_db", "~> 0.3.0"
 
 gem "ohai", "~> 6.24.2"
 gem "chef", "~> 10.32.2"

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -85,6 +85,9 @@ else
   gem "syslogger", version: "~> 1.6"
   require "syslogger"
 
+  gem "yaml_db", version: "~> 0.3.0"
+  require "yaml_db"
+
   # chef related
   gem "mixlib-shellout", version: "~> 1.4"
   require "mixlib/shellout"


### PR DESCRIPTION
* this is primarily needed to provide a rake task (db:data:dump)
  for the supportutils-plugin-suse-openstack-cloud but is also useful
  in general, as you can dump the crowbar database without having to
  specify the type of database (SQLite, MySQL, PostgreSQL etc...)