### PR TITLE
Bring back missing 'Cancel' translation string

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -551,6 +551,7 @@ en:
   all: 'All'
   destroy: 'Remove'
   back: 'Go Back'
+  cancel: 'Cancel'
   edit: 'Edit'
   delete: 'Delete'
   actions: 'Actions'


### PR DESCRIPTION
Was accidently deleted in: 576be88fc563057ce173c5fe322cfec5b0b7c6c6
