### PR TITLE
Refactor dropdown menu for power actions (bsc#955810)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -7,24 +7,6 @@
 //= require_self
 //= require branding
 
-function setBlockUI(events, selector) {
-  selector.live(events, function(event) {
-    $.blockUI({
-      css: {
-        border: 'none',
-        padding: '15px',
-        backgroundColor: '#000',
-        '-webkit-border-radius': '10px',
-        '-moz-border-radius': '10px',
-        opacity: .5,
-        color: '#fff'
-      },
-      message: $(event.target).data('blockui')
-    });
-  });
-}
-
-
 jQuery(document).ready(function($) {
   $('textarea.editor').each(function() {
     var cm = CodeMirror.fromTextArea(this, {
@@ -103,8 +85,36 @@ jQuery(document).ready(function($) {
     ]
   });
 
-  setBlockUI('submit', $('[data-blockui]'));
-  setBlockUI('click', $('body[class="installer/upgrades"]').find('[data-blockui]'));
+  $('[data-blockui]').live('submit', function(event) {
+    $.blockUI({
+      css: {
+        border: 'none',
+        padding: '15px',
+        backgroundColor: '#000',
+        '-webkit-border-radius': '10px',
+	  '-moz-border-radius': '10px',
+        opacity: .5,
+        color: '#fff'
+      },
+      message: $(event.target).data('blockui')
+    });
+  });
+
+  $('[data-blockui-click]').live('click', function(event) {
+    $.blockUI({
+      css: {
+        border: 'none',
+        padding: '15px',
+        backgroundColor: '#000',
+        '-webkit-border-radius': '10px',
+        '-moz-border-radius': '10px',
+        opacity: .5,
+        color: '#fff'
+      },
+      message: $(event.target).data('blockui-click')
+    });
+  });
+
 
   $('[data-checkall]').live('change', function(event) {
     var checker = $(event.target).data('checkall');

--- a/crowbar_framework/app/helpers/proposals_helper.rb
+++ b/crowbar_framework/app/helpers/proposals_helper.rb
@@ -26,8 +26,7 @@ module ProposalsHelper
       :role => "form",
       :class => "form-inline",
       :autocomplete => "off",
-      "data-type" => "html",
-      "data-blockui" => t(".blockui_message")
+      data: { type: "html", blockui: t(".blockui_message") }
     }
 
     form_for :proposal, :url => url, :html => html, &block
@@ -44,8 +43,7 @@ module ProposalsHelper
       :role => "form",
       :id => "update_proposal_form",
       :autocomplete => "off",
-      "data-type" => "html",
-      "data-blockui" => t(".blockui_message")
+      data: { type: "html", blockui: t(".blockui_message") }
     }
 
     form_for :proposal, :url => url, :html => html, &block

--- a/crowbar_framework/app/views/installer/upgrades/download.html.haml
+++ b/crowbar_framework/app/views/installer/upgrades/download.html.haml
@@ -35,6 +35,6 @@
                 = link_to icon_tag("chevron-left", t(".abort")),
                   abort_upgrade_path,
                   class: "btn btn-danger",
-                  data: { blockui: t(".blockui_message") }
+                  data: { blockui_click: t(".blockui_message") }
                 = button_tag icon_tag("chevron-right", t(".continue")),
                   class: "btn btn-primary"

--- a/crowbar_framework/app/views/installer/upgrades/prepare.html.haml
+++ b/crowbar_framework/app/views/installer/upgrades/prepare.html.haml
@@ -31,5 +31,5 @@
               .btn-group{ role: "group" }
                 = button_tag icon_tag("chevron-right", t(".continue")),
                   class: "btn btn-primary",
-                  data: { blockui: t(".blockui_message") }
+                  data: { blockui_click: t(".blockui_message") }
 

--- a/crowbar_framework/app/views/nodes/_buttons_power.html.haml
+++ b/crowbar_framework/app/views/nodes/_buttons_power.html.haml
@@ -1,5 +1,8 @@
 - if @node.bmc_set?
-  = link_to t(".identify"), hit_node_path(@node.handle, "identify"), class: "btn btn-default", remote: true
+  = link_to t(".identify"),
+    hit_node_path(@node.handle, "identify"),
+    class: "btn btn-default",
+    data: { blockui_click: t(".blockui_identify") }
 
 - unless @node.admin?
   - if @node[:platform] != 'windows' || @node.bmc_set?
@@ -10,15 +13,30 @@
     %ul.dropdown-menu{ role: "menu" }
       - if @node[:platform] != 'windows'
         %li{ role: "presentation" }
-          = link_to t(".reboot"), hit_node_path(@node.handle, "reboot"), role: "menuitem", remote: true
+          = link_to t(".reboot"),
+            hit_node_path(@node.handle, "reboot"),
+            role: "menuitem",
+            data: { blockui_click: t(".blockui_reboot") }
         %li{ role: "presentation" }
-          = link_to t(".shutdown"), hit_node_path(@node.handle, "shutdown"), role: "menuitem", remote: true
+          = link_to t(".shutdown"),
+            hit_node_path(@node.handle, "shutdown"),
+            role: "menuitem",
+            data: { blockui_click: t(".blockui_shutdown") }
         %li.divider{ role: "presentation" }
       - if @node.bmc_set?
         %li{ role: "presentation" }
-          = link_to t(".poweron"), hit_node_path(@node.handle, "poweron"), role: "menuitem", remote: true, "data-confirm" => t("are_you_sure")
+          = link_to t(".poweron"),
+            hit_node_path(@node.handle, "poweron"),
+            role: "menuitem",
+            data: { blockui_click: t(".blockui_poweron"), confirm: t("are_you_sure") }
       - if @node[:platform] != 'windows' || @node.bmc_set?
         %li{ role: "presentation" }
-          = link_to t(".powercycle"), hit_node_path(@node.handle, "powercycle"), role: "menuitem", remote: true
+          = link_to t(".powercycle"),
+            hit_node_path(@node.handle, "powercycle"),
+            role: "menuitem",
+            data: { blockui_click: t(".blockui_powercycle") }
         %li{ role: "presentation" }
-          = link_to t(".poweroff"), hit_node_path(@node.handle, "poweroff"), role: "menuitem", remote: true
+          = link_to t(".poweroff"),
+            hit_node_path(@node.handle, "poweroff"),
+            role: "menuitem",
+            data: { blockui_click: t(".blockui_poweroff") }

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -434,6 +434,12 @@ en:
       powercycle: 'Power Cycle'
       poweroff: 'Power Off'
       identify: 'Identify'
+      blockui_reboot: 'Triggering reboot...'
+      blockui_shutdown: 'Triggering shutdown...'
+      blockui_poweron: 'Triggering poweron...'
+      blockui_powercycle: 'Triggering powercycle...'
+      blockui_poweroff: 'Triggering poweroff...'
+      blockui_identify: 'Triggering identify...'
     form:
       allocate: 'Allocate'
       save: 'Save'
@@ -473,7 +479,7 @@ en:
 
   upgrade:
     upgrade:
-      nodes_not_ready: | 
+      nodes_not_ready: |
         Some nodes are not ready: %{nodes}.
         Fix the state of nodes before proceeding with the upgrade.
 


### PR DESCRIPTION
To avoid the situation that it looks like nothing happens we have
removed the AJAX functionality from the power buttons, added a blockui
message, refactored the controller properly to redirect on default html
requests and also refactored the blockui functionality to accept the new
data attribute `data-blockui-click`.

Obsoletes #1389
