### PR TITLE
webui: Only show non-allocated admin IP address on discovery

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -427,7 +427,7 @@ class NodesController < ApplicationController
     @node = NodeObject.find_node_by_name(node_name) if @node.nil?
     if @node
       # If we're in discovery mode, then we have a temporary DHCP IP address.
-      if not ['discovering', 'discovered', 'hardware-installing', 'hardware-installed'].include? @node.state
+      if !["discovering", "discovered"].include?(@node.state)
         intf_if_map = @node.build_node_map
         # build network information (this may need to move into the object)
         @node.networks.each do |intf, data|


### PR DESCRIPTION
When we do hardware-installing/hardware-installed, then the node already
has an allocated IP address.

Backport of https://github.com/crowbar/crowbar-core/pull/98
