### PR TITLE
i18n: fix missing translation in vanilla crowbar (bsc#954756)

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -96,6 +96,7 @@ en:
     show_index:
       created_on: 'Created on %{date}'
       failed: 'Error: %{message}'
+      blockui_message: 'Processing, please wait...'
     show_simplified_index:
       created_on: 'Created on %{date}'
       failed: 'Error: %{message}'


### PR DESCRIPTION
translation missing: en.barclamp.show_index.blockui_message
