### PR TITLE
To to fix the provider network parameters of the floating network (bs…

### DIFF
--- a/chef/cookbooks/crowbar/files/default/crowbar-fix-floating-provider-attributes
+++ b/chef/cookbooks/crowbar/files/default/crowbar-fix-floating-provider-attributes
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+import sqlalchemy
+import sys
+from oslo_config import cfg
+
+_cli_opts = [
+    cfg.StrOpt('network',
+               required=True,
+               help='name of the network to update'),
+    cfg.StrOpt('type',
+               required=True,
+               help='new network type'),
+    cfg.StrOpt('segmentation_id',
+               required=True,
+               help='new segmentation_id'),
+    cfg.StrOpt('physnet',
+               required=True,
+               help='new physnet'),
+]
+
+_db_opts = [
+    cfg.StrOpt('connection',
+               deprecated_name='sql_connection',
+               default='',
+               secret=True,
+               help='URL to database'),
+]
+
+CONF = cfg.ConfigOpts()
+CONF.register_cli_opts(_db_opts, 'database')
+CONF.register_cli_opts(_cli_opts)
+CONF(project='neutron')
+
+db_uri = CONF.database.connection
+
+network = CONF.network
+network_type = CONF.type
+segmentation_id = CONF.segmentation_id
+physnet = CONF.physnet
+
+db = sqlalchemy.create_engine(db_uri)
+try:
+    connection = db.connect()
+except sqlalchemy.exc.SQLAlchemyError as e:
+    print >>sys.stderr, 'Cannot connect to database: %s' % e
+    sys.exit(1)
+
+ret = connection.execute(
+    "UPDATE ml2_network_segments SET "
+    "network_type=%s, segmentation_id=%s, physical_network=%s "
+    "FROM networks WHERE networks.name=%s AND "
+    "ml2_network_segments.network_id=networks.id;",
+    [network_type, segmentation_id, physnet, network])
+sys.exit(0)

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -63,6 +63,22 @@ when "crowbar_upgrade"
     action [:disable, :stop]
   end
 
+  if node["run_list_map"]["neutron-server"]
+    cookbook_file "crowbar-fix-floating-provider-attributes" do
+      source "crowbar-fix-floating-provider-attributes"
+      path "/usr/bin/crowbar-fix-floating-provider-attributes"
+      mode "0755"
+    end
+    execute "fix floating network provider attributes" do
+      command "/usr/bin/crowbar-fix-floating-provider-attributes " \
+        "--physnet floating --segmentation_id 0 --type flat " \
+        "--network floating"
+      action :run
+    end
+    file "/usr/bin/crowbar-fix-floating-provider-attributes" do
+      action :delete
+    end
+  end
 when "revert_to_ready"
 
   service "crowbar_join" do


### PR DESCRIPTION
…c#967009)

Because of several bugs (at least bsc#946882 and bsc#955811) we have setups
where the floating network was created with the wrong provider network
settings. While this somehow continued to work and got unnoticed it will create
problems on system upgrading from juno to liberty. Try to adjust the parameters
directly in the database as part of the upgrade.

https://bugzilla.suse.com/show_bug.cgi?id=967009
