### PR TITLE
crowbar: Fix blockui appearing nearly all the time (bsc#966356)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -104,7 +104,7 @@ jQuery(document).ready(function($) {
   });
 
   setBlockUI('submit', $('[data-blockui]'));
-  setBlockUI('click', $('body[class="installer/upgrades"] [data-blockui]'));
+  setBlockUI('click', $('body[class="installer/upgrades"]').find('[data-blockui]'));
 
   $('[data-checkall]').live('change', function(event) {
     var checker = $(event.target).data('checkall');


### PR DESCRIPTION
selectors were OR chained, not AND

https://bugzilla.suse.com/show_bug.cgi?id=966356
