### PR TITLE
Fix travis ci checks

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -22,7 +22,7 @@ gem "haml-rails", "~> 0.5"
 gem "sass-rails", "~> 4.0"
 gem "rainbows-rails", "~> 1.0"
 
-gem "active_model_serializers", "~> 0.9"
+gem "active_model_serializers", "~> 0.9.0"
 gem "activeresource", "~> 4.0"
 gem "closure-compiler", "~> 1.1"
 gem "dotenv", "~> 1.0"


### PR DESCRIPTION
Change Gemfile requirements as active_models_serializers 0.10 release
breakes our call from crowbar_framework/config/initializers/serializer.rb
