### PR TITLE
Test if admin node has dns_server role for upgrade

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -195,9 +195,15 @@ class CrowbarService < ServiceObject
     # To all nodes, add a new role which prepares them for the upgrade
     nodes_to_upgrade = []
     not_ready_for_upgrade = []
+    admin_with_dns_server_role = false
     all_nodes = NodeObject.all
     all_nodes.each do |n|
       not_ready_for_upgrade.push n.name if !n.admin? && !%w(ready crowbar_upgrade).include?(n.state)
+      admin_with_dns_server_role = true if n.admin? && n.role?("dns-server")
+    end
+
+    unless admin_with_dns_server_role
+      raise I18n.t("upgrade.upgrade.admin_missing_dns_server")
     end
 
     unless not_ready_for_upgrade.empty?

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -476,6 +476,10 @@ en:
       nodes_not_ready: | 
         Some nodes are not ready: %{nodes}.
         Fix the state of nodes before proceeding with the upgrade.
+      admin_missing_dns_server: |
+        The Administration Server does not have the dns-server role while this is mandatory for
+        the upgrade process. Reapply the DNS proposal with this change before proceeding with
+        the upgrade.
 
   support:
     index:


### PR DESCRIPTION
The upgrade process will fail if the admin node does not have the
dns_server role applied. Abort upgrade with a warning, if this is
not the case. See also
https://bugzilla.suse.com/show_bug.cgi?id=978060
