### PR TITLE
Claim RAID disks when node has full info about them from ohai

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -62,8 +62,9 @@ class CrowbarService < ServiceObject
         return [404, "Node not found"]
       end
 
-      if state == "readying"
-        transition_to_readying inst, name, state, node
+      if state == "ready" && !node.admin?
+        # we need to claim raids when we already have ohai data, i.e. after first chef-client run
+        process_raid_claims node
       end
 
       if %w(hardware-installing hardware-updating update).include? state
@@ -310,12 +311,6 @@ class CrowbarService < ServiceObject
   end
 
   protected
-
-  def transition_to_readying(inst, name, state, node = nil)
-    only_unless_admin node do
-      process_raid_claims node
-    end
-  end
 
   def process_raid_claims(node)
     unless node.raid_type == "single"

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1360,7 +1360,7 @@ class NodeObject < ChefObject
     if device
       crowbar_wall[:claimed_disks] ||= {}
 
-      unless disk_owner(device) == owner
+      if owner.empty? || disk_owner(device) != owner
         return false
       end
 


### PR DESCRIPTION
This is an attempt to fix https://bugzilla.suse.com/show_bug.cgi?id=946397

I'm not sure if it is correct. But there is currently indeed a problem that `transition_to_readying` function is called in readying state, when the node still does not have correct information about the disks, thus no RAID disk is actually claimed.

cc @mjura 
