### PR TITLE
Revert all other commits related to "disable 15-minute chef-client run"

### DIFF
--- a/crowbar_framework/app/models/chef_object.rb
+++ b/crowbar_framework/app/models/chef_object.rb
@@ -56,23 +56,4 @@ class ChefObject
     file   = Rails.root.join("db", "#{self.chef_type}_#{name}.json")
     File.open(file, "w") { |f| f.write(self.to_json) }
   end
-
-  # Each operating system can have a different path to the init command of a
-  # service.
-  # In order to manipulate services we can tap the provider mapping for the
-  # correct service class to determine the system's correct init command
-  # https://github.com/chef/chef/blob/master/lib/chef/platform/provider_mapping.rb
-  def self.service_command(platform, version, service_name, action)
-    provider_service_class = Chef::Platform.find(platform, version)[:service]
-    case provider_service_class.to_s
-    when "Chef::Provider::Service::Systemd"
-      "systemctl #{action} #{service_name}"
-    when "Chef::Provider::Service::Upstart"
-      "/etc/init.d/#{service_name} #{action}"
-    when "Chef::Provider::Service::Redhat"
-      "service #{service_name} #{action}"
-    else
-      nil
-    end
-  end
 end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1180,19 +1180,6 @@ class NodeObject < ChefObject
     @node["crowbar_wall"]["status"]["ipmi"]["address_set"]
   end
 
-  def run_service(service_name, action)
-    platform, version = @node["platform"], @node["platform_version"]
-    case service_name
-    when :chef
-      service_cmd = ChefObject.service_command(platform, version, "chef-client", action)
-    end
-    if service_cmd.nil?
-      Rails.logger.error("run_service: service command for #{platform} #{version} could not be determined")
-    else
-      ssh_cmd(service_cmd)
-    end
-  end
-
   def disk_owner(device)
     if device
       crowbar_wall[:claimed_disks][device][:owner] rescue ""

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1000,9 +1000,6 @@ class ServiceObject
   def apply_role(role, inst, in_queue)
     @logger.debug "apply_role(#{role.name}, #{inst}, #{in_queue})"
 
-    # Initialize variables used in ensure at the end of the method
-    chef_daemon_nodes = []
-
     # Query for this role
     old_role = RoleObject.find_role_by_name(role.name)
 

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1455,7 +1455,7 @@ class ServiceObject
       ssh_cmd = ssh.dup << command
 
       # check if there are currently other chef-client runs on the node
-      wait_for_chef_clients(node, :logger => false)
+      wait_for_chef_clients(node)
       # check if the node is currently rebooting
       wait_for_reboot(node)
 
@@ -1468,15 +1468,9 @@ class ServiceObject
 
   private
 
-  def wait_for_chef_clients(node_name, options = {})
-    options = if options.fetch(:logger)
-      {:logger => @logger}
-    else
-      {}
-    end
-    @logger.debug("wait_for_chef_clients: Waiting for already running chef-clients on #{node_name}.")
-    unless RemoteNode.chef_ready?(node_name, 1200, 10, options)
-      @logger.error("Waiting for already running chef-clients on #{node_name} failed.")
+  def wait_for_chef_clients(node_name)
+    unless RemoteNode.chef_ready?(node_name, 1200)
+      STDERR.puts "Waiting for already running chef-clients on #{node_name} failed"
       exit(1)
     end
   end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1468,9 +1468,9 @@ class ServiceObject
 
   private
 
-  def wait_for_chef_clients(node_name)
-    unless RemoteNode.chef_ready?(node_name, 1200)
-      STDERR.puts "Waiting for already running chef-clients on #{node_name} failed"
+  def wait_for_chef_clients(node)
+    unless RemoteNode.chef_ready?(node, 1200)
+      STDERR.puts "Waiting for already running chef-clients on #{node} failed"
       exit(1)
     end
   end

--- a/crowbar_framework/lib/remote_node.rb
+++ b/crowbar_framework/lib/remote_node.rb
@@ -24,7 +24,7 @@ module RemoteNode
   # @param host [string] hostname or IP
   # @param timeout [integer] timeout in seconds
 
-  def self.ready?(host, timeout = 60, sleep_time = 10, options = {})
+  def self.ready?(host, timeout = 60, sleep_time = 10)
     timeout_at = Time.now + timeout
     ip         = self.resolve_host(host)
     msg = "Waiting for host, next attempt in #{sleep_time} seconds until #{timeout_at}"
@@ -32,17 +32,17 @@ module RemoteNode
     nobj = NodeObject.find_node_by_name(host)
     reboot_requesttime = nobj[:crowbar_wall][:wait_for_reboot_requesttime] || 0
 
-    self.wait_until(msg, timeout_at.to_i, sleep_time, options) do
-      self.port_open?(ip, 22) && self.reboot_done?(ip, reboot_requesttime, options) && self.ssh_cmd(ip, runlevel_check_cmd(host))
+    self.wait_until(msg, timeout_at.to_i, sleep_time) do
+      self.port_open?(ip, 22) && self.reboot_done?(ip, reboot_requesttime) && self.ssh_cmd(ip, runlevel_check_cmd(host))
     end
   end
 
   # wait until no other chef-clients are currently running on the host
-  def self.chef_ready?(host, timeout = 60, sleep_time = 10, options = {})
+  def self.chef_ready?(host, timeout = 60, sleep_time = 10)
     timeout_at = Time.now + timeout
     ip         = self.resolve_host(host)
     msg = "Waiting for already running chef-client, next attempt in #{sleep_time} seconds until #{timeout_at}"
-    self.wait_until(msg, timeout_at.to_i, sleep_time, options) do
+    self.wait_until(msg, timeout_at.to_i, sleep_time) do
       self.port_open?(ip, 22) && !self.chef_clients_running?(ip)
     end
   end
@@ -64,11 +64,11 @@ module RemoteNode
     end
   end
 
-  def self.reboot_done?(host_or_ip, reboot_requesttime, options = {})
+  def self.reboot_done?(host_or_ip, reboot_requesttime)
     # if reboot_requesttime is zero, we don't know when the reboot was requested.
     # in this case return true so the process can continue
     if reboot_requesttime > 0
-      boottime = self.ssh_cmd_get_boottime(host_or_ip, options)
+      boottime = self.ssh_cmd_get_boottime(host_or_ip)
       if boottime > 0 and boottime <= reboot_requesttime
         false
       else
@@ -99,16 +99,14 @@ module RemoteNode
   end
 
   # Polls until yielded block returns true or a timeout is reached
-  def self.wait_until(msg, timeout_at, sleep_time = 10, options = {})
-    logger = options.fetch(:logger, nil)
-
+  def self.wait_until(msg, timeout_at, sleep_time = 10)
     done = block_given? ? yield : false
 
     while Time.now.to_i < timeout_at && !done do
       done = block_given? ? yield : false
 
       unless done
-        logger ? logger.info(msg) : puts(msg)
+        puts msg
         sleep(sleep_time)
       end
     end
@@ -122,16 +120,13 @@ module RemoteNode
   end
 
   # get boot time of the given host or 0 if command can not be executed
-  def self.ssh_cmd_get_boottime(host_or_ip, options = {})
-    logger = options.fetch(:logger, nil)
-
+  def self.ssh_cmd_get_boottime(host_or_ip)
     ssh_cmd = self.ssh_cmd_base(host_or_ip)
     ssh_cmd << "'echo $(($(date +%s) - $(cat /proc/uptime|cut -d \" \" -f 1|cut -d \".\" -f 1)))'"
     ssh_cmd = ssh_cmd.map{|x| x.chomp}.join(" ")
     retval = `#{ssh_cmd}`.split(" ")[0].to_i
     if $?.exitstatus != 0
-      msg = "ssh-cmd '#{ssh_cmd}' to get datetime not successful"
-      logger ? logger.info(msg) : puts(msg)
+      puts "ssh-cmd '#{ssh_cmd}' to get datetime not successful"
       retval = 0
     end
     return retval


### PR DESCRIPTION
Since we reverted that feature, let's just revert all the other commits that were required for it and that add nothing useful.

This obsoletes https://github.com/crowbar/barclamp-crowbar/pull/1286.
