### PR TITLE
ensure we install apache2 not lighttpd

### DIFF
--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -19,9 +19,9 @@
 
 package "apache2" do
   case node[:platform]
-  when "centos","redhat","fedora","suse"
+  when "centos", "redhat", "fedora"
     package_name "httpd"
-  when "debian","ubuntu"
+  when "debian", "ubuntu", "suse"
     package_name "apache2"
   when "arch"
     package_name "apache"


### PR DESCRIPTION
On both SLE11 and SLE12, the package name is `apache2`.  Usually installing `httpd` works because the `apache2` package provides the `httpd` virtual package; however if there is a `SLE12-HA-Pool` repository available then `lighttpd` could accidentally get installed instead.

Unfortunately this missed Milestone 2 and appears to break Horizon when HA is used.  Tested on c19 and it works.